### PR TITLE
Add "-c /dev/null" arguments to py.test command

### DIFF
--- a/docs/build-ansible-module-docs.sh
+++ b/docs/build-ansible-module-docs.sh
@@ -13,7 +13,7 @@ git checkout develop
 
 pip install -r requirements-dev.txt
 pip install .
-py.test
+py.test -c /dev/null
 cp module_docs/* $MODULES_OUTPUT/
 
 cd $CWD


### PR DESCRIPTION
Before the NAPALM tests were picked up when running from RTD.

The Ansible Docs didn't build correctly on ReadTheDocs as the wrong tests were loaded.