### PR TITLE
Quickstart

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,4 @@ env
 
 test/unit/test_devices.py
 
+.vagrant

--- a/docs/tutorials/Vagrantfile
+++ b/docs/tutorials/Vagrantfile
@@ -1,0 +1,24 @@
+# Vagrantfile for the quickstart tutorial
+
+Vagrant.configure(2) do |config|
+
+  config.vm.define "base" do |base|
+    # This box will be downloaded and added automatically if you don't
+    # have it already.
+    base.vm.box = "hashicorp/precise64"
+    base.vm.network :forwarded_port, guest: 22, host: 12200, id: 'ssh'
+    base.vm.network "private_network", virtualbox__intnet: "link_1", ip: "10.0.1.100"
+    base.vm.network "private_network", virtualbox__intnet: "link_2", ip: "10.0.2.100"
+    base.vm.provision "shell", inline: "apt-get update; apt-get install lldpd -y"
+  end
+
+  config.vm.define "eos" do |eos|
+    # Box downloaded from Arista and added manually:
+    eos.vm.box = "vEOS-lab-quickstart"
+    eos.vm.network :forwarded_port, guest: 22, host: 12201, id: 'ssh'
+    eos.vm.network :forwarded_port, guest: 443, host: 12443, id: 'https'
+    eos.vm.network "private_network", virtualbox__intnet: "link_1", ip: "169.254.1.11", auto_config: false
+    eos.vm.network "private_network", virtualbox__intnet: "link_2", ip: "169.254.1.11", auto_config: false
+  end
+
+end

--- a/docs/tutorials/Vagrantfile
+++ b/docs/tutorials/Vagrantfile
@@ -1,5 +1,12 @@
 # Vagrantfile for the quickstart tutorial
 
+# Script configuration:
+#
+# Arista vEOS box.
+# Please change this to match your installed version
+# (use `vagrant box list` to see what you have installed).
+VEOS_BOX = "vEOS-lab-4.15.5M-virtualbox"
+
 Vagrant.configure(2) do |config|
 
   config.vm.define "base" do |base|
@@ -13,8 +20,7 @@ Vagrant.configure(2) do |config|
   end
 
   config.vm.define "eos" do |eos|
-    # Box downloaded from Arista and added manually:
-    eos.vm.box = "vEOS-lab-quickstart"
+    eos.vm.box = VEOS_BOX
     eos.vm.network :forwarded_port, guest: 22, host: 12201, id: 'ssh'
     eos.vm.network :forwarded_port, guest: 443, host: 12443, id: 'https'
     eos.vm.network "private_network", virtualbox__intnet: "link_1", ip: "169.254.1.11", auto_config: false

--- a/docs/tutorials/index.rst
+++ b/docs/tutorials/index.rst
@@ -4,5 +4,6 @@ Tutorials
 .. toctree::
    :maxdepth: 1
 
+   quickstart
    first_steps_config
    context_manager

--- a/docs/tutorials/quickstart.rst
+++ b/docs/tutorials/quickstart.rst
@@ -1,0 +1,109 @@
+Quickstart
+==========
+
+This tutorial gets you up-and-running quickly with NAPALM in a local virtual environment so you can see it in action.
+
+.. note::  This tutorial does not cover fully automated configuration management (e.g., using NAPALM in conjunction with Ansible, Chef, Salt, etc.).  We hope that tutorials for these tools will be contributed soon so that you can evaluate the options for your particular environment.
+
+Requirements
+------------
+
+You'll need a few tools:
+
+* Python
+* `pip <https://pip.pypa.io/en/stable/installing/>`_: The PyPA recommended tool for installing Python packages
+* `virtualenv <http://docs.python-guide.org/en/latest/dev/virtualenvs/>`_: a tool to create isolated Python environments
+* `VirtualBox <https://www.virtualbox.org/>`_: a software virtualization tool
+* `Vagrant <https://www.vagrantup.com/downloads.html>`_: a command line utility for managing the lifecycle of virtual machines
+
+As the focus of this tutorial is NAPALM, we don't even scratch the surface of these tools.  If you're not familiar with them, please do some research [#f1]_ as they will be an important part of your development/ops toolkit.
+
+Installation
+------------
+
+If you haven't already installed NAPALM, you can run the code from a virtual environment in the root directory::
+
+    $ virtualenv venv                        # create environment
+    $ source venv/bin/activate               # start environment
+    $ sudo pip install -r requirements.txt   # install dependencies
+    $ python setup.py install                # install NAPALM
+
+Arista vEOS
+-----------
+
+We'll use Arista, which can be downloaded for free from the Arista site.
+
+Create an account at https://www.arista.com/en/user-registration, and go to https://www.arista.com/en/support/software-download.
+
+Download the latest "vEOS-lab-<version>-virtualbox.box" listed in the vEOS folder at the bottom of the page.
+
+Add it to your vagrant box list as "vEOS-lab-quickstart"::
+
+    $ vagrant box add --name vEOS-lab-quickstart ~/Downloads/vEOS-lab-<version>-virtualbox.box
+    $ vagrant box list
+    vEOS-lab-quickstart (virtualbox, 0)
+
+Notes:
+
+* we're setting the ``--name`` parameter here so that the tutorial's Vagrantfile will work out-of-the-box.  You may wish to also ``vagrant box add`` this file with the correct version
+* ``vagrant box add`` copies downloaded file to a designated directory (e.g., for Mac OS X and Linux: ``~/.vagrant.d/boxes``, Windows: ``C:/Users/USERNAME/.vagrant.d/boxes``).
+
+Starting Vagrant
+----------------
+
+The Vagrantfile (in this directory) creates a base box and a vEOS box when you call "vagrant up"::
+
+    $ cd docs/tutorials
+    $ vagrant up
+    ... [omitted] ...
+
+    $ vagrant status
+    Current machine states:
+    base                      running (virtualbox)
+    eos                       running (virtualbox)
+
+You may see some errors when the eos box is getting created [#f2]_.
+
+
+Using the NAPALM command-line client
+------------------------------------
+
+You can now try the example commands at http://napalm.readthedocs.org/en/latest/cli.html.  Cd to the ``test/unit/eos`` directory which contains the .conf files::
+
+    $ cd PROJECT_ROOT/test/unit/eos
+
+    # dry run.
+    # (When prompted, the password is "vagrant")
+    $ cl_napalm_configure \
+      --user vagrant \
+      --vendor eos \
+      --strategy replace \
+      --optional_args 'port=12443' \
+      --dry-run \
+      new_good.conf localhost
+
+
+Try the other examples and commands given at http://napalm.readthedocs.org/en/latest/cli.html.
+
+Shutting down
+-------------
+
+    $ cd PROJECT_ROOT/docs/tutorials
+    $ vagrant destroy -f
+    $ deactivate           # exit the virtualenv environment
+
+Next Steps
+----------
+
+There are many possible steps you could take next:
+
+* create Vagrant boxes for other devices
+* explore using configuration management tools (Ansible, Chef, Salt, etc.)
+
+Thanks for trying NAPALM!  Please contribute to this documentation and help grow the NAPALM community!
+
+
+.. [#f1] Vagrant's `getting started guide <https://www.vagrantup.com/docs/getting-started/>`_ is worth reading and working through.
+
+.. [#f2] Currently, ``vagrant up`` with the eos box prints some warnings: "No guest additions were detected on the base box for this VM! Guest additions are required for forwarded ports, shared folders, host only networking, and more. If SSH fails on this machine, please install the guest additions and repackage the box to continue. This is not an error message; everything may continue to work properly, in which case you may ignore this message."  This is not a reassuring message, but everything still seems to work correctly.
+

--- a/docs/tutorials/quickstart.rst
+++ b/docs/tutorials/quickstart.rst
@@ -12,7 +12,6 @@ You'll need a few tools:
 
 * Python
 * `pip <https://pip.pypa.io/en/stable/installing/>`_: The PyPA recommended tool for installing Python packages
-* `virtualenv <http://docs.python-guide.org/en/latest/dev/virtualenvs/>`_: a tool to create isolated Python environments
 * `VirtualBox <https://www.virtualbox.org/>`_: a software virtualization tool
 * `Vagrant <https://www.vagrantup.com/downloads.html>`_: a command line utility for managing the lifecycle of virtual machines
 
@@ -21,12 +20,9 @@ As the focus of this tutorial is NAPALM, we don't even scratch the surface of th
 Installation
 ------------
 
-If you haven't already installed NAPALM, you can run the code from a virtual environment in the root directory::
+Install NAPALM with pip::
 
-    $ virtualenv venv                        # create environment
-    $ source venv/bin/activate               # start environment
-    $ sudo pip install -r requirements.txt   # install dependencies
-    $ python setup.py install                # install NAPALM
+    pip install napalm
 
 Arista vEOS
 -----------

--- a/docs/tutorials/quickstart.rst
+++ b/docs/tutorials/quickstart.rst
@@ -33,9 +33,9 @@ Create an account at https://www.arista.com/en/user-registration, and go to http
 
 Download the latest "vEOS-lab-<version>-virtualbox.box" listed in the vEOS folder at the bottom of the page.
 
-Add it to your vagrant box list as "vEOS-lab-quickstart"::
+Add it to your vagrant box list, changing the `<version>`::
 
-    $ vagrant box add --name vEOS-lab-quickstart ~/Downloads/vEOS-lab-<version>-virtualbox.box
+    $ vagrant box add --name vEOS-lab-<version>-virtualbox ~/Downloads/vEOS-lab-<version>-virtualbox.box
     $ vagrant box list
     vEOS-lab-quickstart (virtualbox, 0)
 

--- a/docs/tutorials/quickstart.rst
+++ b/docs/tutorials/quickstart.rst
@@ -44,11 +44,17 @@ You can delete the downloaded .box file once you have added it, as ``vagrant box
 Starting Vagrant
 ----------------
 
-The Vagrantfile (in this directory) creates a base box and a vEOS box when you call "vagrant up"::
+Create a Vagrantfile on your machine with the following content:
 
-    $ cd docs/tutorials
+.. literalinclude:: Vagrantfile
+   :language: ruby
+
+The above content is also available on `GitHub <https://raw.githubusercontent.com/napalm-automation/napalm/master/docs/tutorials/Vagrantfile>`_.
+
+This Vagrantfile creates a base box and a vEOS box when you call "vagrant up"::
+
     $ vagrant up
-    ... [omitted] ...
+    ... [output omitted] ...
 
     $ vagrant status
     Current machine states:
@@ -61,9 +67,10 @@ You may see some errors when the eos box is getting created [#f2]_.
 Using the NAPALM command-line client
 ------------------------------------
 
-You can now try the example commands at http://napalm.readthedocs.org/en/latest/cli.html.  Cd to the ``test/unit/eos`` directory which contains the .conf files::
+You can now try the example commands at http://napalm.readthedocs.org/en/latest/cli.html, using the test data files at https://github.com/napalm-automation/napalm-eos/tree/master/test/unit/eos::
 
-    $ cd PROJECT_ROOT/test/unit/eos
+    # Get a sample test file (or copy/paste it from GitHub to new_good.conf):
+    $ wget https://raw.githubusercontent.com/napalm-automation/napalm-eos/master/test/unit/eos/new_good.conf
 
     # dry run.
     # (When prompted, the password is "vagrant")

--- a/docs/tutorials/quickstart.rst
+++ b/docs/tutorials/quickstart.rst
@@ -39,10 +39,7 @@ Add it to your vagrant box list, changing the `<version>`::
     $ vagrant box list
     vEOS-lab-quickstart (virtualbox, 0)
 
-Notes:
-
-* we're setting the ``--name`` parameter here so that the tutorial's Vagrantfile will work out-of-the-box.  You may wish to also ``vagrant box add`` this file with the correct version
-* ``vagrant box add`` copies downloaded file to a designated directory (e.g., for Mac OS X and Linux: ``~/.vagrant.d/boxes``, Windows: ``C:/Users/USERNAME/.vagrant.d/boxes``).
+You can delete the downloaded .box file once you have added it, as ``vagrant box add`` copies downloaded file to a designated directory (e.g., for Mac OS X and Linux: ``~/.vagrant.d/boxes``, Windows: ``C:/Users/USERNAME/.vagrant.d/boxes``).
 
 Starting Vagrant
 ----------------


### PR DESCRIPTION
Replacement for https://github.com/napalm-automation/napalm/pull/235

Copying relevant content from that PR here:

Comments from here on are from @dbarrosop.  With this PR merged into the quickstart branch, I and others can start to address these points:

Change the current tutorials to use the same vagrantfile you have. With that I mean: http://napalm.readthedocs.org/en/latest/tutorials/index.html and http://napalm.readthedocs.org/en/latest/cli.html
Reference all the tutorials in your document. I think it's interesting that after seeing how simple the cli is they can jump into some python code and see that's it's almost as simple and not that different from using just the CLIs they are used to... Just a quick introduction to python code and then a link to the longer tutorial in the same way you did the cli introduction.

...

Back to the PR itself. Right now, I think that most of the content of this PR mostly duplicates work already done in the tutorials. So let me try to explain what I envision for this PR:

The target audience should be developers/network_engineers/users_in_general that heard about napalm and what to see it in action and maybe try it by themselves. The key word here is users. Anyone that might be considering napalm as their main interface to the network. They could be people looking into ansible, writing their own scripts or something else. But definitively not people trying to contribute to napalm. For that people we will have some other document.

The goal of the document should be to be able to copy & paste a few lines and see different things you can do with napalm:

Change configuration
Get diffs.
Get LLDP neighbors/BGP/interfaces/whatever
Test the CLI tool.
Provide a list of resources to explore a bit further.

Right now, most of the stuff is covered on the tutorials, what is missing is:
How to quickly build a lab so you don't have to test on your own network.
Fixing the tutorials so you can actually copy & paste them.

In summary, my problem with the PR right now is that overlaps a lot with the tutorials. I would rather have this PR just telling you how to start a lab to move forward onto the rest of the tutorials and adapt the tutorials so they can be reproduced with the lab.
