### PR TITLE
Fix ios.get_facts() version checking for old versions of IOS

### DIFF
--- a/napalm/ios/ios.py
+++ b/napalm/ios/ios.py
@@ -884,10 +884,10 @@ class IOSDriver(NetworkDriver):
                 except ValueError:
                     # Handle 'Cisco IOS Software [Denali],'
                     _, os_version = re.split(r"Cisco IOS Software \[.*?\], ", line)
-                os_version = os_version.strip()
-            elif re.search(r"IOS (tm).+Software", line):
+            elif re.search(r"IOS \(tm\).+Software", line):
                 _, os_version = line.split("IOS (tm) ")
-                os_version = os_version.strip()
+
+            os_version = os_version.strip()
 
         # Determine domain_name and fqdn
         for line in show_hosts.splitlines():

--- a/test/ios/mocked_data/test_get_facts/old-2950/expected_result.json
+++ b/test/ios/mocked_data/test_get_facts/old-2950/expected_result.json
@@ -1,0 +1,10 @@
+{
+	"os_version": "C2950 Software (C2950-I6K2L2Q4-M), Version 12.1(22)EA13, RELEASE SOFTWARE (fc2)",
+	"uptime": 20332140,
+	"interface_list": ["Vlan1", "Vlan20", "Vlan40", "Vlan41", "GigabitEthernet0/1", "GigabitEthernet0/2", "GigabitEthernet0/3", "GigabitEthernet0/4", "GigabitEthernet0/5", "GigabitEthernet0/6", "GigabitEthernet0/7", "GigabitEthernet0/8", "Port-channel1"],
+	"vendor": "Cisco",
+	"serial_number": "FHK0922W0JC",
+	"model": "WS-C2950T-48-SI",
+	"hostname": "c2950",
+	"fqdn": "c2950.example.com"
+}

--- a/test/ios/mocked_data/test_get_facts/old-2950/show_hosts.txt
+++ b/test/ios/mocked_data/test_get_facts/old-2950/show_hosts.txt
@@ -1,0 +1,7 @@
+Default domain is example.com
+Name/address lookup uses static mappings
+
+Codes: u - unknown, e - expired, * - OK, ? - revalidate
+       t - temporary, p - permanent
+
+Host                      Port  Flags      Age Type   Address(es)

--- a/test/ios/mocked_data/test_get_facts/old-2950/show_ip_interface_brief.txt
+++ b/test/ios/mocked_data/test_get_facts/old-2950/show_ip_interface_brief.txt
@@ -1,0 +1,14 @@
+Interface              IP-Address      OK? Method Status                Protocol
+Vlan1                  unassigned      YES NVRAM  administratively down down
+Vlan20                 172.29.50.3     YES NVRAM  up                    up
+Vlan40                 unassigned      YES unset  up                    up
+Vlan41                 172.29.52.34    YES NVRAM  up                    up
+GigabitEthernet0/1     unassigned      YES unset  up                    up
+GigabitEthernet0/2     unassigned      YES unset  up                    up
+GigabitEthernet0/3     unassigned      YES unset  up                    up
+GigabitEthernet0/4     unassigned      YES unset  down                  down
+GigabitEthernet0/5     unassigned      YES unset  up                    up
+GigabitEthernet0/6     unassigned      YES unset  up                    up
+GigabitEthernet0/7     unassigned      YES unset  up                    up
+GigabitEthernet0/8     unassigned      YES unset  up                    up
+Port-channel1          unassigned      YES unset  administratively down down

--- a/test/ios/mocked_data/test_get_facts/old-2950/show_version.txt
+++ b/test/ios/mocked_data/test_get_facts/old-2950/show_version.txt
@@ -1,0 +1,53 @@
+Cisco Internetwork Operating System Software
+IOS (tm) C2950 Software (C2950-I6K2L2Q4-M), Version 12.1(22)EA13, RELEASE SOFTWARE (fc2)
+Technical Support: http://www.cisco.com/techsupport
+Copyright (c) 1986-2009 by cisco Systems, Inc.
+Compiled Fri 27-Feb-09 22:20 by amvarma
+Image text-base: 0x80010000, data-base: 0x80680000
+
+ROM: Bootstrap program is C2950 boot loader
+
+c2950 uptime is 33 weeks, 4 days, 7 hours, 49 minutes
+System returned to ROM by power-on
+System restarted at 10:02:41 CDT Sat Mar 18 2017
+System image file is "flash:/c2950-i6k2l2q4-mz.121-22.EA13.bin"
+
+
+This product contains cryptographic features and is subject to United
+States and local country laws governing import, export, transfer and
+use. Delivery of Cisco cryptographic products does not imply
+third-party authority to import, export, distribute or use encryption.
+Importers, exporters, distributors and users are responsible for
+compliance with U.S. and local country laws. By using this product you
+agree to comply with applicable laws and regulations. If you are unable
+to comply with U.S. and local laws, return this product immediately.
+
+A summary of U.S. laws governing Cisco cryptographic products may be found at:
+http://www.cisco.com/wwl/export/crypto/tool/stqrg.html
+
+If you require further assistance please contact us by sending email to
+export@cisco.com.
+
+cisco WS-C2950T-48-SI (RC32300) processor (revision F0) with 19912K bytes of memory.
+Processor board ID FHK0922W0JC
+Last reset from system-reset
+Running Standard Image
+48 FastEthernet/IEEE 802.3 interface(s)
+2 Gigabit Ethernet/IEEE 802.3 interface(s)
+
+32K bytes of flash-simulated non-volatile configuration memory.
+Base ethernet MAC Address: 00:14:69:CE:67:40
+Motherboard assembly number: 73-9102-03
+Power supply part number: 34-0965-01
+Motherboard serial number: FOC09205LA5
+Power supply serial number: DAB09199E5R
+Model revision number: F0
+Motherboard revision number: A0
+Model number: WS-C2950T-48-SI
+System serial number: FHK0922W0JC
+CLEI Code Number: CNMRU002RB
+Top Assembly Part Number: 800-24111-02
+Top Assembly Revision Number: A0
+Version ID: N/A
+Configuration register is 0xF
+


### PR DESCRIPTION
resolves #425 

Add unit test for old C2950 software and update version regex to correctly match the older version strings.

I do not have a large pool of Ciscos to test against, but this looks like a bug, and I don't _think_ it'll cause a regression.