### PR TITLE
Add classifier indicating only Python2.7 support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,8 @@ setup(
     classifiers=[
         'Topic :: Utilities',
         'Programming Language :: Python',
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 2.7',
         'Operating System :: POSIX :: Linux',
         'Operating System :: MacOS',
     ],


### PR DESCRIPTION
A similar change was put into napalm-base in this PR https://github.com/napalm-automation/napalm-base/pull/24.

I thought this should also be in the napalm repository (to clarify that we currently only support Python2.7).