### PR TITLE
Added get_route_to in support doc & rearranged lines

### DIFF
--- a/docs/support/index.rst
+++ b/docs/support/index.rst
@@ -62,18 +62,19 @@ _                               EOS   JunOS   IOS-XR  FortiOS  IBM     NXOS    I
 ============================== =====  =====   ======  =======  ======  ======  =====  =========
 **cli**                        |yes|  |yes|   |yes|   |no|     |no|    |yes|   |yes|  |yes|
 **get_facts**                  |yes|  |yes|   |yes|   |yes|    |no|    |yes|   |yes|  |yes|
+**get_environment**            |yes|  |yes|   |yes|   |yes|    |no|    |no|    |yes|  |no|
+**get_snmp_information**       |yes|  |yes|   |yes|   |no|     |no|    |yes|   |yes|  |yes|
+**get_ntp_peers**              |yes|  |yes|   |yes|   |no|     |no|    |yes|   |yes|  |yes|
+**get_mac_address_table**      |yes|  |yes|   |yes|   |no|     |no|    |yes|   |yes|  |yes|
+**get_arp_table**              |yes|  |yes|   |yes|   |no|     |no|    |yes|   |yes|  |no|
 **get_interfaces**             |yes|  |yes|   |yes|   |yes|    |no|    |yes|   |yes|  |yes|
+**get_interfaces_ip**          |yes|  |yes|   |yes|   |no|     |no|    |yes|   |yes|  |no|
 **get_lldp_neighbors**         |yes|  |yes|   |yes|   |yes|    |no|    |no|    |yes|  |yes|
 **get_lldp_neighbors_detail**  |yes|  |yes|   |yes|   |no|     |no|    |yes|   |no|   |yes|
 **get_bgp_neighbors**          |yes|  |yes|   |yes|   |yes|    |no|    |no|    |yes|  |no|
 **get_bgp_neighbors_detail**   |no|   |yes|   |yes|   |no|     |no|    |no|    |no|   |no|
 **get_bgp_config**             |yes|  |yes|   |yes|   |no|     |no|    |no|    |no|   |no|
-**get_environment**            |yes|  |yes|   |yes|   |yes|    |no|    |no|    |yes|  |no|
-**get_mac_address_table**      |yes|  |yes|   |yes|   |no|     |no|    |yes|   |yes|  |yes|
-**get_arp_table**              |yes|  |yes|   |yes|   |no|     |no|    |yes|   |yes|  |no|
-**get_snmp_information**       |yes|  |yes|   |yes|   |no|     |no|    |yes|   |yes|  |yes|
-**get_ntp_peers**              |yes|  |yes|   |yes|   |no|     |no|    |yes|   |yes|  |yes|
-**get_interfaces_ip**          |yes|  |yes|   |yes|   |no|     |no|    |yes|   |yes|  |no|
+**get_route_to**               |yes|  |yes|   |yes|   |no|     |no|    |no|    |no|   |no|
 ============================== =====  =====   ======  =======  ======  ======  =====  =========
 
 Caveats


### PR DESCRIPTION
Just realised that ```get_route_to``` is missing. I rearranged the lines in such order that makes more sense to me -- but not necessarily to everyone. @dbarrosop it is just an idea, just close the PR if does not look good to you, but please add ```get_route_to```. Thanks!