### PR TITLE
Make config lock optional on junos driver

### DIFF
--- a/docs/support/index.rst
+++ b/docs/support/index.rst
@@ -99,6 +99,7 @@ ____________________________________
 
   * :code:`fortios_vdom` (fortios) - VDOM to connect to.
   * :code:`port` (eos, iosxr, junos, ios) - Allows you to specify a port other than the default.
+  * :code:`config_lock` (junos) - Lock the config during open() (default: True).
 
 Adding optional arguments to NAPALM drivers
 ___________________________________________

--- a/napalm/junos.py
+++ b/napalm/junos.py
@@ -42,6 +42,7 @@ class JunOSDriver(NetworkDriver):
         if optional_args is None:
             optional_args = {}
         self.port = optional_args.get('port', 22)
+        self.config_lock = optional_args.get('config_lock', True)
 
         self.device = Device(hostname, user=username, password=password, port=self.port)
 
@@ -49,10 +50,12 @@ class JunOSDriver(NetworkDriver):
         self.device.open()
         self.device.timeout = self.timeout
         self.device.bind(cu=Config)
-        self.device.cu.lock()
+        if self.config_lock:
+            self.device.cu.lock()
 
     def close(self):
-        self.device.cu.unlock()
+        if self.config_lock:
+            self.device.cu.unlock()
         self.device.close()
 
     def _load_candidate(self, filename, config, overwrite):


### PR DESCRIPTION
In the case of long standing sessions we don't want an exclusive lock on the config. Make this optional.