### PR TITLE
Add quickstart tutorial.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,4 @@ env
 
 test/unit/test_devices.py
 
+.vagrant

--- a/docs/tutorials/Vagrantfile
+++ b/docs/tutorials/Vagrantfile
@@ -1,0 +1,24 @@
+# Vagrantfile for the quickstart tutorial
+
+Vagrant.configure(2) do |config|
+
+  config.vm.define "base" do |base|
+    # This box will be downloaded and added automatically if you don't
+    # have it already.
+    base.vm.box = "hashicorp/precise64"
+    base.vm.network :forwarded_port, guest: 22, host: 12200, id: 'ssh'
+    base.vm.network "private_network", virtualbox__intnet: "link_1", ip: "10.0.1.100"
+    base.vm.network "private_network", virtualbox__intnet: "link_2", ip: "10.0.2.100"
+    base.vm.provision "shell", inline: "apt-get update; apt-get install lldpd -y"
+  end
+
+  config.vm.define "eos" do |eos|
+    # Box downloaded from Arista and added manually:
+    eos.vm.box = "vEOS-lab-quickstart"
+    eos.vm.network :forwarded_port, guest: 22, host: 12201, id: 'ssh'
+    eos.vm.network :forwarded_port, guest: 443, host: 12443, id: 'https'
+    eos.vm.network "private_network", virtualbox__intnet: "link_1", ip: "169.254.1.11", auto_config: false
+    eos.vm.network "private_network", virtualbox__intnet: "link_2", ip: "169.254.1.11", auto_config: false
+  end
+
+end

--- a/docs/tutorials/Vagrantfile
+++ b/docs/tutorials/Vagrantfile
@@ -1,5 +1,12 @@
 # Vagrantfile for the quickstart tutorial
 
+# Script configuration:
+#
+# Arista vEOS box.
+# Please change this to match your installed version
+# (use `vagrant box list` to see what you have installed).
+VEOS_BOX = "vEOS-lab-4.15.5M-virtualbox"
+
 Vagrant.configure(2) do |config|
 
   config.vm.define "base" do |base|
@@ -13,8 +20,7 @@ Vagrant.configure(2) do |config|
   end
 
   config.vm.define "eos" do |eos|
-    # Box downloaded from Arista and added manually:
-    eos.vm.box = "vEOS-lab-quickstart"
+    eos.vm.box = VEOS_BOX
     eos.vm.network :forwarded_port, guest: 22, host: 12201, id: 'ssh'
     eos.vm.network :forwarded_port, guest: 443, host: 12443, id: 'https'
     eos.vm.network "private_network", virtualbox__intnet: "link_1", ip: "169.254.1.11", auto_config: false

--- a/docs/tutorials/index.rst
+++ b/docs/tutorials/index.rst
@@ -4,5 +4,6 @@ Tutorials
 .. toctree::
    :maxdepth: 1
 
+   quickstart
    first_steps_config
    context_manager

--- a/docs/tutorials/quickstart.rst
+++ b/docs/tutorials/quickstart.rst
@@ -1,0 +1,109 @@
+Quickstart
+==========
+
+This tutorial gets you up-and-running quickly with NAPALM in a local virtual environment so you can see it in action.
+
+.. note::  This tutorial does not cover fully automated configuration management (e.g., using NAPALM in conjunction with Ansible, Chef, Salt, etc.).  We hope that tutorials for these tools will be contributed soon so that you can evaluate the options for your particular environment.
+
+Requirements
+------------
+
+You'll need a few tools:
+
+* Python
+* `pip <https://pip.pypa.io/en/stable/installing/>`_: The PyPA recommended tool for installing Python packages
+* `virtualenv <http://docs.python-guide.org/en/latest/dev/virtualenvs/>`_: a tool to create isolated Python environments
+* `VirtualBox <https://www.virtualbox.org/>`_: a software virtualization tool
+* `Vagrant <https://www.vagrantup.com/downloads.html>`_: a command line utility for managing the lifecycle of virtual machines
+
+As the focus of this tutorial is NAPALM, we don't even scratch the surface of these tools.  If you're not familiar with them, please do some research [#f1]_ as they will be an important part of your development/ops toolkit.
+
+Installation
+------------
+
+If you haven't already installed NAPALM, you can run the code from a virtual environment in the root directory::
+
+    $ virtualenv venv                        # create environment
+    $ source venv/bin/activate               # start environment
+    $ sudo pip install -r requirements.txt   # install dependencies
+    $ python setup.py install                # install NAPALM
+
+Arista vEOS
+-----------
+
+We'll use Arista, which can be downloaded for free from the Arista site.
+
+Create an account at https://www.arista.com/en/user-registration, and go to https://www.arista.com/en/support/software-download.
+
+Download the latest "vEOS-lab-<version>-virtualbox.box" listed in the vEOS folder at the bottom of the page.
+
+Add it to your vagrant box list as "vEOS-lab-quickstart"::
+
+    $ vagrant box add --name vEOS-lab-quickstart ~/Downloads/vEOS-lab-<version>-virtualbox.box
+    $ vagrant box list
+    vEOS-lab-quickstart (virtualbox, 0)
+
+Notes:
+
+* we're setting the ``--name`` parameter here so that the tutorial's Vagrantfile will work out-of-the-box.  You may wish to also ``vagrant box add`` this file with the correct version
+* ``vagrant box add`` copies downloaded file to a designated directory (e.g., for Mac OS X and Linux: ``~/.vagrant.d/boxes``, Windows: ``C:/Users/USERNAME/.vagrant.d/boxes``).
+
+Starting Vagrant
+----------------
+
+The Vagrantfile (in this directory) creates a base box and a vEOS box when you call "vagrant up"::
+
+    $ cd docs/tutorials
+    $ vagrant up
+    ... [omitted] ...
+
+    $ vagrant status
+    Current machine states:
+    base                      running (virtualbox)
+    eos                       running (virtualbox)
+
+You may see some errors when the eos box is getting created [#f2]_.
+
+
+Using the NAPALM command-line client
+------------------------------------
+
+You can now try the example commands at http://napalm.readthedocs.org/en/latest/cli.html.  Cd to the ``test/unit/eos`` directory which contains the .conf files::
+
+    $ cd PROJECT_ROOT/test/unit/eos
+
+    # dry run.
+    # (When prompted, the password is "vagrant")
+    $ cl_napalm_configure \
+      --user vagrant \
+      --vendor eos \
+      --strategy replace \
+      --optional_args 'port=12443' \
+      --dry-run \
+      new_good.conf localhost
+
+
+Try the other examples and commands given at http://napalm.readthedocs.org/en/latest/cli.html.
+
+Shutting down
+-------------
+
+    $ cd PROJECT_ROOT/docs/tutorials
+    $ vagrant destroy -f
+    $ deactivate           # exit the virtualenv environment
+
+Next Steps
+----------
+
+There are many possible steps you could take next:
+
+* create Vagrant boxes for other devices
+* explore using configuration management tools (Ansible, Chef, Salt, etc.)
+
+Thanks for trying NAPALM!  Please contribute to this documentation and help grow the NAPALM community!
+
+
+.. [#f1] Vagrant's `getting started guide <https://www.vagrantup.com/docs/getting-started/>`_ is worth reading and working through.
+
+.. [#f2] Currently, ``vagrant up`` with the eos box prints some warnings: "No guest additions were detected on the base box for this VM! Guest additions are required for forwarded ports, shared folders, host only networking, and more. If SSH fails on this machine, please install the guest additions and repackage the box to continue. This is not an error message; everything may continue to work properly, in which case you may ignore this message."  This is not a reassuring message, but everything still seems to work correctly.
+

--- a/docs/tutorials/quickstart.rst
+++ b/docs/tutorials/quickstart.rst
@@ -12,7 +12,6 @@ You'll need a few tools:
 
 * Python
 * `pip <https://pip.pypa.io/en/stable/installing/>`_: The PyPA recommended tool for installing Python packages
-* `virtualenv <http://docs.python-guide.org/en/latest/dev/virtualenvs/>`_: a tool to create isolated Python environments
 * `VirtualBox <https://www.virtualbox.org/>`_: a software virtualization tool
 * `Vagrant <https://www.vagrantup.com/downloads.html>`_: a command line utility for managing the lifecycle of virtual machines
 
@@ -21,12 +20,9 @@ As the focus of this tutorial is NAPALM, we don't even scratch the surface of th
 Installation
 ------------
 
-If you haven't already installed NAPALM, you can run the code from a virtual environment in the root directory::
+Install NAPALM with pip::
 
-    $ virtualenv venv                        # create environment
-    $ source venv/bin/activate               # start environment
-    $ sudo pip install -r requirements.txt   # install dependencies
-    $ python setup.py install                # install NAPALM
+    pip install napalm
 
 Arista vEOS
 -----------

--- a/docs/tutorials/quickstart.rst
+++ b/docs/tutorials/quickstart.rst
@@ -33,9 +33,9 @@ Create an account at https://www.arista.com/en/user-registration, and go to http
 
 Download the latest "vEOS-lab-<version>-virtualbox.box" listed in the vEOS folder at the bottom of the page.
 
-Add it to your vagrant box list as "vEOS-lab-quickstart"::
+Add it to your vagrant box list, changing the `<version>`::
 
-    $ vagrant box add --name vEOS-lab-quickstart ~/Downloads/vEOS-lab-<version>-virtualbox.box
+    $ vagrant box add --name vEOS-lab-<version>-virtualbox ~/Downloads/vEOS-lab-<version>-virtualbox.box
     $ vagrant box list
     vEOS-lab-quickstart (virtualbox, 0)
 

--- a/docs/tutorials/quickstart.rst
+++ b/docs/tutorials/quickstart.rst
@@ -44,11 +44,17 @@ You can delete the downloaded .box file once you have added it, as ``vagrant box
 Starting Vagrant
 ----------------
 
-The Vagrantfile (in this directory) creates a base box and a vEOS box when you call "vagrant up"::
+Create a Vagrantfile on your machine with the following content:
 
-    $ cd docs/tutorials
+.. literalinclude:: Vagrantfile
+   :language: ruby
+
+The above content is also available on `GitHub <https://raw.githubusercontent.com/napalm-automation/napalm/master/docs/tutorials/Vagrantfile>`_.
+
+This Vagrantfile creates a base box and a vEOS box when you call "vagrant up"::
+
     $ vagrant up
-    ... [omitted] ...
+    ... [output omitted] ...
 
     $ vagrant status
     Current machine states:
@@ -61,9 +67,10 @@ You may see some errors when the eos box is getting created [#f2]_.
 Using the NAPALM command-line client
 ------------------------------------
 
-You can now try the example commands at http://napalm.readthedocs.org/en/latest/cli.html.  Cd to the ``test/unit/eos`` directory which contains the .conf files::
+You can now try the example commands at http://napalm.readthedocs.org/en/latest/cli.html, using the test data files at https://github.com/napalm-automation/napalm-eos/tree/master/test/unit/eos::
 
-    $ cd PROJECT_ROOT/test/unit/eos
+    # Get a sample test file (or copy/paste it from GitHub to new_good.conf):
+    $ wget https://raw.githubusercontent.com/napalm-automation/napalm-eos/master/test/unit/eos/new_good.conf
 
     # dry run.
     # (When prompted, the password is "vagrant")

--- a/docs/tutorials/quickstart.rst
+++ b/docs/tutorials/quickstart.rst
@@ -39,10 +39,7 @@ Add it to your vagrant box list, changing the `<version>`::
     $ vagrant box list
     vEOS-lab-quickstart (virtualbox, 0)
 
-Notes:
-
-* we're setting the ``--name`` parameter here so that the tutorial's Vagrantfile will work out-of-the-box.  You may wish to also ``vagrant box add`` this file with the correct version
-* ``vagrant box add`` copies downloaded file to a designated directory (e.g., for Mac OS X and Linux: ``~/.vagrant.d/boxes``, Windows: ``C:/Users/USERNAME/.vagrant.d/boxes``).
+You can delete the downloaded .box file once you have added it, as ``vagrant box add`` copies downloaded file to a designated directory (e.g., for Mac OS X and Linux: ``~/.vagrant.d/boxes``, Windows: ``C:/Users/USERNAME/.vagrant.d/boxes``).
 
 Starting Vagrant
 ----------------


### PR DESCRIPTION
Compilation of information from several sources into a single canonical document for new users.

I added a separate Vagrantfile, rather than reusing the one at test/unit/Vagrant/Vagrantfile, as I wanted to keep the vagrantfile short focussed, and to reduce the version numbering issues (the new Vagrantfile hardcodes the box name as "vEOS-lab-quickstart" per the tutorial instructions).

Addresses https://github.com/napalm-automation/napalm/issues/230