### PR TITLE
Raise RuntimeError when NAPALM is not installed in Python 2.7 environment

### DIFF
--- a/napalm/__init__.py
+++ b/napalm/__init__.py
@@ -12,4 +12,9 @@
 # License for the specific language governing permissions and limitations under
 # the License.
 
+import sys
+
 from napalm_base import get_network_driver
+
+if not(sys.version_info.major == 2 and sys.version_info.minor == 7):
+    raise RuntimeError('You need Python 2.7 for NAPALM.')


### PR DESCRIPTION
Comes together with https://github.com/napalm-automation/napalm/pull/268 and https://github.com/napalm-automation/napalm/pull/267 to make sure that NAPALM is used in the right environment.