### PR TITLE
Add load_replace tutorial example.

### DIFF
--- a/docs/tutorials/index.rst
+++ b/docs/tutorials/index.rst
@@ -7,6 +7,7 @@ Tutorials
    outline
    installation
    lab
+   samples
    ../cli.rst
    first_steps_config
    context_manager

--- a/docs/tutorials/lab.rst
+++ b/docs/tutorials/lab.rst
@@ -47,6 +47,12 @@ This Vagrantfile creates a base box and a vEOS box when you call "vagrant up"::
 
 You may see some errors when the eos box is getting created [#f1]_.
 
+Troubleshooting
+^^^^^^^^^^^^^^^
+
+* After running ``vagrant up``, ensure that you can ssh to the box with ``vagrant ssh eos``.
+* If you receive the warning "eos: Warning: Remote connection disconnect.  Retrying...", see `this StackOverflow post <http://stackoverflow.com/questions/22575261/vagrant-stuck-connection-timeout-retrying>`_.
+
 Sample files
 ------------
 

--- a/docs/tutorials/sample_scripts/load_replace.py
+++ b/docs/tutorials/sample_scripts/load_replace.py
@@ -1,0 +1,60 @@
+# Sample script to demonstrate loading a config for a device.
+#
+# Note: this script is as simple as possible: it assumes that you have
+# followed the lab setup in the quickstart tutorial, and so hardcodes
+# the device IP and password.  You should also have the
+# 'new_good.conf' configuration saved to disk.
+
+
+import napalm
+import sys
+import os
+
+def main(config_file):
+    """Load a config for the device."""
+
+    if not (os.path.exists(config_file) and os.path.isfile(config_file)):
+        msg = 'Missing or invalid config file {0}'.format(config_file)
+        raise ValueError(msg)
+
+    print 'Loading config file {0}.'.format(config_file)
+
+    # Use the appropriate network driver to connect to the device:
+    driver = napalm.get_network_driver('eos')
+
+    # Connect:
+    device = driver(hostname='127.0.0.1', username='vagrant',
+                    password='vagrant', optional_args={'port': 12443})
+
+    print 'Opening ...'
+    device.open()
+
+    print 'Loading replacement candidate ...'
+    device.load_replace_candidate(filename=config_file)
+
+    # Note that the changes have not been applied yet. Before applying
+    # the configuration you can check the changes:
+    print '\nDiff:'
+    print device.compare_config()
+
+    # You can commit or discard the candidate changes.
+    choice = raw_input("\nWould you like to commit these changes? [yN]: ")
+    if choice == 'y':
+      print 'Committing ...'
+      device.commit_config()
+    else:
+      print 'Discarding ...'
+      device.discard_config()
+
+    # close the session with the device.
+    device.close()
+
+    print 'Done.'
+
+if __name__ == '__main__':
+    if len(sys.argv) < 2:
+        print 'Please supply the full path to "new_good.conf"'
+        sys.exit(1)
+    config_file = sys.argv[1]
+
+    main(config_file)

--- a/docs/tutorials/samples.rst
+++ b/docs/tutorials/samples.rst
@@ -1,0 +1,25 @@
+Programming samples
+===================
+
+NAPALM tries to provide a common interface and mechanisms to push configuration and retrieve state data from network devices. This method is very useful in combination with tools like `Ansible <http://www.ansible.com>`_, which in turn allows you to manage a set of devices independent of their network OS.
+
+.. note::  These samples assume you have set up your virtual lab (see :doc:`./lab`), and that the 'eos' box is accessible via point 12443 on your machine.  You should also have the sample configuration files saved locally.
+
+Now that you have installed NAPALM (see :doc:`./installation`) and set up your virtual lab, you can try running some sample scripts to demonstrate NAPALM in action.  You can run each of the scripts below by either pulling the files from the GitHub repository, or you can copy the content to a local script (e.g., ``sample_napalm_script.py``) and run it.
+
+For people new to Python:
+
+* the script name should not conflict with any existing module or package.  For example, don't call the script ``napalm.py``.
+* run a Python script with ``$ python your_script_name.py``.
+
+Load/Replace configuration
+--------------------------
+
+Create a file called ``load_replace.py`` in a folder with the following content:
+
+.. literalinclude:: sample_scripts/load_replace.py
+   :language: python
+
+Run the script, passing the path to the ``new_good.conf`` file as an argument::
+
+    python load_replace.py ../sample_configs/new_good.conf


### PR DESCRIPTION
An initial example for discussion with @dbarrosop and anyone else interested.

This sample code builds on the virtual lab, so people can try out a running script immediately.

We could merge this into the quickstart branch and iterate on it, or I can fix up minor things here beforehand.

Future todos:

- add other samples.  Slack chat w/ DB: "would be cool to organize scripts by major feature: `context manager`, `load_merge`, `load_replace`, `load_template` ... then showing the `compare`, `discard`, `rollback`, etc... you would actually use the functional tests defined here as general idea"
- figure out how the docs should be arranged
- _somehow_ add unit tests to ensure that these things continue to work in the future.  I've manually tried it out and it works fine, but that's really not good enough for an ongoing project.