### PR TITLE
(eos) Add mtu to get_interfaces()

### DIFF
--- a/napalm/eos/eos.py
+++ b/napalm/eos/eos.py
@@ -271,6 +271,8 @@ class EOSDriver(NetworkDriver):
             interfaces[interface]['mac_address'] = napalm.base.helpers.convert(
                 napalm.base.helpers.mac, values.pop('physicalAddress', u''))
 
+            interfaces[interface]['mtu'] = int(values['mtu'])
+
         return interfaces
 
     def get_lldp_neighbors(self):

--- a/test/eos/mocked_data/test_get_interfaces/issue68_iface_no_physical_addr/expected_result.json
+++ b/test/eos/mocked_data/test_get_interfaces/issue68_iface_no_physical_addr/expected_result.json
@@ -5,6 +5,7 @@
     "last_flapped": 1474274582.7947989,
     "is_up": true,
     "mac_address": "",
+    "mtu": 65535,
     "speed": 0
   }
 }

--- a/test/eos/mocked_data/test_get_interfaces/normal/expected_result.json
+++ b/test/eos/mocked_data/test_get_interfaces/normal/expected_result.json
@@ -5,6 +5,7 @@
     "last_flapped": 1466586841.4151127,
     "is_up": true,
     "mac_address": "08:00:27:10:C4:8F",
+    "mtu": 9214,
     "speed": 0
   },
   "Management1": {
@@ -13,6 +14,7 @@
     "last_flapped": 1466586841.4284112,
     "is_up": true,
     "mac_address": "08:00:27:20:B9:04",
+    "mtu": 1500,
     "speed": 1000
   },
   "Ethernet1": {
@@ -21,6 +23,7 @@
     "last_flapped": 1466586841.4148579,
     "is_up": true,
     "mac_address": "08:00:27:C6:00:F0",
+    "mtu": 9214,
     "speed": 0
   },
   "Ethernet4": {
@@ -29,6 +32,7 @@
     "last_flapped": 1466586841.415464,
     "is_up": true,
     "mac_address": "08:00:27:E0:12:D2",
+    "mtu": 9214,
     "speed": 0
   },
   "Ethernet3": {
@@ -37,6 +41,7 @@
     "last_flapped": 1466586841.4152465,
     "is_up": true,
     "mac_address": "08:00:27:1F:60:43",
+    "mtu": 9214,
     "speed": 0
   }
 }


### PR DESCRIPTION
Update return values for `EOSDriver.get_interfaces() to return MTU.

Logical (loopback) interfaces are 65535, not sure if we want to change that?