### PR TITLE
Adds SSH keys discovery extra args to doc

### DIFF
--- a/docs/support/index.rst
+++ b/docs/support/index.rst
@@ -141,6 +141,10 @@ ____________________________________
 * :code:`auto_rollback_on_error` (ios) - Disable automatic rollback (certain versions of IOS support configure replace, but not rollback on error) (default: True).
 * :code:`global_delay_factor` (ios) - Allow for additional delay in command execution (default: .5).
 * :code:`nxos_protocol` (nxos) - Protocol to connect with.  Only 'https' and 'http' allowed (default: 'http').
+* :code:`allow_agent` (ios) - Paramiko argument, enable connecting to the SSH agent (default: 'False').
+* :code:`use_keys` (ios) - Paramiko argument, enable searching for discoverable private key files in ~/.ssh/ (default: 'False').
+
+
 
 
 Adding optional arguments to NAPALM drivers


### PR DESCRIPTION
Descriptions from:
http://docs.paramiko.org/en/2.0/api/client.html?highlight=allow_agent