### PR TITLE
adds a dynamic network driver loader concept

### DIFF
--- a/napalm/__init__.py
+++ b/napalm/__init__.py
@@ -12,31 +12,142 @@
 # License for the specific language governing permissions and limitations under
 # the License.
 
-from eos import EOSDriver
-from iosxr import IOSXRDriver
-from junos import JunOSDriver
-from fortios import FortiOSDriver
-from nxos import NXOSDriver
-from ibm import IBMDriver
-from ios import IOSDriver
-from pluribus import PluribusDriver
+import sys
+import imp
 
-def get_network_driver(vendor):
-    driver_mapping = {
-        'EOS': EOSDriver,
-        'ARISTA': EOSDriver,
-        'IOS-XR': IOSXRDriver,
-        'IOSXR': IOSXRDriver,
-        'JUNOS': JunOSDriver,
-        'JUNIPER': JunOSDriver,
-        'FORTIOS': FortiOSDriver,
-        'NXOS': NXOSDriver,
-        'IBM': IBMDriver,
-        'IOS' : IOSDriver,
-        'PLURIBUS': PluribusDriver
-    }
+#from eos import EOSDriver
+#from iosxr import IOSXRDriver
+#from junos import JunOSDriver
+#from fortios import FortiOSDriver
+#from nxos import NXOSDriver
+#from ibm import IBMDriver
+#from ios import IOSDriver
+#from pluribus import PluribusDriver
+#
+#def get_network_driver(vendor):
+#    driver_mapping = {
+#        'EOS': EOSDriver,
+#        'ARISTA': EOSDriver,
+#        'IOS-XR': IOSXRDriver,
+#        'IOSXR': IOSXRDriver,
+#        'JUNOS': JunOSDriver,
+#        'JUNIPER': JunOSDriver,
+#        'FORTIOS': FortiOSDriver,
+#        'NXOS': NXOSDriver,
+#        'IBM': IBMDriver,
+#        'IOS' : IOSDriver,
+#        'PLURIBUS': PluribusDriver
+#    }
+#    try:
+#        return driver_mapping[vendor.upper()]
+#    except KeyError:
+#        raise Exception('Vendor/OS not supported: %s' % vendor)
+#
+
+def import_module(name):
+    """Imports a module into the current runtime environment
+
+    This function will take a full path module name and break it into
+    its parts iteratively attempting to import each one.  The function
+    will check to be sure that the module hasn't been previously imported.
+
+    .. doctest::
+
+        >>> import_module('os') #doctest: +ELLIPSIS
+        <module 'os' from '...'>
+
+    :param str name:
+        The name of the module to import
+
+    :returns:
+        The imported Python module
+    """
+    parts = name.split('.')
+    path = None
+    module_name = ''
+    fhandle = None
+
+    for index, part in enumerate(parts):
+        module_name = part if index == 0 else '%s.%s' % (module_name, part)
+        path = [path] if path is not None else path
+
+        try:
+            fhandle, path, descr = imp.find_module(part, path)
+            if module_name in sys.modules:
+                # since imp.load_module works like reload, need to be sure not
+                # to reload a previously loaded module
+                mod = sys.modules[module_name]
+            else:
+                mod = imp.load_module(module_name, fhandle, path, descr)
+        finally:
+            # lets be sure to clean up after ourselves
+            if fhandle:
+                fhandle.close()
+
+    return mod
+
+def load_module(name):
+    """Attempts to load a module into the current environment
+
+    This function will load a module from the Python sys.path.  It will
+    check to be sure the module wasn't already loaded.  If the module
+    was prevsiouly loaded, it will simply return the loaded module and not
+    reload it
+
+    .. doctest::
+
+        >>> load_module('sys')
+        <module 'sys' (built-in)>
+
+    :param str name:
+        The name of the module to load
+
+    :returns:
+        The named Python module
+
+    :raises ImportError:
+        If the module could not be loaded
+    """
     try:
-        return driver_mapping[vendor.upper()]
+        mod = None
+        mod = sys.modules[name]
     except KeyError:
-        raise Exception('Vendor/OS not supported: %s' % vendor)
+        try:
+            mod = import_module(name)
+        except ImportError:
+            raise
+    finally:
+        if not mod:
+            raise
+        return mod
+
+
+def get_network_driver(module, *args, **kwargs):
+    """Attempts to load a class instance from the module
+
+    The function will load the specified module and create
+    an instance.  The loader works by looking for a function in
+    the module and loading it.
+
+    :param str module:
+        The name of the module to dynamically load
+
+    :param args:
+        An ordered set of arbitrary arguments that are passed to the
+        instance function
+
+    :param kwargs:
+        An unordered set of arbitrary keyword arguments that are passed
+        to the instance function
+
+    :returns object:
+        Instantiates a Python object an returns it
+    """
+    mod = load_module(module)
+    if not hasattr(mod, 'load_driver'):
+        raise Exception('Missing load_driver function from %s' % module)
+    func = getattr(mod, 'load_driver')
+    return func(*args, **kwargs)
+
+
 

--- a/napalm/eos.py
+++ b/napalm/eos.py
@@ -1038,3 +1038,6 @@ class EOSDriver(NetworkDriver):
             }
 
         return snmp_information
+
+def load_driver():
+    return EOSDriver


### PR DESCRIPTION
This adds a dynamic loader to replace the currently static loading of
network device modules.  This allows NAPALM to load drivers dynamically
based on namespace

```
>>> import napalm
>>> driver = napalm.get_network_driver('napalm.eos')
>>> device = driver('veos01', 'admin', 'admin')
>>> device.open()
>>> device
<napalm.eos.EOSDriver instance at 0x10629d638>
>>> device.get_facts()
{'os_version': u'4.15.0F-2387143.4150F', 'uptime': 1309109, 'interface_list': [u'Ethernet1', u'Ethernet2', u'Ethernet3', u'Ethernet4', u'Ethernet5', u'Ethernet6', u'Ethernet7', u'Management1'], 'vendor': u'Arista', 'serial_number': u'', 'model': u'vEOS', 'hostname': u'veos01', 'fqdn': u'veos01.eng.ansible.com'}
```

Drivers do not have to be in the napalm namespace although for this to work.

```
>>> driver = napalm.get_network_driver('my.namespace.eos')
>>> device = driver('veos01', 'admin', 'admin')
>>> device.open()
>>> device
<my.namespace.eos.EOSDriver instance at 0x102193b68>
>>> device.get_facts()
```

This commit is just a proof of concept.  It includes on module (eos.py) that
has been modfied for testing purposes.