### PR TITLE
iosxr remove bare except statements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,4 +60,7 @@ env
 
 napalm/fix_script.sh
 test/unit/ios/*.conf
-
+test/unit/iosxr/*.conf
+test/unit/iosxr/*.diff
+test/unit/test_devices.py
+test/unit/test_devices.pyc

--- a/.gitignore
+++ b/.gitignore
@@ -60,7 +60,5 @@ env
 
 napalm/fix_script.sh
 test/unit/ios/*.conf
-test/unit/iosxr/*.conf
-test/unit/iosxr/*.diff
 test/unit/test_devices.py
 test/unit/test_devices.pyc

--- a/napalm/iosxr.py
+++ b/napalm/iosxr.py
@@ -576,8 +576,6 @@ class IOSXRDriver(NetworkDriver):
 
         # init result dict
         lldp = {}
-
-        # fetch sh ip bgp output
         sh_lldp = self.device.show_lldp_neighbors().splitlines()[5:-3]
 
         for n in sh_lldp:

--- a/napalm/iosxr.py
+++ b/napalm/iosxr.py
@@ -335,8 +335,8 @@ class IOSXRDriver(NetworkDriver):
                     this_neighbor['is_enabled'] = True
                 try:
                     this_neighbor['description'] = unicode(neighbor.find('Description').text)
-                except:
-                    pass
+                except AttributeError:
+                    this_neighbor['description'] = u''
 
                 this_neighbor['is_enabled'] = str(neighbor.find('ConnectionAdminStatus').text) is "1"
 
@@ -378,7 +378,7 @@ class IOSXRDriver(NetworkDriver):
 
                 try:
                     neighbor_ip = unicode(neighbor.find('Naming/NeighborAddress/IPV4Address').text)
-                except:
+                except AttributeError:
                     neighbor_ip = unicode(neighbor.find('Naming/NeighborAddress/IPV6Address').text)
 
                 neighbors[neighbor_ip] = this_neighbor


### PR DESCRIPTION
I thought it made sense to allow the unit test to pass without having BGP descriptions.

Also probably better not to have bare 'except:' statements as it can make debugging hard so I added explicit 'except AttributeError:' statement. This should be the right exception type.
