### PR TITLE
MANIFEST.in is named incorrectly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,5 @@ docs/_build/
 env
 *.swp
 
-napalm/fix_script.sh
 test/unit/test_devices.py
 

--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,7 @@ docs/_build/
 
 env
 *.swp
+
+napalm/fix_script.sh
+test/unit/test_devices.py
+

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include requirements.txt
+include napalm/utils/*.yml

--- a/Manifest.in
+++ b/Manifest.in
@@ -1,2 +1,0 @@
-include requirements.txt
-include napalm/utils/*.yml


### PR DESCRIPTION
This also fixes the issue with ./napalm/utils/junos_views.yml not being copied when executing 'python setup.py install'.