### PR TITLE
Junos ipv6 neighbors table

### DIFF
--- a/napalm/junos/junos.py
+++ b/napalm/junos/junos.py
@@ -1209,6 +1209,24 @@ class JunOSDriver(NetworkDriver):
 
         return arp_table
 
+    def get_ipv6_neighbors_table(self):
+        """Return the IPv6 neighbors table."""
+        ipv6_neighbors_table = []
+
+        ipv6_neighbors_table_raw = junos_views.junos_ipv6_neighbors_table(self.device)
+        ipv6_neighbors_table_raw.get()
+        ipv6_neighbors_table_items = ipv6_neighbors_table_raw.items()
+
+        for ipv6_table_entry in ipv6_neighbors_table_items:
+            ipv6_entry = {
+                elem[0]: elem[1] for elem in ipv6_table_entry[1]
+            }
+            ipv6_entry['mac'] = napalm.base.helpers.mac(ipv6_entry.get('mac'))
+            ipv6_entry['ip'] = napalm.base.helpers.ip(ipv6_entry.get('ip'))
+            ipv6_neighbors_table.append(ipv6_entry)
+
+        return ipv6_neighbors_table
+
     def get_ntp_peers(self):
         """Return the NTP peers configured on the device."""
         ntp_table = junos_views.junos_ntp_peers_config_table(self.device)

--- a/napalm/junos/utils/junos_views.yml
+++ b/napalm/junos/utils/junos_views.yml
@@ -426,6 +426,20 @@ junos_arp_view:
     ip: {ip-address: unicode}
     age: {time-to-expire: float}
 
+junos_ipv6_neighbors_table:
+  rpc: get-ipv6-nd-information
+  item: ipv6-nd-entry
+  key: ipv6-nd-interface-name
+  view: junos_ipv6_neighbors_view
+
+junos_ipv6_neighbors_view:
+  fields:
+    interface: {ipv6-nd-interface-name: unicode}
+    mac: {ipv6-nd-neighbor-l2-address: unicode}
+    ip: {ipv6-nd-neighbor-address: unicode}
+    age: {ipv6-nd-expire: float}
+    state: {ipv6-nd-state: unicode}
+
 ###
 ### Interfaces IPs
 ###

--- a/test/junos/mocked_data/test_get_ipv6_neighbors_table/normal/expected_result.json
+++ b/test/junos/mocked_data/test_get_ipv6_neighbors_table/normal/expected_result.json
@@ -1,0 +1,1 @@
+[{"interface": "em0.0", "ip": "fd00:1111:1111::2", "mac": "FE:54:00:08:EE:00", "age": 884.0, "state": "stale"}, {"interface": "em0.0", "ip": "fd00:2222:2222::2", "mac": "FE:54:00:08:EE:00", "age": 8.0, "state": "reachable"}, {"interface": "em0.0", "ip": "fe80::24e6:6cff:fe85:9ecb", "mac": "FE:54:00:08:EE:00", "age": 850.0, "state": "stale"}]

--- a/test/junos/mocked_data/test_get_ipv6_neighbors_table/normal/get-ipv6-nd-information.xml
+++ b/test/junos/mocked_data/test_get_ipv6_neighbors_table/normal/get-ipv6-nd-information.xml
@@ -1,0 +1,30 @@
+<ipv6-nd-information>
+    <ipv6-nd-entry>
+        <ipv6-nd-neighbor-address>fd00:1111:1111::2</ipv6-nd-neighbor-address>
+        <ipv6-nd-neighbor-l2-address>fe:54:00:08:ee:00</ipv6-nd-neighbor-l2-address>
+        <ipv6-nd-state>stale</ipv6-nd-state>
+        <ipv6-nd-expire>884</ipv6-nd-expire>
+        <ipv6-nd-isrouter>no</ipv6-nd-isrouter>
+        <ipv6-nd-issecure>no</ipv6-nd-issecure>
+        <ipv6-nd-interface-name>em0.0</ipv6-nd-interface-name>
+    </ipv6-nd-entry>
+    <ipv6-nd-entry>
+        <ipv6-nd-neighbor-address>fd00:2222:2222::2</ipv6-nd-neighbor-address>
+        <ipv6-nd-neighbor-l2-address>fe:54:00:08:ee:00</ipv6-nd-neighbor-l2-address>
+        <ipv6-nd-state>reachable</ipv6-nd-state>
+        <ipv6-nd-expire>8</ipv6-nd-expire>
+        <ipv6-nd-isrouter>no</ipv6-nd-isrouter>
+        <ipv6-nd-issecure>no</ipv6-nd-issecure>
+        <ipv6-nd-interface-name>em0.0</ipv6-nd-interface-name>
+    </ipv6-nd-entry>
+    <ipv6-nd-entry>
+        <ipv6-nd-neighbor-address>fe80::24e6:6cff:fe85:9ecb</ipv6-nd-neighbor-address>
+        <ipv6-nd-neighbor-l2-address>fe:54:00:08:ee:00</ipv6-nd-neighbor-l2-address>
+        <ipv6-nd-state>stale</ipv6-nd-state>
+        <ipv6-nd-expire>850</ipv6-nd-expire>
+        <ipv6-nd-isrouter>no</ipv6-nd-isrouter>
+        <ipv6-nd-issecure>no</ipv6-nd-issecure>
+        <ipv6-nd-interface-name>em0.0</ipv6-nd-interface-name>
+    </ipv6-nd-entry>
+    <ipv6-nd-total>3</ipv6-nd-total>
+</ipv6-nd-information>


### PR DESCRIPTION
Support for `get_ipv6_neighbors_table()` in Junos

Note the `age` field is expiration time (same for `get_arp_table`)