### PR TITLE
Remove download counter which no longer works

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 [![PyPI](https://img.shields.io/pypi/v/napalm.svg)](https://pypi.python.org/pypi/napalm)
-[![PyPI](https://img.shields.io/pypi/dm/napalm.svg)](https://pypi.python.org/pypi/napalm)
 [![Build Status](https://travis-ci.org/napalm-automation/napalm.svg?branch=master)](https://travis-ci.org/napalm-automation/napalm)
 
 


### PR DESCRIPTION
Removing the download counter which has stopped working:
[![PyPI](https://img.shields.io/pypi/dm/napalm.svg)](https://pypi.python.org/pypi/napalm)

It can give the wrong impression of the project. And of course, so that everything looks nice for the hacktoberfest. :)