### PR TITLE
Add Cisco ios get_arp_table support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -76,4 +76,5 @@ script:
   - nosetests -v TestIOSDriver:TestGetterIOSDriver.test_get_interfaces_counters
   - nosetests -v TestIOSDriver:TestGetterIOSDriver.test_get_interfaces_ip
   - nosetests -v TestIOSDriver:TestGetterIOSDriver.test_get_lldp_neighbors
+  - nosetests -v TestIOSDriver:TestGetterIOSDriver.test_get_arp_table
   - nosetests -v TestIOSDriver:TestGetterIOSDriver.test_ios_only_bgp_time_conversion #IOS only test

--- a/test/unit/TestIOSDriver.py
+++ b/test/unit/TestIOSDriver.py
@@ -177,8 +177,13 @@ class FakeIOSDevice:
     def send_command_expect(self, command):
         """Fake execute a command in the device by just returning the content of a file."""
         cmd = re.sub(r'[\[\]\*\^\+\s\|]', '_', command)
-        return self.read_txt_file('ios/mock_data/{}.txt'.format(cmd))
+        output = self.read_txt_file('ios/mock_data/{}.txt'.format(cmd))
+        return unicode(output)
 
     def send_command(self, command):
         """Fake execute a command in the device by just returning the content of a file."""
         return self.send_command_expect(command)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/unit/ios/mock_data/show_arp.txt
+++ b/test/unit/ios/mock_data/show_arp.txt
@@ -1,0 +1,10 @@
+Protocol  Address          Age (min)  Hardware Addr   Type   Interface
+Internet  10.10.10.1              8   001f.9002.16fb  ARPA   FastEthernet4
+Internet  10.10.10.20             -   c89c.100a.0eb6  ARPA   FastEthernet4
+Internet  10.10.10.22           122   0024.900e.8577  ARPA   FastEthernet4
+Internet  10.10.10.28           130   5254.000e.446c  ARPA   FastEthernet4
+Internet  10.10.10.29            71   5254.0008.69b6  ARPA   FastEthernet4
+Internet  10.10.10.30           144   5254.0002.13bb  ARPA   FastEthernet4
+Internet  10.10.10.31           191   5254.0000.3737  ARPA   FastEthernet4
+Internet  10.10.10.38             9   0001.000f.0001  ARPA   FastEthernet4
+Internet  10.10.10.100          101   f0ad.4001.d933  ARPA   FastEthernet4


### PR DESCRIPTION
This replaces PR #178.

Rebased the code. Added the get_arp_table function from @ande0581. Added support for mock.