### PR TITLE
Change docs for `transport` argument

### DIFF
--- a/docs/support/index.rst
+++ b/docs/support/index.rst
@@ -113,6 +113,19 @@ NAPALM supports passing certain optional arguments to some drivers. To do that y
     >>> device = driver('192.168.76.10', 'dbarroso', 'this_is_not_a_secure_password', optional_args=optional_args)
     >>> device.open()
 
+
+The transport argument
+______________________
+
+Certain drivers support providing an alternate transport in the :code:`optional_args`, overriding the default protocol to connect with. Allowed transports are therefore device/library dependant:
+
+=============== ====================  ====================  ===================
+_               EOS                   NXOS                  IOS
+=============== ====================  ====================  ===================
+**Default**     ``https``             ``https``             ``ssh``
+**Supported**   ``http``, ``https``   ``http``, ``https``   ``telnet``, ``ssh``
+=============== ====================  ====================  ===================
+
 List of supported optional arguments
 ____________________________________
 
@@ -122,7 +135,7 @@ ____________________________________
 * :code:`dest_file_system` (ios) - Destination file system for SCP transfers (default: ``flash:``).
 * :code:`auto_rollback_on_error` (ios) - Disable automatic rollback (certain versions of IOS support configure replace, but not rollback on error) (default: ``True``).
 * :code:`global_delay_factor` (ios, vyos) - Allow for additional delay in command execution (default: ``1``).
-* :code:`transport` (eos, ios, nxos) - Protocol to connect with. Allowed transports depends on the underlying library, but typically ``http``/``https`` and/or ``telnet``/``ssh``. Defaults to ``https`` on EOS and NXOS and ``ssh`` on IOS.
+* :code:`transport` (eos, ios, nxos) - Protocol to connect with.
 * :code:`enable_password` (eos) - Password required to enter privileged exec (enable) (default: ``''``).
 * :code:`ssh_strict` (iosxr, ios, panos, vyos) - Automatically reject unknown SSH host keys (default: ``False``, which means unknown SSH host keys will be accepted).
 * :code:`allow_agent` (ios, iosxr, panos, vyos) - Paramiko argument, enable connecting to the SSH agent (default: ``False``).

--- a/docs/support/index.rst
+++ b/docs/support/index.rst
@@ -135,7 +135,7 @@ ____________________________________
 * :code:`dest_file_system` (ios) - Destination file system for SCP transfers (default: ``flash:``).
 * :code:`auto_rollback_on_error` (ios) - Disable automatic rollback (certain versions of IOS support configure replace, but not rollback on error) (default: ``True``).
 * :code:`global_delay_factor` (ios, vyos) - Allow for additional delay in command execution (default: ``1``).
-* :code:`transport` (eos, ios, nxos) - Protocol to connect with.
+* :code:`transport` (eos, ios, nxos) - Protocol to connect with (see `The transport argument`_ for more information).
 * :code:`enable_password` (eos) - Password required to enter privileged exec (enable) (default: ``''``).
 * :code:`ssh_strict` (iosxr, ios, panos, vyos) - Automatically reject unknown SSH host keys (default: ``False``, which means unknown SSH host keys will be accepted).
 * :code:`allow_agent` (ios, iosxr, panos, vyos) - Paramiko argument, enable connecting to the SSH agent (default: ``False``).

--- a/docs/support/index.rst
+++ b/docs/support/index.rst
@@ -114,18 +114,6 @@ NAPALM supports passing certain optional arguments to some drivers. To do that y
     >>> device.open()
 
 
-The transport argument
-______________________
-
-Certain drivers support providing an alternate transport in the :code:`optional_args`, overriding the default protocol to connect with. Allowed transports are therefore device/library dependant:
-
-=============== ====================  ====================  ===================
-_               EOS                   NXOS                  IOS
-=============== ====================  ====================  ===================
-**Default**     ``https``             ``https``             ``ssh``
-**Supported**   ``http``, ``https``   ``http``, ``https``   ``telnet``, ``ssh``
-=============== ====================  ====================  ===================
-
 List of supported optional arguments
 ____________________________________
 
@@ -146,6 +134,18 @@ ____________________________________
 * :code:`alt_host_keys` (ios, iosxr, panos, vyos) - If ``True``, host keys will be loaded from the file specified in ``alt_key_file``.
 * :code:`alt_key_file` (ios, iosxr, panos, vyos) - SSH host key file to use (if ``alt_host_keys`` is ``True``).
 * :code:`keepalive` (junos, iosxr, ios) - SSH keepalive interval, in seconds (default: ``30`` seconds).
+
+The transport argument
+______________________
+
+Certain drivers support providing an alternate transport in the :code:`optional_args`, overriding the default protocol to connect with. Allowed transports are therefore device/library dependant:
+
+=============== ====================  ====================  ===================
+_               EOS                   NXOS                  IOS
+=============== ====================  ====================  ===================
+**Default**     ``https``             ``https``             ``ssh``
+**Supported**   ``http``, ``https``   ``http``, ``https``   ``telnet``, ``ssh``
+=============== ====================  ====================  ===================
 
 Adding optional arguments to NAPALM drivers
 ___________________________________________

--- a/docs/support/index.rst
+++ b/docs/support/index.rst
@@ -122,7 +122,7 @@ ____________________________________
 * :code:`dest_file_system` (ios) - Destination file system for SCP transfers (default: ``flash:``).
 * :code:`auto_rollback_on_error` (ios) - Disable automatic rollback (certain versions of IOS support configure replace, but not rollback on error) (default: ``True``).
 * :code:`global_delay_factor` (ios, vyos) - Allow for additional delay in command execution (default: ``1``).
-* :code:`nxos_protocol` (nxos) - Protocol to connect with.  Only 'https' and 'http' allowed (default: ``http``).
+* :code:`transport` (eos, ios, nxos) - Protocol to connect with. Allowed transports depends on the underlying library, but typically ``http``/``https`` and/or ``telnet``/``ssh``. Defaults to ``https`` on EOS and NXOS and ``ssh`` on IOS.
 * :code:`enable_password` (eos) - Password required to enter privileged exec (enable) (default: ``''``).
 * :code:`ssh_strict` (iosxr, ios, panos, vyos) - Automatically reject unknown SSH host keys (default: ``False``, which means unknown SSH host keys will be accepted).
 * :code:`allow_agent` (ios, iosxr, panos, vyos) - Paramiko argument, enable connecting to the SSH agent (default: ``False``).


### PR DESCRIPTION
Updates the documentation to reflect the new `transport` optional argument

References:
* napalm-automation/napalm-ios#159
* napalm-automation/napalm-ios#132
* napalm-automation/napalm-eos#167
* napalm-automation/napalm-nxos#94