### PR TITLE
Remove bad clitools entry point.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,10 +25,5 @@ setup(
     ],
     url="https://github.com/napalm-automation/napalm",
     include_package_data=True,
-    install_requires=reqs,
-    entry_points={
-        'console_scripts': [
-            'cl_napalm_configure=napalm.clitools.cl_napalm_configure:main',
-        ],
-    }
+    install_requires=reqs
 )


### PR DESCRIPTION
clitools has moved to napalm_base module.

Proposed fix for part of https://github.com/napalm-automation/napalm/issues/249

I didn't bump the version, I assume that the maintainers do that.