### PR TITLE
Fix typos

### DIFF
--- a/docs/development/testing_framework.rst
+++ b/docs/development/testing_framework.rst
@@ -10,7 +10,7 @@ The testing framework has the following features:
 
 1. Same tests across all vendors. Tests defined in ``napalm_base/test/getters.py`` are shared across all drivers.
 2. Multiple test cases per test.
-3. Target of the test can be configured with enviromental variables.
+3. Target of the test can be configured with environmental variables.
 4. Expected output is compared against the actual output of the test result.
 5. NotImplemented methods are skipped automatically.
 
@@ -35,7 +35,7 @@ Each folder will have to contain it's own mocked data and expected result.
 Target
 ^^^^^^
 
-By default, the tests are going to be run agains mocked data but you can change that behavior with the following enviromental variables:
+By default, the tests are going to be run against mocked data but you can change that behavior with the following environmental variables:
 
 * ``NAPALM_TEST_MOCK`` - 1 (default) for mocked data and 0 for connecting to a device.
 * ``NAPALM_HOSTNAME``

--- a/docs/hackathons/hackathon2016/locations.rst
+++ b/docs/hackathons/hackathon2016/locations.rst
@@ -1,7 +1,7 @@
 Location
 ________
 
-The hackathon will be held online. We will use slack as the main communications channel, github to coordinate the work and hangouts for live presentations, which will be posted online on a youtbe channel within the hour.
+The hackathon will be held online. We will use slack as the main communications channel, github to coordinate the work and hangouts for live presentations, which will be posted online on a youtube channel within the hour.
 
 Check this :ref:`link <hackathon2016-useful-information>` for more information regarding the slack channel, hangouts, youtube, etc..
 

--- a/docs/installation/index.rst
+++ b/docs/installation/index.rst
@@ -51,7 +51,7 @@ or:
 Dependencies
 ------------
 
-Althought dependencies for the transport libraries are solved by `pip`, on some operating systems there are some particular requirements:
+Although dependencies for the transport libraries are solved by `pip`, on some operating systems there are some particular requirements:
 
 .. toctree::
    :maxdepth: 1

--- a/docs/support/index.rst
+++ b/docs/support/index.rst
@@ -58,7 +58,7 @@ _                       EOS         JunOS   IOS-XR      FortiOS         NXOS    
 Getters support matrix
 ----------------------
 
-.. note:: The following table is built automatically. Everytime there is a release of a supported driver a built is triggered. The result of the tests are aggreggated on the following table.
+.. note:: The following table is built automatically. Every time there is a release of a supported driver a built is triggered. The result of the tests are aggregated on the following table.
 
 .. include:: matrix.rst
 

--- a/docs/support/ios.rst
+++ b/docs/support/ios.rst
@@ -51,7 +51,7 @@ Configuration file
 
 * IOS requires config file to begin with a `version` eg. `15.0` and `end` marker at the end of the file. Otherwise IOS will reject `configure replace` operation.
 * For the diff to work properly, indentation of your candidate file has to exactly match the indentation in the running config.
-* Finish blocks with `!` as with the running config, otherweise, some IOS version might not be able to generate the diff properly.
+* Finish blocks with `!` as with the running config, otherwise, some IOS version might not be able to generate the diff properly.
 
 
 Self-Signed Certificate (and the hidden tab character)

--- a/docs/tutorials/ansible-napalm.rst
+++ b/docs/tutorials/ansible-napalm.rst
@@ -15,12 +15,12 @@
 napalm-ansible
 ==============
 
-Collection of ansible modules that use `napalm <https://github.com/napalm-automation/napalm>`_ to retrieve data or modify configuration on netwroking devices.
+Collection of ansible modules that use `napalm <https://github.com/napalm-automation/napalm>`_ to retrieve data or modify configuration on networking devices.
 
 Modules
 -------
 
-The following modules are currenty available:
+The following modules are currently available:
 
 * napalm_get_facts
 * napalm_install_config
@@ -134,7 +134,7 @@ Example to get compliance report::
 A More Detailed Example
 -----------------------
 
-It's very oftern we come to these tools needing to know how to run before we can walk.
+It's very often we come to these tools needing to know how to run before we can walk.
 Please review the `Ansible Documentation <http://docs.ansible.com/ansible/playbooks.html>`_ as this will answer some basic questions.
 It is also advised to have some kind of `yaml linter <https://pypi.python.org/pypi/yamllint>`_ or syntax checker available.
 

--- a/docs/validate/index.rst
+++ b/docs/validate/index.rst
@@ -270,11 +270,11 @@ Why this and what's next
 ------------------------
 
 As mentioned in the introduction, this is interesting to validate state. You could, for example,
-very easily check that your BGP neigbors are configured and that the state is up. It becomes even more
+very easily check that your BGP neighbors are configured and that the state is up. It becomes even more
 interesting if you can build the validator file from data from your inventory. That way you could
 deploy your network and verify it matches your expectations all the time without human intervention.
 
 Something else you could do is write the validation file manually prior to a maintenance based on
-some gathered data from the network and on your expectations. You could, then, perform your changs
+some gathered data from the network and on your expectations. You could, then, perform your changes
 and use this tool to verify the state of the network is exactly the one you wanted. No more
 forgetting things or writing one-offs scripts to validate deployments.


### PR DESCRIPTION
  * `enviromental` -> `environmental`
  * `agains` -> `against`
  * `youtbe` -> `youtube`
  * `Althought` -> `Although`
  * `Everytime` -> `Every time`
  * `otherweise` -> `otherwise`
  * `netwroking` -> `networking`
  * `currenty` -> `currently`
  * `oftern` -> `often`
  * `neigbors` -> `neighbors`
  * `changs` -> `changes`

I didn't change this one because it almost seemed like it was on purpose? If that isn't the case, I could easily add another commit to this branch.

> or just correct my **_spleling_**, please, ping ``dbarroso`` on slack.