### PR TITLE
Fix get_optics fail on some JUNOS versions

### DIFF
--- a/napalm/junos/constants.py
+++ b/napalm/junos/constants.py
@@ -14,3 +14,7 @@ OC_NETWORK_INSTANCE_TYPE_MAP = {
     'vpls': 'BGP_VPLS',
     'forwarding': 'L2P2P'
 }
+# OPTICS_NULL_LEVEL_SPC matches infinite light level '- Inf'
+# reading on some versions of JUNOS
+# https://github.com/napalm-automation/napalm/issues/491
+OPTICS_NULL_LEVEL_SPC = '- Inf'

--- a/napalm/junos/junos.py
+++ b/napalm/junos/junos.py
@@ -1873,6 +1873,8 @@ class JunOSDriver(NetworkDriver):
                 optics_detail[interface_name]['physical_channels'] = {}
                 optics_detail[interface_name]['physical_channels']['channel'] = []
 
+            INVALID_LIGHT_LEVEL = [None, C.OPTICS_NULL_LEVEL, C.OPTICS_NULL_LEVEL_SPC]
+
             # Defaulting avg, min, max values to 0.0 since device does not
             # return these values
             intf_optics = {
@@ -1882,7 +1884,7 @@ class JunOSDriver(NetworkDriver):
                                     'instant': (
                                         float(optics['input_power'])
                                         if optics['input_power'] not in
-                                        [None, C.OPTICS_NULL_LEVEL]
+                                        INVALID_LIGHT_LEVEL
                                         else 0.0),
                                     'avg': 0.0,
                                     'max': 0.0,
@@ -1892,7 +1894,7 @@ class JunOSDriver(NetworkDriver):
                                     'instant': (
                                         float(optics['output_power'])
                                         if optics['output_power'] not in
-                                        [None, C.OPTICS_NULL_LEVEL]
+                                        INVALID_LIGHT_LEVEL
                                         else 0.0),
                                     'avg': 0.0,
                                     'max': 0.0,
@@ -1902,7 +1904,7 @@ class JunOSDriver(NetworkDriver):
                                     'instant': (
                                         float(optics['laser_bias_current'])
                                         if optics['laser_bias_current'] not in
-                                        [None, C.OPTICS_NULL_LEVEL]
+                                        INVALID_LIGHT_LEVEL
                                         else 0.0),
                                     'avg': 0.0,
                                     'max': 0.0,

--- a/test/junos/mocked_data/test_get_optics/infinite_with_space/expected_result.json
+++ b/test/junos/mocked_data/test_get_optics/infinite_with_space/expected_result.json
@@ -1,0 +1,31 @@
+{
+"xe-2/2/2": {
+        "physical_channels": {
+            "channel": [
+                {
+                    "index": 0,
+                    "state": {
+                        "input_power": {
+                            "avg": 0.0,
+                            "instant": -31.55,
+                            "max": 0.0,
+                            "min": 0.0
+                        },
+                        "laser_bias_current": {
+                            "avg": 0.0,
+                            "instant": 33.490,
+                            "max": 0.0,
+                            "min": 0.0
+                        },
+                        "output_power": {
+                            "avg": 0.0,
+                            "instant": 0.0,
+                            "max": 0.0,
+                            "min": 0.0
+                        }
+                    }
+                }
+            ]
+        }
+    }
+}

--- a/test/junos/mocked_data/test_get_optics/infinite_with_space/get-interface-optics-diagnostics-information.xml
+++ b/test/junos/mocked_data/test_get_optics/infinite_with_space/get-interface-optics-diagnostics-information.xml
@@ -1,0 +1,65 @@
+
+<interface-information>
+    <physical-interface>
+        <name>xe-2/2/2</name>
+        <optics-diagnostics>
+            <laser-bias-current>33.490</laser-bias-current>
+            <laser-output-power>0.6980</laser-output-power>
+            <laser-output-power-dbm>- Inf</laser-output-power-dbm>
+            <module-temperature>33 degrees C / 92 degrees F</module-temperature>
+            <module-voltage>3.2760</module-voltage>
+            <rx-signal-avg-optical-power>0.0007</rx-signal-avg-optical-power>
+            <rx-signal-avg-optical-power-dbm>-31.55</rx-signal-avg-optical-power-dbm>
+            <laser-bias-current-high-alarm>off</laser-bias-current-high-alarm>
+            <laser-bias-current-low-alarm>off</laser-bias-current-low-alarm>
+            <laser-bias-current-high-warn>off</laser-bias-current-high-warn>
+            <laser-bias-current-low-warn>off</laser-bias-current-low-warn>
+            <laser-tx-power-high-alarm>off</laser-tx-power-high-alarm>
+            <laser-tx-power-low-alarm>off</laser-tx-power-low-alarm>
+            <laser-tx-power-high-warn>off</laser-tx-power-high-warn>
+            <laser-tx-power-low-warn>off</laser-tx-power-low-warn>
+            <module-temperature-high-alarm>off</module-temperature-high-alarm>
+            <module-temperature-low-alarm>off</module-temperature-low-alarm>
+            <module-temperature-high-warn>off</module-temperature-high-warn>
+            <module-temperature-low-warn>off</module-temperature-low-warn>
+            <module-voltage-high-alarm>off</module-voltage-high-alarm>
+            <module-voltage-low-alarm>off</module-voltage-low-alarm>
+            <module-voltage-high-warn>off</module-voltage-high-warn>
+            <module-voltage-low-warn>off</module-voltage-low-warn>
+            <laser-rx-power-high-alarm>off</laser-rx-power-high-alarm>
+            <laser-rx-power-low-alarm>on</laser-rx-power-low-alarm>
+            <laser-rx-power-high-warn>off</laser-rx-power-high-warn>
+            <laser-rx-power-low-warn>on</laser-rx-power-low-warn>
+            <laser-bias-current-high-alarm-threshold>85.000</laser-bias-current-high-alarm-threshold>
+            <laser-bias-current-low-alarm-threshold>15.000</laser-bias-current-low-alarm-threshold>
+            <laser-bias-current-high-warn-threshold>80.000</laser-bias-current-high-warn-threshold>
+            <laser-bias-current-low-warn-threshold>20.000</laser-bias-current-low-warn-threshold>
+            <laser-tx-power-high-alarm-threshold>1.5840</laser-tx-power-high-alarm-threshold>
+            <laser-tx-power-high-alarm-threshold-dbm>2.00</laser-tx-power-high-alarm-threshold-dbm>
+            <laser-tx-power-low-alarm-threshold>0.1580</laser-tx-power-low-alarm-threshold>
+            <laser-tx-power-low-alarm-threshold-dbm>-8.01</laser-tx-power-low-alarm-threshold-dbm>
+            <laser-tx-power-high-warn-threshold>1.2580</laser-tx-power-high-warn-threshold>
+            <laser-tx-power-high-warn-threshold-dbm>1.00</laser-tx-power-high-warn-threshold-dbm>
+            <laser-tx-power-low-warn-threshold>0.1990</laser-tx-power-low-warn-threshold>
+            <laser-tx-power-low-warn-threshold-dbm>-7.01</laser-tx-power-low-warn-threshold-dbm>
+            <module-temperature-high-alarm-threshold>88 degrees C / 190 degrees F</module-temperature-high-alarm-threshold>
+            <module-temperature-low-alarm-threshold>-13 degrees C / 9 degrees F
+            </module-temperature-low-alarm-threshold>
+            <module-temperature-high-warn-threshold>85 degrees C / 185 degrees F
+            </module-temperature-high-warn-threshold>
+            <module-temperature-low-warn-threshold>-8 degrees C / 18 degrees F</module-temperature-low-warn-threshold>
+            <module-voltage-high-alarm-threshold>3.700</module-voltage-high-alarm-threshold>
+            <module-voltage-low-alarm-threshold>2.900</module-voltage-low-alarm-threshold>
+            <module-voltage-high-warn-threshold>3.600</module-voltage-high-warn-threshold>
+            <module-voltage-low-warn-threshold>3.000</module-voltage-low-warn-threshold>
+            <laser-rx-power-high-alarm-threshold>1.7783</laser-rx-power-high-alarm-threshold>
+            <laser-rx-power-high-alarm-threshold-dbm>2.50</laser-rx-power-high-alarm-threshold-dbm>
+            <laser-rx-power-low-alarm-threshold>0.0100</laser-rx-power-low-alarm-threshold>
+            <laser-rx-power-low-alarm-threshold-dbm>-20.00</laser-rx-power-low-alarm-threshold-dbm>
+            <laser-rx-power-high-warn-threshold>1.5849</laser-rx-power-high-warn-threshold>
+            <laser-rx-power-high-warn-threshold-dbm>2.00</laser-rx-power-high-warn-threshold-dbm>
+            <laser-rx-power-low-warn-threshold>0.0158</laser-rx-power-low-warn-threshold>
+            <laser-rx-power-low-warn-threshold-dbm>-18.01</laser-rx-power-low-warn-threshold-dbm>
+        </optics-diagnostics>
+    </physical-interface>
+</interface-information>


### PR DESCRIPTION
This fixes #491 where get_optics fails on some versions of JUNOS such as 12.3 because of a space in Infinite light levels.