### PR TITLE
Add get_snmp_information() to JunOS, IOS-XR, NXOS & EOS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ script:
   - nosetests -v TestJunOSDriver:TestGetterJunOSDriver.test_get_interfaces_ip
   - nosetests -v TestJunOSDriver:TestGetterJunOSDriver.test_get_mac_address_table
   - nosetests -v TestJunOSDriver:TestGetterJunOSDriver.test_get_route_to
+  - nosetests -v TestJunOSDriver:TestGetterJunOSDriver.test_get_snmp_information
   # testing eos getters
   - nosetests -v TestEOSDriver:TestGetterEOSDriver.test_get_bgp_config
   - nosetests -v TestEOSDriver:TestGetterEOSDriver.test_get_bgp_neighbors
@@ -40,6 +41,7 @@ script:
   - nosetests -v TestEOSDriver:TestGetterEOSDriver.test_get_interfaces_ip
   - nosetests -v TestEOSDriver:TestGetterEOSDriver.test_get_mac_address_table
   - nosetests -v TestEOSDriver:TestGetterEOSDriver.test_get_route_to
+  - nosetests -v TestEOSDriver:TestGetterEOSDriver.test_get_snmp_information
   # testing iosxr getters
   - nosetests -v TestIOSXRDriver:TestGetterIOSXRDriver.test_get_bgp_config
   - nosetests -v TestIOSXRDriver:TestGetterIOSXRDriver.test_get_bgp_neighbors
@@ -55,6 +57,7 @@ script:
   - nosetests -v TestIOSXRDriver:TestGetterIOSXRDriver.test_get_interfaces_ip
   - nosetests -v TestIOSXRDriver:TestGetterIOSXRDriver.test_get_mac_address_table
   - nosetests -v TestIOSXRDriver:TestGetterIOSXRDriver.test_get_route_to
+  - nosetests -v TestIOSXRDriver:TestGetterIOSXRDriver.test_get_snmp_information
 # testing nxos getters
   - nosetests -v TestNXOSDriver:TestGetterNXOSDriver.test_get_facts
   - nosetests -v TestNXOSDriver:TestGetterNXOSDriver.test_get_interfaces
@@ -64,6 +67,7 @@ script:
   - nosetests -v TestNXOSDriver:TestGetterNXOSDriver.test_get_ntp_peers
   - nosetests -v TestNXOSDriver:TestGetterNXOSDriver.test_get_interfaces_ip
   - nosetests -v TestNXOSDriver:TestGetterNXOSDriver.test_get_mac_address_table
+  - nosetests -v TestNXOSDriver:TestGetterNXOSDriver.test_get_snmp_information
 # testing pluribus getters
   - nosetests -v TestPluribusDriver:TestGetterPluribusDriver.test_get_facts
   - nosetests -v TestPluribusDriver:TestGetterPluribusDriver.test_get_interfaces
@@ -71,6 +75,7 @@ script:
   - nosetests -v TestPluribusDriver:TestGetterPluribusDriver.test_get_lldp_neighbors_detail
   - nosetests -v TestPluribusDriver:TestGetterPluribusDriver.test_get_ntp_peers
   - nosetests -v TestPluribusDriver:TestGetterPluribusDriver.test_get_mac_address_table
+  - nosetests -v TestPluribusDriver:TestGetterPluribusDriver.test_get_snmp_information
 # testing ios getters
   - nosetests -v TestIOSDriver:TestGetterIOSDriver.test_get_bgp_neighbors
   - nosetests -v TestIOSDriver:TestGetterIOSDriver.test_get_environment

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 include requirements.txt
 include napalm/utils/*.yml
 include napalm/templates/*/*.j2
+include napalm/utils/textfsm_templates/*/*.tpl

--- a/docs/support/index.rst
+++ b/docs/support/index.rst
@@ -71,7 +71,7 @@ _                               EOS   JunOS   IOS-XR  FortiOS  IBM     NXOS    I
 **get_environment**            |yes|  |yes|   |yes|   |yes|    |no|    |no|    |yes|  |no|
 **get_mac_address_table**      |yes|  |yes|   |yes|   |no|     |no|    |yes|   |yes|  |yes|
 **get_arp_table**              |yes|  |yes|   |yes|   |no|     |no|    |yes|   |yes|  |no|
-**get_snmp_information**       |no|   |no|    |no|    |no|     |no|    |no|    |yes|  |yes|
+**get_snmp_information**       |yes|  |yes|   |yes|   |no|     |no|    |yes|   |yes|  |yes|
 **get_ntp_peers**              |yes|  |yes|   |yes|   |no|     |no|    |yes|   |yes|  |yes|
 **get_interfaces_ip**          |yes|  |yes|   |yes|   |no|     |no|    |yes|   |yes|  |no|
 ============================== =====  =====   ======  =======  ======  ======  =====  =========

--- a/napalm/base.py
+++ b/napalm/base.py
@@ -16,6 +16,8 @@ import os
 import sys
 import jinja2
 
+import textfsm
+
 import napalm.exceptions
 
 
@@ -177,6 +179,33 @@ class NetworkDriver:
             )
 
         self.load_merge_candidate(config=configuration)
+
+    @staticmethod
+    def _textfsm_extractor(template_relative_path, raw_text):
+
+        """
+        Will apply a TextFSM template over a raw text and return the mathing table
+        """
+
+        textfsm_data = list()
+
+        template_path = '{current_dir}/utils/textfsm_templates/{rel_path}'.format(
+            current_dir=os.path.dirname(os.path.abspath(__file__)),
+            rel_path=template_relative_path
+        )
+
+        fsm_handler = textfsm.TextFSM(open(template_path))
+        objects = fsm_handler.ParseText(raw_text)
+
+        for obj in objects:
+            index = 0
+            entry = {}
+            for entry_value in obj:
+                entry[fsm_handler.header[index].lower()] = str(entry_value)
+                index += 1
+            textfsm_data.append(entry)
+
+        return textfsm_data
 
     def get_facts(self):
         """

--- a/napalm/base.py
+++ b/napalm/base.py
@@ -184,7 +184,7 @@ class NetworkDriver:
     def _textfsm_extractor(template_relative_path, raw_text):
 
         """
-        Will apply a TextFSM template over a raw text and return the mathing table
+        Will apply a TextFSM template over a raw text and return the matching table
         """
 
         textfsm_data = list()

--- a/napalm/eos.py
+++ b/napalm/eos.py
@@ -1017,9 +1017,7 @@ class EOSDriver(NetworkDriver):
         commands.append('show running-config | section snmp-server')
         raw_snmp_config = self.device.run_commands(commands, encoding = 'text')[0].get('output', '')
 
-        fsmtemplate_relative_path = 'eos/snmp_config.tpl'
-
-        snmp_config = self._textfsm_extractor(fsmtemplate_relative_path, raw_snmp_config)
+        snmp_config = self._textfsm_extractor('snmp_config', raw_snmp_config)
 
         if not snmp_config:
             return snmp_information

--- a/napalm/eos.py
+++ b/napalm/eos.py
@@ -1037,7 +1037,7 @@ class EOSDriver(NetworkDriver):
                 continue
             snmp_information['community'][community_name] = {
                 'acl': unicode(snmp_entry.get('acl', '')),
-                'mode': unicode(snmp_entry.get('mode', ''))
+                'mode': unicode(snmp_entry.get('mode', '').lower())
             }
 
         return snmp_information

--- a/napalm/eos.py
+++ b/napalm/eos.py
@@ -1025,9 +1025,9 @@ class EOSDriver(NetworkDriver):
             return snmp_information
 
         snmp_information = {
-            'contact'   : unicode(snmp_config[-1].get('contact', '')),
-            'location'  : unicode(snmp_config[-1].get('location', '')),
-            'chassis_id': unicode(snmp_config[-1].get('chassis_id', '')),
+            'contact'   : unicode(snmp_config[0].get('contact', '')),
+            'location'  : unicode(snmp_config[0].get('location', '')),
+            'chassis_id': unicode(snmp_config[0].get('chassis_id', '')),
             'community' : {}
         }
 
@@ -1037,7 +1037,7 @@ class EOSDriver(NetworkDriver):
                 continue
             snmp_information['community'][community_name] = {
                 'acl': unicode(snmp_entry.get('acl', '')),
-                'mode': unicode(snmp_entry.get('mode', '').lower())
+                'mode': unicode(snmp_entry.get('mode', 'ro').lower())
             }
 
         return snmp_information

--- a/napalm/iosxr.py
+++ b/napalm/iosxr.py
@@ -1297,3 +1297,34 @@ class IOSXRDriver(NetworkDriver):
                     first_route = False
 
         return routes
+
+    def get_snmp_information(self):
+
+        snmp_information = dict()
+
+        snmp_rpc_command = '<Get><Configuration><SNMP></SNMP></Configuration></Get>'
+
+        snmp_result_tree = ET.fromstring(self.device.make_rpc_call(snmp_rpc_command))
+
+        _PRIVILEGE_MODE_MAP_ = {
+            'ReadOnly': u'ro',
+            'ReadWrite': u'rw'
+        }
+
+        snmp_information = {
+            'chassis_id': unicode(self._find_txt(snmp_result_tree, './/ChassisID')),
+            'contact': unicode(self._find_txt(snmp_result_tree, './/Contact')),
+            'location': unicode(self._find_txt(snmp_result_tree, './/Location')),
+            'community': {}
+        }
+
+        for community in snmp_result_tree.iter('DefaultCommunity'):
+            name = unicode(self._find_txt(community, 'Naming/CommunityName'))
+            privilege = self._find_txt(community, 'Priviledge')
+            acl = unicode(self._find_txt(community, 'AccessList'))
+            snmp_information['community'][name] = {
+                'mode': _PRIVILEGE_MODE_MAP_.get(privilege, u''),
+                'acl' : acl
+            }
+
+        return snmp_information

--- a/napalm/nxos.py
+++ b/napalm/nxos.py
@@ -521,7 +521,7 @@ class NXOSDriver(NetworkDriver):
 
         snmp_command = 'show running-config | section snmp-server'
 
-        snmp_raw_output = self.cli(snmp_command).get(snmp_command, '')
+        snmp_raw_output = self.cli([snmp_command]).get(snmp_command, '')
 
         fsmtemplate_relative_path = 'nxos/snmp_config.tpl'
 
@@ -543,7 +543,7 @@ class NXOSDriver(NetworkDriver):
                 continue
             snmp_information['community'][community_name] = {
                 'acl': unicode(snmp_entry.get('acl', '')),
-                'mode': unicode(snmp_entry.get('mode', ''))
+                'mode': unicode(snmp_entry.get('mode', '').lower())
             }
 
         return snmp_information

--- a/napalm/nxos.py
+++ b/napalm/nxos.py
@@ -523,9 +523,7 @@ class NXOSDriver(NetworkDriver):
 
         snmp_raw_output = self.cli([snmp_command]).get(snmp_command, '')
 
-        fsmtemplate_relative_path = 'nxos/snmp_config.tpl'
-
-        snmp_config = self._textfsm_extractor(fsmtemplate_relative_path, snmp_raw_output)
+        snmp_config = self._textfsm_extractor('snmp_config', snmp_raw_output)
 
         if not snmp_config:
             return snmp_information

--- a/napalm/nxos.py
+++ b/napalm/nxos.py
@@ -531,9 +531,9 @@ class NXOSDriver(NetworkDriver):
             return snmp_information
 
         snmp_information = {
-            'contact'   : unicode(snmp_config[-1].get('contact', '')),
-            'location'  : unicode(snmp_config[-1].get('location', '')),
-            'chassis_id': unicode(snmp_config[-1].get('chassis_id', '')),
+            'contact'   : unicode(snmp_config[0].get('contact', '')),
+            'location'  : unicode(snmp_config[0].get('location', '')),
+            'chassis_id': unicode(snmp_config[0].get('chassis_id', '')),
             'community' : {}
         }
 

--- a/napalm/pluribus.py
+++ b/napalm/pluribus.py
@@ -260,7 +260,7 @@ class PluribusDriver(NetworkDriver):
         for snmp_line in snmp_lines:
             snmp_line_details = snmp_line.split(';')
             snmp_community = unicode(snmp_line_details[1])
-            snmp_mode      = _SNMP_MODE_MAP_.get(snmp_line_details[1])
+            snmp_mode      = _SNMP_MODE_MAP_.get(snmp_line_details[2], u'ro')
             snmp_acl       = u''
             snmp_information['community'][snmp_community] = {
                 'acl' : snmp_acl,

--- a/napalm/utils/junos_views.yml
+++ b/napalm/utils/junos_views.yml
@@ -458,3 +458,19 @@ junos_route_table_view:
     ### ISIS Specific fields
     ###
     level: {../rt-isis-level: int}
+
+###
+### SNMP Config
+###
+
+junos_snmp_config_table:
+  get: snmp/community
+  view: junos_snmp_config_view
+
+junos_snmp_config_view:
+  fields:
+    name: name
+    authorization: authorization
+    location: ../location
+    contact: ../contact
+    chassis: ../system-name

--- a/napalm/utils/textfsm_templates/eos/snmp_config.tpl
+++ b/napalm/utils/textfsm_templates/eos/snmp_config.tpl
@@ -1,14 +1,14 @@
-Value Location (.*)
-Value Contact (.*)
-Value Chassis_ID (.*)
-Value Community (.*)
-Value Mode (.*)
-Value ACL (.*)
+Value Location (\w+.*)
+Value Contact (\w+.*)
+Value Chassis_ID (\w+.*)
+Value Community (\w+.*)
+Value Mode (ro|rw)
+Value ACL (\w+.*)
 
 Start
-  ^snmp-server location ${Location}
-  ^snmp-server contact ${Contact}
-  ^snmp-server chassis-id ${Chassis_ID}
-  ^snmp-server community ${Community} ${Mode} ${ACL} -> Next.Record
+  ^snmp-server\slocation\s${Location}
+  ^snmp-server\scontact\s${Contact}
+  ^snmp-server\schassis-id\s${Chassis_ID}
+  ^snmp-server\scommunity\s${Community}\s((${Mode} ${ACL})|(group\s(.*))) -> Next.Record
 
 EOF

--- a/napalm/utils/textfsm_templates/eos/snmp_config.tpl
+++ b/napalm/utils/textfsm_templates/eos/snmp_config.tpl
@@ -1,0 +1,14 @@
+Value Location (.*)
+Value Contact (.*)
+Value Chassis_ID (.*)
+Value Community (.*)
+Value Mode (.*)
+Value ACL (.*)
+
+Start
+  ^snmp-server location ${Location}
+  ^snmp-server contact ${Contact}
+  ^snmp-server chassis-id ${Chassis_ID}
+  ^snmp-server community ${Community} ${Mode} ${ACL} -> Next.Record
+
+EOF

--- a/napalm/utils/textfsm_templates/nxos/snmp_config.tpl
+++ b/napalm/utils/textfsm_templates/nxos/snmp_config.tpl
@@ -1,14 +1,14 @@
-Value Location (.*)
-Value Contact (.*)
-Value Chassis_ID (.*)
-Value Community (.*)
-Value Mode (.*)
-Value ACL (.*)
+Value Location (\w+.*)
+Value Contact (\w+.*)
+Value Chassis_ID (\w+.*)
+Value Community (\w+.*)
+Value Mode (ro|rw)
+Value ACL (\w+.*)
 
 Start
-  ^snmp-server location ${Location}
-  ^snmp-server contact ${Contact}
-  ^snmp-server chassis-id ${Chassis_ID}
-  ^snmp-server community ${Community} ${Mode} ${ACL} -> Next.Record
+  ^snmp-server\slocation\s${Location}
+  ^snmp-server\scontact\s${Contact}
+  ^snmp-server\schassis-id\s${Chassis_ID}
+  ^snmp-server\scommunity\s${Community}\s((${Mode} ${ACL})|(group\s(.*))) -> Next.Record
 
 EOF

--- a/napalm/utils/textfsm_templates/nxos/snmp_config.tpl
+++ b/napalm/utils/textfsm_templates/nxos/snmp_config.tpl
@@ -1,0 +1,14 @@
+Value Location (.*)
+Value Contact (.*)
+Value Chassis_ID (.*)
+Value Community (.*)
+Value Mode (.*)
+Value ACL (.*)
+
+Start
+  ^snmp-server location ${Location}
+  ^snmp-server contact ${Contact}
+  ^snmp-server chassis-id ${Chassis_ID}
+  ^snmp-server community ${Community} ${Mode} ${ACL} -> Next.Record
+
+EOF

--- a/test/unit/eos/mock_data/show_running_config_section_snmp_server.txt
+++ b/test/unit/eos/mock_data/show_running_config_section_snmp_server.txt
@@ -1,0 +1,5 @@
+snmp-server contact noc@cloudflare.com
+snmp-server location Marseille, France
+snmp-server chassis-id edge02.mrs01
+snmp-server community hackme ro ifyoucan
+snmp-server community tryagain group not-enough

--- a/test/unit/iosxr/mock_data/_Get__Configuration__SNMP___SNMP___Configuration___Get_.rpc
+++ b/test/unit/iosxr/mock_data/_Get__Configuration__SNMP___SNMP___Configuration___Get_.rpc
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Response MajorVersion="1" MinorVersion="0">
+    <Get>
+        <Configuration>
+            <SNMP MajorVersion="12" MinorVersion="6">
+                <Administration>
+                    <DefaultCommunityTable>
+                        <DefaultCommunity>
+                            <Naming>
+                                <CommunityName>
+                                    hackme
+                                </CommunityName>
+                            </Naming>
+                            <Priviledge>
+                                ReadOnly
+                            </Priviledge>
+                            <AccessList>
+                                ifyoucan
+                            </AccessList>
+                        </DefaultCommunity>
+                    </DefaultCommunityTable>
+                </Administration>
+                <System>
+                    <ChassisID>
+                        edge01.yyz01
+                    </ChassisID>
+                    <Contact>
+                        noc@cloudflare.com
+                    </Contact>
+                    <Location>
+                        Toronto, Canada
+                    </Location>
+                </System>
+            </SNMP>
+        </Configuration>
+    </Get>
+    <ResultSummary ErrorCount="0"/>
+</Response>

--- a/test/unit/junos/mock_data/_configuration__snmp__community____snmp___configuration_.txt
+++ b/test/unit/junos/mock_data/_configuration__snmp__community____snmp___configuration_.txt
@@ -1,0 +1,11 @@
+<configuration commit-seconds="1457011246" commit-localtime="2016-03-03 13:20:46 UTC">
+        <snmp>
+            <contact>noc@cloudflare.com</contact>
+            <location>Stockholm, Sweden</location>
+            <system-name>edge02.arn02</system-name>
+            <community>
+                <name>hackme</name>
+                <authorization>read-only</authorization>
+            </community>
+        </snmp>
+</configuration>

--- a/test/unit/nxos/mock_data/show_running-config___section_snmp-server.txt
+++ b/test/unit/nxos/mock_data/show_running-config___section_snmp-server.txt
@@ -1,0 +1,5 @@
+snmp-server contact noc@cloudflare.com
+snmp-server location Manila, Philippines
+snmp-server chassis-id sw20.mnl01
+snmp-server community hackme ro ifyoucan
+snmp-server community tryagain group not-enough


### PR DESCRIPTION
I take this chance to introduce TextFSM parser (the library is required anyway by pycsco).
I am pretty sure this will be useful for other future implementations (from our side, we plan to refactor ```get_bgp_config``` and implement ```get_bgp_neighbors_detail``` for EOS and NXOS).