### PR TITLE
Remove interface_description from get_lldp_neighbors_detail

### DIFF
--- a/napalm/base.py
+++ b/napalm/base.py
@@ -375,7 +375,6 @@ class NetworkDriver:
 
         Inner dictionaries contain fields:
             * parent_interface (string)
-            * interface_description (string)
             * remote_port (string)
             * remote_port_description (string)
             * remote_chassis_id (string)
@@ -390,7 +389,6 @@ class NetworkDriver:
                 'TenGigE0/0/0/8': [
                     {
                         'parent_interface': u'Bundle-Ether8',
-                        'interface_description': u'TenGigE0/0/0/8',
                         'remote_chassis_id': u'8c60.4f69.e96c',
                         'remote_system_name': u'switch',
                         'remote_port': u'Eth2/2/1',

--- a/napalm/eos.py
+++ b/napalm/eos.py
@@ -486,7 +486,6 @@ class EOSDriver(NetworkDriver):
                 lldp_neighbors_out[interface].append(
                     {
                         'parent_interface'              : interface, # no parent interfaces
-                        # 'interface_description'         : neighbor.get('neighborInterfaceInfo', {}).get('interfaceDescription', u''),
                         'remote_port'                   : neighbor.get('neighborInterfaceInfo', {}).get('interfaceId', u''),
                         'remote_port_description'       : u'',
                         'remote_system_name'            : neighbor.get('systemName', u''),


### PR DESCRIPTION
interface_description is not needed for get_lldp_neigbhors_detail and is not currently present in the unit test models.py (so it is not currently implemented by platforms).