### PR TITLE
Fixing NXOS file write issue Python3

### DIFF
--- a/napalm/nxos/nxos.py
+++ b/napalm/nxos/nxos.py
@@ -211,7 +211,7 @@ class NXOSDriver(NetworkDriver):
 
         file_content = self.fix_checkpoint_string(file_content, self.replace_file)
         temp_file = tempfile.NamedTemporaryFile()
-        temp_file.write(file_content)
+        temp_file.write(file_content.encode())
         temp_file.flush()
         self.replace_file = cfg_filename
 


### PR DESCRIPTION
Using Python3 nxos API will fail on an replace config operation due to a failure writing a temporary file.