### PR TITLE
Better install docs

### DIFF
--- a/docs/installation/index.rst
+++ b/docs/installation/index.rst
@@ -7,9 +7,9 @@ Full installation
 
 If you want to fully install NAPALM you can do it by executing:
 
-```
+``
 pip install napalm
-```
+``
 
 That will install all the drivers currently available.
 
@@ -19,16 +19,16 @@ Partial Installation
 
 If you want to install just a subset of the available modules you can just pick them as follows:
 
-```
+``
 pip install napalm-eos napalm-junos
-```
+``
 
 That will install only the `eos` and the `junos` drivers. If you want to remove or add a module later on you can just use `pip` to do it:
 
-```
+``
 pip uninstall napalm-junos
 pip install napalm-ios
-```
+``
 
 Check the ['Supported Network Operating Systems'](http://napalm.readthedocs.io/en/latest/support/index.html) section for more information about supported modules.
 
@@ -38,34 +38,27 @@ Upgrading
 
 We plan to upgrade napalm as fast as possible. Adding new methods and bugfixes. To upgrade napalm it's a simple as repeating the steps you performed while installing but adding the `-U` flag. For example:
 
-```
+``
 pip install napalm -U
-```
+``
 
 or:
 
-```
+``
 pip install napalm-eos napalm-junos -U
-```
+``
 
 Dependencies
 ------------
 
-Dependencies are supposed to be solved by `pip` and in most cases it works out of the box. However, on some systems some dependencies have to be installed using system tools. For example, the ``cryptography`` package that ``napalm-ios`` uses.
+Althought dependencies for the transport libraries are solved by `pip`, on some operating systems there are some particular requirements:
 
-* `napalm_ios`
+.. toctree::
+   :maxdepth: 1
 
-To to ensure all dependencies are met for these drivers, use the following commands:
-
-**Debian/Ubuntu**:
-
-```
-sudo apt-get install build-essential libssl-dev libffi-dev python-dev
-```
-
-**Fedora and RHEL-derivatives**:
-
-```
-sudo yum install gcc libffi-devel python-devel openssl-devel
-```
-
+   junos
+   iosxr
+   ios
+   panos
+   pluribus
+   vyos

--- a/docs/installation/ios.rst
+++ b/docs/installation/ios.rst
@@ -1,0 +1,24 @@
+napalm-ios dependencies
+=======================
+
+
+Ubuntu and Debian
+-----------------
+
+``
+sudo apt-get install -y --force-yes libssl-dev libffi-dev python-dev python-cffi
+``
+
+RedHat and CentOS
+-----------------
+
+``
+sudo yum install -y python-pip gcc openssl openssl-devel libffi-devel python-devel
+``
+
+FreeBSD
+-------
+
+``
+sudo pkg_add -r py27-pip
+``

--- a/docs/installation/iosxr.rst
+++ b/docs/installation/iosxr.rst
@@ -1,0 +1,24 @@
+napalm-iosxr dependencies
+=========================
+
+
+Ubuntu and Debian
+-----------------
+
+``
+sudo apt-get install -y --force-yes libssl-dev libffi-dev python-dev python-cffi
+``
+
+RedHat and CentOS
+-----------------
+
+``
+sudo yum install -y python-pip python-devel libxml2-devel gcc openssl openssl-devel libffi-devel
+``
+
+FreeBSD
+-------
+
+``
+sudo pkg_add -r py27-pip libxml2
+``

--- a/docs/installation/junos.rst
+++ b/docs/installation/junos.rst
@@ -1,0 +1,24 @@
+napalm-junos dependencies
+=========================
+
+
+Ubuntu and Debian
+-----------------
+
+``
+sudo apt-get install -y --force-yes libxslt1-dev libssl-dev libffi-dev python-dev python-cffi
+``
+
+RedHat and CentOS
+-----------------
+
+``
+sudo yum install -y python-pip python-devel libxml2-devel libxslt-devel gcc openssl openssl-devel libffi-devel
+``
+
+FreeBSD
+-------
+
+``
+sudo pkg_add -r py27-pip libxml2 libxslt
+``

--- a/docs/installation/panos.rst
+++ b/docs/installation/panos.rst
@@ -1,0 +1,24 @@
+napalm-panos dependencies
+=========================
+
+
+Ubuntu and Debian
+-----------------
+
+``
+sudo apt-get install -y --force-yes libssl-dev libffi-dev python-dev python-cffi
+``
+
+RedHat and CentOS
+-----------------
+
+``
+sudo yum install -y python-pip gcc openssl openssl-devel libffi-devel python-devel
+``
+
+FreeBSD
+-------
+
+``
+sudo pkg_add -r py27-pip
+``

--- a/docs/installation/pluribus.rst
+++ b/docs/installation/pluribus.rst
@@ -1,0 +1,24 @@
+napalm-pluribus dependencies
+============================
+
+
+Ubuntu and Debian
+-----------------
+
+``
+sudo apt-get install -y --force-yes libssl-dev libffi-dev python-dev python-cffi
+``
+
+RedHat and CentOS
+-----------------
+
+``
+sudo yum install -y python-pip gcc openssl openssl-devel libffi-devel python-devel
+``
+
+FreeBSD
+-------
+
+``
+sudo pkg_add -r py27-pip
+``

--- a/docs/installation/vyos.rst
+++ b/docs/installation/vyos.rst
@@ -1,0 +1,24 @@
+napalm-vyos dependencies
+========================
+
+
+Ubuntu and Debian
+-----------------
+
+``
+sudo apt-get install -y --force-yes libssl-dev libffi-dev python-dev python-cffi
+``
+
+RedHat and CentOS
+-----------------
+
+``
+sudo yum install -y python-pip gcc openssl openssl-devel libffi-devel python-devel
+``
+
+FreeBSD
+-------
+
+``
+sudo pkg_add -r py27-pip
+``


### PR DESCRIPTION
The current installation docs don't provide enough details when it comes to platform dependencies (http://napalm.readthedocs.io/en/latest/installation.html#dependencies)
Also, they depend on the driver the user needs to install. So I thought to separate them by the driver so the user can go straight and see what they need to install for each driver.