### PR TITLE
add dependency installation commands to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,13 @@ pip install napalm
 
 That will install all the drivers currently available.
 
+When installing on Linux, to ensure all dependencies are met, use the following commands:
+
+**Debian/Ubuntu**:
+`sudo apt-get install build-essential libssl-dev libffi-dev python-dev`
+
+**Fedora and RHEL-derivatives**:
+`sudo yum install gcc libffi-devel python-devel openssl-devel`
 
 Partial Installation
 --------------------


### PR DESCRIPTION
Using Napalm with Ansible, it was not finding `napalm-ios` even though it was installed via pip.
```
fatal: [192.168.0.2]: FAILED! => {"changed": false, "failed": true, "msg": "cannot connect to device: Cannot import \"napalm_ios\". Is the library installed?"}
```
After some digging it turned out the [cryptography](https://cryptography.io/en/latest/) package had not installed properly. This was fixed by installing `libssl` & `libffi`.

I took the liberty of adding this to the readme, rather than raising an issue, I hope you don't mind, if you'd rather it was mentioned elsewhere, let me know, or of course feel free to not merge, obviously. :smile: 
I can also add it to the docs?

Thanks to [this SO answer](https://stackoverflow.com/questions/22073516/failed-to-install-python-cryptography-package-with-pip-and-setup-py#22210069) 