### PR TITLE
docs: fix cl_napalm_configure example

### DIFF
--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -9,7 +9,7 @@ my current configuration and a new candidate configuration:
 
 .. code-block:: diff
 
-    # cl_napalm_configure --user vagrant --vendor eos --strategy replace --optional_args 'port=12443' --dry-run new_good.conf localhost
+    # cl_napalm_configure --user vagrant --vendor eos --strategy replace --optional_args 'port=12443' --dry-run localhost new_good.conf
     Enter password:
     @@ -2,30 +2,38 @@
      !


### PR DESCRIPTION
First positional argument is the host, second positional is the configuration file. Not the reverse.