### PR TITLE
change output from abbreviated interface names to full names for IOS

### DIFF
--- a/napalm/ios.py
+++ b/napalm/ios.py
@@ -321,7 +321,7 @@ class IOSDriver(NetworkDriver):
             return True
         return False
 
-    def get_lldp_neighbors(self):
+    def get_lldp_neighbors_detail(self):
         '''
         Output command format:
 


### PR DESCRIPTION
changed the output for the get_interfaces() method to return the full interface name instead of the abbreviated name to keeps this consistent.