### PR TITLE
Model parsing and hostname on nxos_ssh

### DIFF
--- a/napalm/nxos_ssh/nxos_ssh.py
+++ b/napalm/nxos_ssh/nxos_ssh.py
@@ -777,9 +777,9 @@ class NXOSSSHDriver(NetworkDriver):
                 os_version = line.split()[2]
                 os_version = os_version.strip()
 
-            if 'cisco' in line and 'Chassis' in line:
-                _, model = line.split()[:2]
-                model = model.strip()
+            if re.search(r"cisco.*Chassis", line):
+                match = re.search(r"cisco (.*) Chassis ", line)
+                model = match.group(1).strip()
 
         hostname = show_hostname.strip()
 
@@ -791,6 +791,7 @@ class NXOSSSHDriver(NetworkDriver):
                 break
         if hostname.count(".") >= 2:
             fqdn = hostname
+            hostname = hostname.split(".")[0]
         elif domain_name:
             fqdn = '{}.{}'.format(hostname, domain_name)
 

--- a/test_base/nxos_ssh/mocked_data/test_get_facts/7009_6_2_14/expected_result.json
+++ b/test_base/nxos_ssh/mocked_data/test_get_facts/7009_6_2_14/expected_result.json
@@ -18,7 +18,7 @@
     ], 
     "vendor": "Cisco", 
     "serial_number": "JAF1602BKEN", 
-    "model": "Nexus7000", 
-    "hostname": "EGGS-SW01.spam.com", 
+    "model": "Nexus7000 C7009 (9 Slot)",
+    "hostname": "EGGS-SW01", 
     "fqdn": "EGGS-SW01.spam.com"
 }

--- a/test_base/nxos_ssh/mocked_data/test_get_facts/normal/expected_result.json
+++ b/test_base/nxos_ssh/mocked_data/test_get_facts/normal/expected_result.json
@@ -1,5 +1,5 @@
 {
-    "hostname": "nxos1.twb-tech.com", 
+    "hostname": "nxos1",
     "fqdn": "nxos1.twb-tech.com",
     "model": "NX-OSv", 
     "uptime": 2030983,


### PR DESCRIPTION
This is a minor fix to improve some issues I saw with NXOS-SSH while testing on the reunification branch.

It doesn't matter if you implement it now or not. I can re-submit it later, if need be.