### PR TITLE
Extended NAPALM with PluribusDriver & few more methods

### DIFF
--- a/napalm/__init__.py
+++ b/napalm/__init__.py
@@ -19,6 +19,7 @@ from fortios import FortiOSDriver
 from nxos import NXOSDriver
 from ibm import IBMDriver
 from ios import IOSDriver
+from pluribus import PluribusDriver
 
 def get_network_driver(vendor):
     driver_mapping = {
@@ -32,6 +33,7 @@ def get_network_driver(vendor):
         'NXOS': NXOSDriver,
         'IBM': IBMDriver,
         'IOS' : IOSDriver,
+        'PLURIBUS': PluribusDriver
     }
     try:
         return driver_mapping[vendor.upper()]

--- a/napalm/base.py
+++ b/napalm/base.py
@@ -364,3 +364,35 @@ class NetworkDriver:
             }
         """
         raise NotImplementedError
+
+    def get_bgp_neighbors_detail(self, neighbor_address = ''):
+
+        raise NotImplementedError
+
+    def cli(self, command = ''):
+
+        raise NotImplementedError
+
+    def get_arp_table(self, interface = '', host = '', ip = '', mac = ''):
+
+        raise NotImplementedError
+
+    def get_mac_address_table(self, address ='', interface = '', dynamic = False, static = False, vlan = None):
+
+        raise NotImplementedError
+
+    def get_ntp_peers(self):
+
+        raise NotImplementedError
+
+    def get_lldp_neighbors_detail(self):
+
+        raise NotImplementedError
+
+    def show_route(self, destination = ''):
+
+        raise NotImplementedError
+
+    def get_interfaces_ip(self):
+
+        raise NotImplementedError

--- a/napalm/eos.py
+++ b/napalm/eos.py
@@ -15,7 +15,7 @@
 import pyeapi
 import re
 from base import NetworkDriver
-from exceptions import MergeConfigException, ReplaceConfigException, SessionLockedException
+# from exceptions import MergeConfigException, ReplaceConfigException, SessionLockedException
 from datetime import datetime
 import time
 from napalm.utils import string_parsers
@@ -434,3 +434,62 @@ class EOSDriver(NetworkDriver):
         }
 
         return environment_counters
+
+    def get_mac_address_table(self):
+
+        mac_table = dict()
+
+        return mac_table
+
+    def get_lldp_neighbors_detail(self):
+
+        lldp_neighbors = dict()
+
+        commands = list()
+        commands.append('show lldp neighbors detail')
+
+        output = self.device.run_commands(commands)[0]['lldpNeighbors']
+
+        for interface in output:
+            neighbor_info = output.get(interface).get('lldpNeighborInfo')
+            if not neighbor_info:
+                # in case of empty infos
+                continue
+            neighbor_info = neighbor_info[0]
+            if interface not in lldp_neighbors.keys():
+                lldp_neighbors[interface] = list()
+            lldp_neighbors[interface].append(
+                {
+                    'interface_descr': neighbor_info.get('neighborInterfaceInfo').get('interfaceDescription'),
+                    'remote_port':  neighbor_info.get('neighborInterfaceInfo').get('interfaceId'),
+                    'remote_system_name': neighbor_info.get('systemName'),
+                    'remote_system_descr': neighbor_info.get('systemDescription'),
+                    'remote_chassis_id': neighbor_info.get('chassisId')
+                }
+            )
+
+        return lldp_neighbors
+
+    def get_arp_table(self):
+
+        arp_table = dict()
+
+        return arp_table
+
+    def get_bgp_neighbors(self, neighbor_address = ''):
+
+        bgp_neighbors = dict()
+
+        return bgp_neighbors
+
+    def get_ntp_peers(self, destination = ''):
+
+        ntp_peers = dict()
+
+        return ntp_peers
+
+    def show_route(self, destination = ''):
+
+        route = dict()
+
+        return route

--- a/napalm/iosxr.py
+++ b/napalm/iosxr.py
@@ -19,7 +19,7 @@ from pyIOSXR import IOSXR
 from pyIOSXR.iosxr import __execute_show__
 from pyIOSXR.exceptions import InvalidInputError, XMLCLIError
 
-# from exceptions import MergeConfigException, ReplaceConfigException
+from exceptions import MergeConfigException, ReplaceConfigException
 import xml.etree.ElementTree as ET
 from collections import defaultdict
 import re

--- a/napalm/iosxr.py
+++ b/napalm/iosxr.py
@@ -598,6 +598,10 @@ class IOSXRDriver(NetworkDriver):
                 command = command
             )
 
+    def get_interfaces_ip(self):
+
+        return []
+
     def get_arp_table(self):
 
         arp_table = dict()
@@ -747,6 +751,11 @@ class IOSXRDriver(NetworkDriver):
                 output_messages         = int(neighbor.find('MessagesSent').text)
                 connection_up_count     = int(neighbor.find('ConnectionUpCount').text)
                 connection_down_count   = int(neighbor.find('ConnectionDownCount').text)
+                import_policy           = neighbor.find('RoutePolicyIn').text
+                export_policy           = neighbor.find('RoutePolicyOut').text
+                accepted_prefixes       = int(neighbor.find('PrefixesAccepted').text)
+                supressed_prefixes      = int(neighbor.find('PrefixesDenied').text)
+                advertised_prefixes     = int(neighbor.find('PrefixesAdvertised'.text))
                 local_port = int(neighbor.find('ConnectionLocalPort').text)
                 remote_port = int(neighbor.find('ConnectionRemotePort').text)
                 flap_count = connection_down_count / 2

--- a/napalm/junos.py
+++ b/napalm/junos.py
@@ -387,7 +387,7 @@ class JunOSDriver(NetworkDriver):
             '\s+([0-9\.]+)\s?$'
         )
 
-        ntp_assoc_output = self.device.cli('show ntp associations')
+        ntp_assoc_output = self.device.cli('show ntp associations no-resolve')
         ntp_assoc_output_lines = ntp_assoc_output.split('\n')
 
         for ntp_assoc_output_line in ntp_assoc_output_lines[3:-1]: #except last line
@@ -402,13 +402,13 @@ class JunOSDriver(NetworkDriver):
                     'type'          : line_groups[4],
                     'when'          : line_groups[5],
                     'hostpoll'      : int(line_groups[6]),
-                    'reachability'  : line_groups[7],
+                    'reachability'  : int(line_groups[7]),
                     'delay'         : float(line_groups[8]),
                     'offset'        : float(line_groups[9]),
                     'jitter'        : float(line_groups[10])
                 }
             except Exception:
-                continue
+                continue # jump to next line
 
         return ntp_peers
 
@@ -474,6 +474,7 @@ class JunOSDriver(NetworkDriver):
                 routes[prefix] = list()
             route_detail = route[1]
             # TODO have to do it in the clean fucking way!!!!
+            # TODO preferably with hierarchical Junos YAML Views
             if type(route_detail[0][1]) is list:
                 number_of_routes = len(route_detail[0][1])
                 for route_no in range(0, number_of_routes):

--- a/napalm/junos.py
+++ b/napalm/junos.py
@@ -412,42 +412,32 @@ class JunOSDriver(NetworkDriver):
 
         return ntp_peers
 
-    def get_bgp_summary(self, instance = '', group = ''):
+    def get_bgp_stats(self, group = ''):
 
-        bgp_summary = {
-            'tables': {}, # with an overview over all tables
-            'peers' : {}  # and over the peers only, grouped by AS number
-        }
+        bgp_stats = dict()
 
-        bgp_tables_summary_table = junos_views.junos_bgp_tables_summary_table(self.device)
-        bgp_peers_summary_table  = junos_views.junos_bgp_peers_summary_table(self.device)
+        return bgp_stats
 
-        bgp_tables_summary_table.get(
-            instance = instance,
-            group = group
-        )
+    def get_bgp_neighbors(self, neighbor_address = ''):
+
+        bgp_neighbors = dict()
+
+        bgp_peers_summary_table  = junos_views.junos_bgp_neighbors_table(self.device)
+
         bgp_peers_summary_table.get(
-            instance = instance,
-            group = group
+            neighbor_address = neighbor_address
         )
-        bgp_tables_summary_items = bgp_tables_summary_table.items()
         bgp_peers_summary_items = bgp_peers_summary_table.items()
-
-        for bgp_tables_summary_entry in bgp_tables_summary_items:
-            rib_name = bgp_tables_summary_entry[0]
-            bgp_summary['tables'][rib_name] = {
-                elem[0]: elem[1] for elem in bgp_tables_summary_entry[1]
-            }
 
         for bgp_peers_summary_entry in bgp_peers_summary_items:
             peer_as = bgp_peers_summary_entry[0]
-            if peer_as not in bgp_summary['peers'].keys():
-                bgp_summary['peers'][peer_as] = list()
-            bgp_summary['peers'][peer_as].append(
+            if peer_as not in bgp_neighbors.keys():
+                bgp_neighbors[peer_as] = list()
+            bgp_neighbors[peer_as].append(
                 {elem[0]: elem[1] for elem in bgp_peers_summary_entry[1]}
             )
 
-        return bgp_summary
+        return bgp_neighbors
 
     def show_route(self, destination = ''):
 

--- a/napalm/junos.py
+++ b/napalm/junos.py
@@ -473,10 +473,16 @@ class JunOSDriver(NetworkDriver):
             if prefix not in routes.keys():
                 routes[prefix] = list()
             route_detail = route[1]
-            number_of_routes = len(route_detail[0][1])
-            for route_no in range(0, number_of_routes):
+            # TODO have to do it in the clean fucking way!!!!
+            if type(route_detail[0][1]) is list:
+                number_of_routes = len(route_detail[0][1])
+                for route_no in range(0, number_of_routes):
+                        routes[prefix].append({
+                            route_params[0]:  route_params[1][route_no] for route_params in route_detail
+                        })
+            else:
                 routes[prefix].append({
-                    route_params[0]:  route_params[1][route_no] for route_params in route_detail
+                    route_params[0]:  route_params[1] for route_params in route_detail
                 })
 
         return routes

--- a/napalm/junos.py
+++ b/napalm/junos.py
@@ -21,7 +21,7 @@ from jnpr.junos import Device
 from jnpr.junos.utils.config import Config
 from jnpr.junos.exception import ConfigLoadError
 from jnpr.junos.exception import RpcTimeoutError
-from exceptions import ReplaceConfigException, MergeConfigException
+# from exceptions import ReplaceConfigException, MergeConfigException
 
 
 
@@ -325,6 +325,21 @@ class JunOSDriver(NetworkDriver):
 
         return self.device.cli(command)
 
+
+    def get_interfaces_ip(self):
+
+        ip_list = []
+
+        ip_table = junos_views.junos_ip_interfaces_table(self.device)
+        ip_table.get()
+        ip_items = ip_table.items()
+
+        for interface in ip_items:
+            interface_ip_list = interface[1][0][1]
+            if interface_ip_list:
+                ip_list.extend(interface_ip_list)
+
+        return ip_list
 
     def get_arp_table(self):
 

--- a/napalm/junos.py
+++ b/napalm/junos.py
@@ -21,7 +21,7 @@ from jnpr.junos import Device
 from jnpr.junos.utils.config import Config
 from jnpr.junos.exception import ConfigLoadError
 from jnpr.junos.exception import RpcTimeoutError
-# from exceptions import ReplaceConfigException, MergeConfigException
+from exceptions import ReplaceConfigException, MergeConfigException
 
 
 

--- a/napalm/junos.py
+++ b/napalm/junos.py
@@ -42,10 +42,10 @@ class JunOSDriver(NetworkDriver):
         self.device.open()
         self.device.timeout = self.timeout
         self.device.bind(cu=Config)
-        self.device.cu.lock()
+        # self.device.cu.lock()
 
     def close(self):
-        self.device.cu.unlock()
+        # self.device.cu.unlock()
         self.device.close()
 
     def _load_candidate(self, filename, config, overwrite):

--- a/napalm/nxos.py
+++ b/napalm/nxos.py
@@ -12,6 +12,8 @@
 # License for the specific language governing permissions and limitations under
 # the License.
 
+import xmltodict
+
 import tempfile
 import re
 from datetime import datetime
@@ -196,3 +198,289 @@ class NXOSDriver(NetworkDriver):
 
     def get_checkpoint_file(self):
         return install_config.get_checkpoint(self.device)
+
+    def get_bgp_neighbors_detail(self, neighbor_address = ''):
+
+        bgp_neighbors = dict()
+
+        return bgp_neighbors
+
+    def _get_reply_body(self, result):
+
+        # useful for debugging
+
+        return result.get('ins_api', {}).get('outputs', {}).get('output', {}).get('body', {})
+
+    def _get_reply_table(self, result, tablename, rowname):
+
+        # still useful for debugging
+        return self._get_reply_body(result).get(tablename, {}).get(rowname, [])
+
+    def _get_command_table(self, command, tablename, rowname):
+
+        result = {}
+
+        try:
+            # xml_result          = self.device.show(command)
+            # json_output  = xmltodict.parse(xml_result[1])
+
+            # or directly retrive JSON
+            result = self.device.show(command, fmat = 'json')
+            json_output = eval(result[1])
+            # which will converted to a plain dictionary
+        except Exception:
+            return []
+
+        return self._get_reply_table(json_output, tablename, rowname)
+
+    def cli(self, command = ''):
+
+        if not command:
+            return 'Please enter a valid command!'
+
+        try:
+            string_output = self.device.show(command, fmat = 'json', text = True)[1]
+            dict_output   = eval(string_output)
+            return self._get_reply_body(dict_output)
+        except Exception as e:
+            return e
+
+        return ''
+
+    def get_arp_table(self, interface = '', host = '', ip = '', mac = ''):
+
+        arp_table = dict()
+
+        filter = ''
+
+        if interface:
+            filter  = interface
+            ip      = ''
+        if ip:
+            filter = ip
+
+        command = 'show ip arp {filter}'.format(
+            filter = filter
+        )
+
+        arp_table_raw = self._get_command_table(command, 'TABLE_vrf', 'ROW_vrf').get('TABLE_adj', {}).get('ROW_adj', [])
+
+        if type(arp_table_raw) is dict:
+            arp_table_raw = [arp_table_raw]
+
+        for arp_table_entry in arp_table_raw:
+            ip          = arp_table_entry.get('ip-addr-out')
+            mac         = arp_table_entry.get('mac')
+            age         = arp_table_entry.get('time-stamp') # TODO convert time to seconds
+            interface   = arp_table_entry.get('intf-out')
+            if interface not in arp_table.keys():
+                arp_table[interface] = list()
+            arp_table[interface].append(
+                {
+                    'mac'   : mac,
+                    'ip'    : ip,
+                    'age'   : age
+                }
+            )
+
+        return arp_table
+
+
+    def get_mac_address_table(self, address ='', interface = '', dynamic = False, static = False, vlan = None):
+
+        mac_table = dict()
+
+        raw_command = 'show mac address-table'
+
+        filter = '' # NXOS allows only one single filter :(
+
+        # will set the filters
+        if address:
+            filter = 'address {mac}'.format(
+                        mac = address
+                    )
+            # deactivate the other filters in case they happen to be set...
+            interface = ''
+            dynamic = False
+            static = False
+            vlan = ''
+        if interface:
+            filter = 'interface {name}'.format(
+                        name = interface
+                    )
+            dynamic = False
+            static = False
+            vlan   = ''
+        if dynamic is True:
+            filter = 'dynamic'
+            static = False
+            vlan   = ''
+        if static is True:
+            filter = 'static'
+            vlan = ''
+        if type(vlan) is int:
+            filter = 'vlan {id}'.format(
+                        id = vlan
+                    )
+
+        command = '{raw_command} {filter}'.format(
+            raw_command = raw_command,
+            filter      = filter
+        )
+
+        mac_table_raw = self._get_command_table(command, 'TABLE_mac_address', 'ROW_mac_address')
+
+        if type(mac_table_raw) is dict:
+            mac_table_raw = [mac_table_raw]
+
+        for mac_entry in mac_table_raw:
+            mac         = mac_entry.get('disp_mac_addr')
+            interface   = mac_entry.get('disp_port')
+            age         = mac_entry.get('disp_age')
+            vlan        = int(mac_entry.get('disp_vlan'))
+            active      = True
+            static      = (mac_entry.get('disp_is_static') != '0')
+            moves       = None
+            last_move   = None
+            if vlan not in mac_table.keys():
+                mac_table[vlan] = list()
+            mac_table[vlan].append(
+                {
+                    'mac'       : mac,
+                    'interface' : interface,
+                    'active'    : active,
+                    'static'    : static,
+                    'moves'     : moves,
+                    'last_move' : last_move
+                }
+            )
+
+        return mac_table
+
+    def get_ntp_peers(self):
+
+        ntp_peers = dict()
+
+        command = 'show ntp peer-status'
+
+        ntp_peers_table = self._get_command_table(command, 'TABLE_peersstatus', 'ROW_peersstatus')
+
+        if type(ntp_peers_table) is dict:
+            ntp_peers_table = [ntp_peers_table]
+
+        for ntp_peer in ntp_peers_table:
+            peer_address = ntp_peer.get('remote')
+            stratum      = int(ntp_peer.get('st'))
+            hostpoll     = int(ntp_peer.get('poll'))
+            reachability = int(ntp_peer.get('reach'))
+            delay        = float(ntp_peer.get('delay'))
+            ntp_peers[peer_address] = {
+                'referenceid'   : None,
+                'stratum'       : stratum,
+                'type'          : None,
+                'when'          : None,
+                'hostpoll'      : hostpoll,
+                'reachability'  : reachability,
+                'delay'         : delay,
+                'offset'        : 0.0,
+                'jitter'        : 0.0
+            }
+
+        return ntp_peers
+
+    def get_lldp_neighbors_detail(self, interface = ''):
+
+        lldp_neighbors = dict()
+
+        filter = ''
+        if interface:
+            filter = 'interface {name} '.format(
+                name = interface
+            )
+
+        command = 'show lldp neighbors {filter}detail'.format(
+            filter = filter
+        ) # seems that show LLDP neighbors detail does not return JSON output...
+
+        lldp_neighbors_table_str = self.cli(command)
+        # thus we need to take the raw text output
+
+        lldp_neighbors_list = lldp_neighbors_table_str.splitlines()
+
+        if not lldp_neighbors_list:
+            return lldp_neighbors # empty dict
+
+        CHASSIS_REGEX       = '^(Chassis id:)\s+([a-z0-9\.]+)$'
+        PORT_REGEX          = '^(Port id:)\s+([0-9]+)$'
+        LOCAL_PORT_ID_REGEX = '^(Local Port id:)\s+(.*)$'
+        PORT_DESCR_REGEX    = '^(Port Description:)\s+(.*)$'
+        SYSTEM_NAME_REGEX   = '^(System Name:)\s+(.*)$'
+        SYSTEM_DESCR_REGEX  = '^(System Description:)\s+(.*)$'
+        SYST_CAPAB_REEGX    = '^(System Capabilities:)\s+(.*)$'
+        ENABL_CAPAB_REGEX   = '^(Enabled Capabilities:)\s+(.*)$'
+        VLAN_ID_REGEX       = '^(Vlan ID:)\s+(.*)$'
+
+        lldp_neighbor = {}
+        interface_name = None
+        for line in lldp_neighbors_list:
+            chassis_rgx = re.search(CHASSIS_REGEX, line, re.I)
+            if chassis_rgx:
+                lldp_neighbor = {
+                    'chassis_id': chassis_rgx.groups()[1]
+                }
+                continue
+            port_rgx = re.search(PORT_REGEX, line, re.I)
+            if port_rgx:
+                lldp_neighbor['local_port_id'] = port_rgx.groups()[1]
+                continue # jump to next line
+            local_port_rgx = re.search(LOCAL_PORT_ID_REGEX, line, re.I)
+            if local_port_rgx:
+                interface_name = local_port_rgx.groups()[1]
+                continue
+            port_descr_rgx = re.search(PORT_DESCR_REGEX, line, re.I)
+            if port_descr_rgx:
+                lldp_neighbor['local_port_descr'] = port_descr_rgx.groups()[1]
+                continue
+            syst_name_rgx = re.search(SYSTEM_NAME_REGEX, line, re.I)
+            if syst_name_rgx:
+                lldp_neighbor['remote_system_name'] = syst_name_rgx.groups()[1]
+                continue
+            syst_capab_rgx = re.search(SYST_CAPAB_REEGX, line, re.I)
+            if syst_capab_rgx:
+                lldp_neighbor['remote_system_capabilities'] = syst_capab_rgx.groups()[1]
+                continue
+            syst_enabled_rgx = re.search(ENABL_CAPAB_REGEX, line, re.I)
+            if syst_enabled_rgx:
+                lldp_neighbor['remote_system_enabled_capabilities'] = syst_enabled_rgx.groups()[1]
+                continue
+            vlan_rgx = re.search(VLAN_ID_REGEX, line, re.I)
+            if vlan_rgx:
+                # at the end of the loop
+                if interface_name not in lldp_neighbors.keys():
+                    lldp_neighbors[interface_name] = list()
+                lldp_neighbors[interface_name].append(lldp_neighbor)
+
+        return lldp_neighbors
+
+    def show_route(self, destination = ''):
+
+        return {}
+
+    def get_interfaces_ip(self):
+
+        ip_list = list()
+
+        command = 'show ip interface brief'
+
+        ip_interf_table_vrf = self._get_command_table(command, 'TABLE_intf', 'ROW_intf')
+
+        if type(ip_interf_table_vrf) is dict:
+            # when there's one single entry, it is not returned as a list
+            # with one single element
+            # but as a simple dict
+            ip_interf_table_vrf = [ip_interf_table_vrf]
+
+        for interface in ip_interf_table_vrf:
+            ip_list.append(interface.get('prefix'))
+
+        return ip_list

--- a/napalm/pluribus.py
+++ b/napalm/pluribus.py
@@ -1,0 +1,37 @@
+# Copyright 2016 CloudFlare, Inc. All rights reserved.
+#
+# The contents of this file are licensed under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with the
+# License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+
+from base import NetworkDriver
+
+
+class PluribusDriver(NetworkDriver):
+
+    def __init__(self, hostname, username, password, timeout = 60):
+
+        pass
+
+
+    def open(self):
+
+        pass
+
+
+    def close(self):
+
+        pass
+
+    def cli(self, command = ''):
+
+        pass
+

--- a/napalm/pluribus.py
+++ b/napalm/pluribus.py
@@ -42,10 +42,6 @@ class PluribusDriver(NetworkDriver):
 
         self.device.close()
 
-    def cli(self, command = ''):
-
-        return self.device.cli(command)
-
     def get_facts(self):
 
         switch_info = self.device.execute_show('show switch-info')
@@ -85,7 +81,60 @@ class PluribusDriver(NetworkDriver):
 
         return facts
 
-    def get_lldp_neighbors_detail(self):
+    def get_bgp_neighbors_detail(self, neighbor_address = ''):
+
+        bgp_neighbors = dict()
+
+        return bgp_neighbors
+
+    def cli(self, command = ''):
+
+        return self.device.cli(command)
+
+    def get_arp_table(self, interface = '', host = '', ip = '', mac = ''):
+
+        arp_table = dict()
+
+        return arp_table
+
+    def get_mac_address_table(self, address = '', interface = '', dynamic = False, static = False, vlan = None):
+
+        mac_table = dict()
+
+        mac_show = self.device.execute_show('l2-table-show')
+        lines = mac_show.split('\n')[1:-1]
+
+        for line in lines:
+            mac_details = line.split(';')
+            mac         = mac_details[2].strip()
+            vlan        = int(mac_details[3].strip())
+            ports       = mac_details[8].strip()
+            active      = (mac_details[9].strip == 'active')
+            hostname    = mac_details[10].strip()
+            status      = mac_details[11].strip()
+            migrate     = mac_details[-1].strip()
+            if vlan not in mac_table.keys():
+                mac_table[vlan] = list()
+            mac_table[vlan].append(
+                {
+                    'mac'       : mac,
+                    'interface' : ports,
+                    'active'    : active,
+                    'hostname'  : hostname,
+                    'status'    : status,
+                    'migrate'   : migrate
+                }
+            )
+
+        return mac_table
+
+    def get_ntp_peers(self):
+
+        ntp_peers = dict()
+
+        return ntp_peers
+
+    def get_lldp_neighbors_detail(self, interface = ''):
 
         lldp_neighbors = dict()
 
@@ -111,55 +160,14 @@ class PluribusDriver(NetworkDriver):
 
         return lldp_neighbors
 
-    def get_mac_address_table(self):
-
-        mac_table = dict()
-
-        mac_show = self.device.execute_show('l2-table-show')
-        lines = mac_show.split('\n')[1:-1]
-
-        for line in lines:
-            mac_details = line.split(';')
-            mac         = mac_details[2].strip()
-            vlan        = int(mac_details[3].strip())
-            ports       = mac_details[8].strip()
-            active      = (mac_details[9].strip == 'active')
-            hostname    = mac_details[10].strip()
-            status      = mac_details[11].strip()
-            migrate     = mac_details[-1].strip()
-            if vlan not in mac_table.keys():
-                mac_table[vlan] = list()
-            mac_table[vlan].append({
-                'mac'       : mac,
-                'interface' : ports,
-                'active'    : active,
-                'hostname'  : hostname,
-                'status'    : status,
-                'migrate'   : migrate
-            })
-
-        return mac_table
-
-    def get_arp_table(self):
-
-        arp_table = dict()
-
-        return arp_table
-
-    def get_bgp_neighbors(self, neighbor_address = ''):
-
-        bgp_neighbors = dict()
-
-        return bgp_neighbors
-
-    def get_ntp_peers(self):
-
-        ntp_peers = dict()
-
-        return ntp_peers
-
     def show_route(self, destination = ''):
 
         route = dict()
 
         return route
+
+    def get_interfaces_ip(self):
+
+        ip_list = list()
+
+        return ip_list

--- a/napalm/pluribus.py
+++ b/napalm/pluribus.py
@@ -111,3 +111,55 @@ class PluribusDriver(NetworkDriver):
 
         return lldp_neighbors
 
+    def get_mac_address_table(self):
+
+        mac_table = dict()
+
+        mac_show = self.device.execute_show('l2-table-show')
+        lines = mac_show.split('\n')[1:-1]
+
+        for line in lines:
+            mac_details = line.split(';')
+            mac         = mac_details[2].strip()
+            vlan        = int(mac_details[3].strip())
+            ports       = mac_details[8].strip()
+            active      = (mac_details[9].strip == 'active')
+            hostname    = mac_details[10].strip()
+            status      = mac_details[11].strip()
+            migrate     = mac_details[-1].strip()
+            if vlan not in mac_table.keys():
+                mac_table[vlan] = list()
+            mac_table[vlan].append({
+                'mac'       : mac,
+                'interface' : ports,
+                'active'    : active,
+                'hostname'  : hostname,
+                'status'    : status,
+                'migrate'   : migrate
+            })
+
+        return mac_table
+
+    def get_arp_table(self):
+
+        arp_table = dict()
+
+        return arp_table
+
+    def get_bgp_neighbors(self, neighbor_address = ''):
+
+        bgp_neighbors = dict()
+
+        return bgp_neighbors
+
+    def get_ntp_peers(self):
+
+        ntp_peers = dict()
+
+        return ntp_peers
+
+    def show_route(self, destination = ''):
+
+        route = dict()
+
+        return route

--- a/napalm/utils/junos_views.yml
+++ b/napalm/utils/junos_views.yml
@@ -22,141 +22,6 @@ junos_iface_view:
     speed: speed
     mac_address: current-physical-address
 
-###
-### ARP Table
-###
-
-junos_arp_table:
-  rpc: get-arp-table-information
-  item: arp-table-entry
-  key: interface-name
-  view: junos_arp_view
-
-junos_arp_view:
-  fields:
-    mac_address: mac-address
-    ip_address: ip-address
-    hostname: hostname
-    flags: arp-table-entry-flags
-
-###
-### LLDP Neighbors
-###
-
-junos_lldp_neighbors_detail_table:
-  rpc: get-lldp-neighbors-information
-  item: lldp-neighbor-information
-  key: lldp-local-port-id
-  view: junos_lldp_neighbors_detail_view
-
-junos_lldp_neighbors_detail_view:
-  fields:
-    parent_interface: lldp-local-parent-interface-name
-    remote_port: lldp-remote-port-id
-    remote_system_chassis_id: lldp-remote-chassis-id
-    remote_system_name: lldp-remote-system-name
-
-###
-### Route Information
-###
-
-junos_route_table:
-  rpc: get-route-information
-  args_key:
-    destination
-  item: route-table/rt
-  key: rt-destination
-  view: junos_route_table_view
-
-junos_route_table_view:
-  fields:
-    protocol: rt-entry/protocol-name
-    active_tag: rt-entry/active-tag
-    age: {rt-entry/age/@seconds: int}
-    as_path: rt-entry/as-path
-    next_hop: rt-entry/nh/to
-    via: rt-entry/nh/via
-    local_preference: {rt-entry/local-preference: int}
-    preference: {rt-entry/preference: int}
-
-###
-### MAC Address table
-###
-
-junos_mac_address_table:
-  rpc: get-bridge-mac-table
-  item: l2ald-mac-entry
-  key: l2-mac-logical-interface
-  view: junos_mac_address_view
-
-junos_mac_address_view:
-  fields:
-    vlan: {l2-bridge-vlan: int}
-    logical_interface: l2-mac-logical-interface
-    bridge_domain: l2-mac-bridging-domain
-    logical_system: logical-system
-    base_logical_interface: l2-mac-base-logical-interface
-    mac_addresses: l2-mac-address
-    routing_instance: l2-mac-routing-instance
-
-####
-#### BGP Details
-####
-
-junos_bgp_tables_summary_table:
-  rpc: get-bgp-summary-information
-  args:
-    instance: ''
-    group: ''
-  item: bgp-rib
-  key: name
-  view: junos_bgp_tables_summary_view
-
-junos_bgp_tables_summary_view:
-  fields:
-    routing_table: name
-    total_prefix_count: total-prefix-count
-    received_prefix_count: received-prefix-count
-    active_prefix_count: active-prefix-count
-    suppressed_prefix_count: suppressed-prefix-count
-    history_prefix_count: history-prefix-count
-    damped_prefix_count: damped-prefix-count
-    total_external_prefix_count: total-external-prefix-count
-    active_external_prefix_count: active-external-prefix-count
-    accepted_external_prefix_count: accepted-external-prefix-count
-    suppressed_external_prefix_count: suppressed-external-prefix-count
-    total_internal_prefix_count: total-internal-prefix-count
-    active_internal_prefix_count: active-internal-prefix-count
-    accepted_internal_prefix_count: accepted-internal-prefix-count
-    suppressed_internal_prefix_count: suppressed-internal-prefix-count
-    pending_prefix_count: pending-prefix-count
-    bgp_rib_state: bgp-rib-state
-
-junos_bgp_peers_summary_table:
-  rpc: get-bgp-summary-information
-  args:
-    instance: ''
-    group: ''
-  item: bgp-peer
-  key: peer-as
-  view: junos_bgp_peers_summary_view
-
-junos_bgp_peers_summary_view:
-  fields:
-    peer_address: peer-address
-    peer_as: peer-as
-    input_messages: input-messages
-    output_messages: output-messages
-    route_queue_count: route-queue-count
-    flap_count: flap-count
-    elapsed_time: elapsed-time
-    peer_state: peer-state
-    rib_name: bgp-rib/name
-    active_prefix_count: bgp-rib/active-prefix-count
-    received_prefix_count: bgp-rib/received-prefix-count
-    accepted_prefix_count: bgp-rib/accepted-prefix-count
-    suppressed_prefix_count: bgp-rib/suppressed-prefix-count
-
 ####
 #### BGP tables
 ####
@@ -305,3 +170,137 @@ junos_temperature_thresholds_view:
     red-alarm: { red-alarm: int }
     tx_discards: { output-drops: int }
 
+###
+### ARP Table
+###
+
+junos_arp_table:
+  rpc: get-arp-table-information
+  item: arp-table-entry
+  key: interface-name
+  view: junos_arp_view
+
+junos_arp_view:
+  fields:
+    mac_address: mac-address
+    ip_address: ip-address
+    hostname: hostname
+    flags: arp-table-entry-flags
+
+###
+### LLDP Neighbors
+###
+
+junos_lldp_neighbors_detail_table:
+  rpc: get-lldp-neighbors-information
+  item: lldp-neighbor-information
+  key: lldp-local-port-id
+  view: junos_lldp_neighbors_detail_view
+
+junos_lldp_neighbors_detail_view:
+  fields:
+    parent_interface: lldp-local-parent-interface-name
+    remote_port: lldp-remote-port-id
+    remote_system_chassis_id: lldp-remote-chassis-id
+    remote_system_name: lldp-remote-system-name
+
+###
+### Route Information
+###
+
+junos_route_table:
+  rpc: get-route-information
+  args_key:
+    destination
+  item: route-table/rt
+  key: rt-destination
+  view: junos_route_table_view
+
+junos_route_table_view:
+  fields:
+    protocol: rt-entry/protocol-name
+    active_route: {rt-entry/active-tag: True=*}
+    age: {rt-entry/age/@seconds: int}
+    as_path: rt-entry/as-path
+    next_hop: rt-entry/nh/to
+    outgoing_interface: rt-entry/nh/via
+    local_preference: {rt-entry/local-preference: int}
+    preference: {rt-entry/preference: int}
+
+###
+### MAC Address table
+###
+
+junos_mac_address_table:
+  rpc: get-bridge-mac-table
+  item: l2ald-mac-entry
+  key: l2-mac-logical-interface
+  view: junos_mac_address_view
+
+junos_mac_address_view:
+  fields:
+    vlan: {l2-bridge-vlan: int}
+    logical_interface: l2-mac-logical-interface
+    bridge_domain: l2-mac-bridging-domain
+    logical_system: logical-system
+    base_logical_interface: l2-mac-base-logical-interface
+    mac_addresses: l2-mac-address
+    routing_instance: l2-mac-routing-instance
+
+####
+#### BGP Neighbors and Routing Tables Stats
+####
+
+junos_bgp_tables_summary_table:
+  rpc: get-bgp-summary-information
+  args:
+    instance: ''
+    group: ''
+  item: bgp-rib
+  key: name
+  view: junos_bgp_tables_summary_view
+
+junos_bgp_tables_summary_view:
+  fields:
+    routing_table: name
+    total_prefix_count: {total-prefix-count: int}
+    received_prefix_count: {received-prefix-countL: int}
+    active_prefix_count: {active-prefix-count: int}
+    suppressed_prefix_count: {suppressed-prefix-count: int}
+    history_prefix_count: {history-prefix-count: int}
+    damped_prefix_count: {damped-prefix-count: int}
+    total_external_prefix_count: {total-external-prefix-count: int}
+    active_external_prefix_count: {active-external-prefix-count: int}
+    accepted_external_prefix_count: {accepted-external-prefix-count: int}
+    suppressed_external_prefix_count: {suppressed-external-prefix-count: int}
+    total_internal_prefix_count: {total-internal-prefix-count: int}
+    active_internal_prefix_count: {active-internal-prefix-count: int}
+    accepted_internal_prefix_count: {accepted-internal-prefix-count: int}
+    suppressed_internal_prefix_count: {suppressed-internal-prefix-count: int}
+    pending_prefix_count: {pending-prefix-count: int}
+    bgp_rib_state: bgp-rib-state
+
+junos_bgp_peers_summary_table:
+  rpc: get-bgp-summary-information
+  args:
+    instance: ''
+    group: ''
+  item: bgp-peer
+  key: peer-as
+  view: junos_bgp_peers_summary_view
+
+junos_bgp_peers_summary_view:
+  fields:
+    peer_address: peer-address
+    peer_as: {peer-as: int}
+    input_messages: {input-messages: int}
+    output_messages: {output-messages: int}
+    route_queue_count: {route-queue-count: int}
+    flap_count: {flap-count: int}
+    elapsed_time: {elapsed-time/@seconds: int}
+    peer_state: peer-state
+    rib_name: bgp-rib/name
+    active_prefix_count: {bgp-rib/active-prefix-count: int}
+    received_prefix_count: {bgp-rib/received-prefix-count: int}
+    accepted_prefix_count: {bgp-rib/accepted-prefix-count: int}
+    suppressed_prefix_count: {bgp-rib/suppressed-prefix-count: int}

--- a/napalm/utils/junos_views.yml
+++ b/napalm/utils/junos_views.yml
@@ -176,16 +176,21 @@ junos_temperature_thresholds_view:
 
 junos_arp_table:
   rpc: get-arp-table-information
+  args:
+    expiration-time: true
+  args_key:
+    - interface
+    - hostname
   item: arp-table-entry
   key: interface-name
   view: junos_arp_view
 
 junos_arp_view:
   fields:
-    mac_address: mac-address
-    ip_address: ip-address
+    mac: mac-address
+    ip: ip-address
     hostname: hostname
-    flags: arp-table-entry-flags
+    tte: time-to-expire
 
 ###
 ### LLDP Neighbors
@@ -199,10 +204,17 @@ junos_lldp_neighbors_detail_table:
 
 junos_lldp_neighbors_detail_view:
   fields:
+    interface: lldp-local-port-id
     parent_interface: lldp-local-parent-interface-name
     remote_port: lldp-remote-port-id
-    remote_system_chassis_id: lldp-remote-chassis-id
+    remote_chassis_id: lldp-remote-chassis-id
+    remote_port: lldp-remote-port-id
+    remote_port_description: lldp-remote-port-description
     remote_system_name: lldp-remote-system-name
+    remote_system_description: lldp-system-description/lldp-remote-system-description
+    remote_system_capab: lldp-remote-system-capabilities-supported
+    remote_system_enable_capab: lldp-remote-system-capabilities-enabled
+
 
 ###
 ### Route Information
@@ -217,15 +229,17 @@ junos_route_table:
   view: junos_route_table_view
 
 junos_route_table_view:
-  fields:
-    protocol: rt-entry/protocol-name
-    active_route: {rt-entry/active-tag: True=*}
-    age: {rt-entry/age/@seconds: int}
-    as_path: rt-entry/as-path
-    next_hop: rt-entry/nh/to
-    outgoing_interface: rt-entry/nh/via
-    local_preference: {rt-entry/local-preference: int}
-    preference: {rt-entry/preference: int}
+  groups:
+    entry: rt-entry
+  fields_entry:
+    protocol: protocol-name
+    active_route: {active-tag: True=*}
+    age: {age/@seconds: int}
+    as_path: as-path
+    next_hop: nh/to
+    outgoing_interface: nh/via
+    local_preference: {local-preference: int}
+    preference: {preference: int}
 
 ###
 ### MAC Address table
@@ -234,17 +248,18 @@ junos_route_table_view:
 junos_mac_address_table:
   rpc: get-bridge-mac-table
   item: l2ald-mac-entry
-  key: l2-mac-logical-interface
+  args:
+    extensive: True
+  args_key:
+    - interface
+    - vlan_id
+  key: l2-bridge-vlan
   view: junos_mac_address_view
 
 junos_mac_address_view:
   fields:
-    vlan: {l2-bridge-vlan: int}
-    logical_interface: l2-mac-logical-interface
-    bridge_domain: l2-mac-bridging-domain
-    logical_system: logical-system
-    base_logical_interface: l2-mac-base-logical-interface
-    mac_addresses: l2-mac-address
+    interface: l2-mac-logical-interface
+    mac: l2-mac-address
     routing_instance: l2-mac-routing-instance
 
 ####

--- a/napalm/utils/junos_views.yml
+++ b/napalm/utils/junos_views.yml
@@ -280,26 +280,34 @@ junos_bgp_tables_summary_view:
     pending_prefix_count: {pending-prefix-count: int}
     bgp_rib_state: bgp-rib-state
 
-junos_bgp_peers_summary_table:
-  rpc: get-bgp-summary-information
-  args:
-    instance: ''
-    group: ''
+junos_bgp_neighbors_table:
+  rpc: get-bgp-neighbor-information
+  args_key: neighbor_address
   item: bgp-peer
   key: peer-as
-  view: junos_bgp_peers_summary_view
+  view: junos_bgp_neighbors_view
 
-junos_bgp_peers_summary_view:
+junos_bgp_neighbors_view:
   fields:
     peer_address: peer-address
     peer_as: {peer-as: int}
+    peer_type: peer-type
+    local_as: {local-as: int}
+    up: {peer-state: True=Established}
     input_messages: {input-messages: int}
     output_messages: {output-messages: int}
     route_queue_count: {route-queue-count: int}
     flap_count: {flap-count: int}
+    last_flap_event: last-flap-event
+    local_interface_name: local-interface-name
+    local_interface_index: local-interface-index
+    last_received: {last-received: int}
+    last_sent: {last-sent: int}
+    last_checked: {last-checked: int}
     elapsed_time: {elapsed-time/@seconds: int}
-    peer_state: peer-state
     rib_name: bgp-rib/name
+    export_policy: bgp-option-information/export-policy
+    import_policy: bgp-option-information/import-policy
     active_prefix_count: {bgp-rib/active-prefix-count: int}
     received_prefix_count: {bgp-rib/received-prefix-count: int}
     accepted_prefix_count: {bgp-rib/accepted-prefix-count: int}

--- a/napalm/utils/junos_views.yml
+++ b/napalm/utils/junos_views.yml
@@ -22,6 +22,141 @@ junos_iface_view:
     speed: speed
     mac_address: current-physical-address
 
+###
+### ARP Table
+###
+
+junos_arp_table:
+  rpc: get-arp-table-information
+  item: arp-table-entry
+  key: interface-name
+  view: junos_arp_view
+
+junos_arp_view:
+  fields:
+    mac_address: mac-address
+    ip_address: ip-address
+    hostname: hostname
+    flags: arp-table-entry-flags
+
+###
+### LLDP Neighbors
+###
+
+junos_lldp_neighbors_detail_table:
+  rpc: get-lldp-neighbors-information
+  item: lldp-neighbor-information
+  key: lldp-local-port-id
+  view: junos_lldp_neighbors_detail_view
+
+junos_lldp_neighbors_detail_view:
+  fields:
+    parent_interface: lldp-local-parent-interface-name
+    remote_port: lldp-remote-port-id
+    remote_system_chassis_id: lldp-remote-chassis-id
+    remote_system_name: lldp-remote-system-name
+
+###
+### Route Information
+###
+
+junos_route_table:
+  rpc: get-route-information
+  args_key:
+    destination
+  item: route-table/rt
+  key: rt-destination
+  view: junos_route_table_view
+
+junos_route_table_view:
+  fields:
+    protocol: rt-entry/protocol-name
+    active_tag: rt-entry/active-tag
+    age: {rt-entry/age/@seconds: int}
+    as_path: rt-entry/as-path
+    next_hop: rt-entry/nh/to
+    via: rt-entry/nh/via
+    local_preference: {rt-entry/local-preference: int}
+    preference: {rt-entry/preference: int}
+
+###
+### MAC Address table
+###
+
+junos_mac_address_table:
+  rpc: get-bridge-mac-table
+  item: l2ald-mac-entry
+  key: l2-mac-logical-interface
+  view: junos_mac_address_view
+
+junos_mac_address_view:
+  fields:
+    vlan: {l2-bridge-vlan: int}
+    logical_interface: l2-mac-logical-interface
+    bridge_domain: l2-mac-bridging-domain
+    logical_system: logical-system
+    base_logical_interface: l2-mac-base-logical-interface
+    mac_addresses: l2-mac-address
+    routing_instance: l2-mac-routing-instance
+
+####
+#### BGP Details
+####
+
+junos_bgp_tables_summary_table:
+  rpc: get-bgp-summary-information
+  args:
+    instance: ''
+    group: ''
+  item: bgp-rib
+  key: name
+  view: junos_bgp_tables_summary_view
+
+junos_bgp_tables_summary_view:
+  fields:
+    routing_table: name
+    total_prefix_count: total-prefix-count
+    received_prefix_count: received-prefix-count
+    active_prefix_count: active-prefix-count
+    suppressed_prefix_count: suppressed-prefix-count
+    history_prefix_count: history-prefix-count
+    damped_prefix_count: damped-prefix-count
+    total_external_prefix_count: total-external-prefix-count
+    active_external_prefix_count: active-external-prefix-count
+    accepted_external_prefix_count: accepted-external-prefix-count
+    suppressed_external_prefix_count: suppressed-external-prefix-count
+    total_internal_prefix_count: total-internal-prefix-count
+    active_internal_prefix_count: active-internal-prefix-count
+    accepted_internal_prefix_count: accepted-internal-prefix-count
+    suppressed_internal_prefix_count: suppressed-internal-prefix-count
+    pending_prefix_count: pending-prefix-count
+    bgp_rib_state: bgp-rib-state
+
+junos_bgp_peers_summary_table:
+  rpc: get-bgp-summary-information
+  args:
+    instance: ''
+    group: ''
+  item: bgp-peer
+  key: peer-as
+  view: junos_bgp_peers_summary_view
+
+junos_bgp_peers_summary_view:
+  fields:
+    peer_address: peer-address
+    peer_as: peer-as
+    input_messages: input-messages
+    output_messages: output-messages
+    route_queue_count: route-queue-count
+    flap_count: flap-count
+    elapsed_time: elapsed-time
+    peer_state: peer-state
+    rib_name: bgp-rib/name
+    active_prefix_count: bgp-rib/active-prefix-count
+    received_prefix_count: bgp-rib/received-prefix-count
+    accepted_prefix_count: bgp-rib/accepted-prefix-count
+    suppressed_prefix_count: bgp-rib/suppressed-prefix-count
+
 ####
 #### BGP tables
 ####
@@ -85,8 +220,6 @@ junos_lldp_view:
   fields:
     hostname: lldp-remote-system-name
     port: lldp-remote-port-description | lldp-remote-port-id
-
-
 
 ####
 #### Interface counters

--- a/napalm/utils/junos_views.yml
+++ b/napalm/utils/junos_views.yml
@@ -312,3 +312,16 @@ junos_bgp_neighbors_view:
     received_prefix_count: {bgp-rib/received-prefix-count: int}
     accepted_prefix_count: {bgp-rib/accepted-prefix-count: int}
     suppressed_prefix_count: {bgp-rib/suppressed-prefix-count: int}
+
+###
+### Interfaces IPs
+###
+
+junos_ip_interfaces_table:
+  rpc: get-interface-information
+  item: physical-interface
+  view: junos_ip_interfaces_view
+
+junos_ip_interfaces_view:
+  fields:
+    ip: logical-interface/address-family/interface-address/ifa-local

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ pyFG
 pycsco
 bnclient
 netmiko
+pyPluribus


### PR DESCRIPTION
In this PR we propose to extend the capabilities of NAPALM with one more driver for Pluribus devices. Although the library pyPluribus is not yet mature, we are still working on it and will add new features in the near future.
Also we have implemented the following methods for JunOS, IOS-XR, NXOS, EOS and Pluribus:
- get_arp_table
- get_mac_table
- get_ntp_peers
- get_lldp_neighbors_detailed (which is a detailed version of the existing get_lldp_neighbors -- probably it would be a good idea to merge them in a future release).

Also, on some devices we have designed few other methods such as show_route, get_interfaces_ip or get_bgp_neighbors_detail.