### PR TITLE
[docs] Add "-c /dev/null" arguments to py.test command (#561)

### DIFF
--- a/docs/build-ansible-module-docs.sh
+++ b/docs/build-ansible-module-docs.sh
@@ -13,7 +13,7 @@ git checkout develop
 
 pip install -r requirements-dev.txt
 pip install .
-py.test
+py.test -c /dev/null
 cp module_docs/* $MODULES_OUTPUT/
 
 cd $CWD

--- a/docs/test.sh
+++ b/docs/test.sh
@@ -4,7 +4,7 @@ TEST_RESULTS_PATH="$CWD/support/tests"
 
 if [ ! -f "report.json" ]; then
     set -e
-    pip install -r ../requirements/all -r ../requirements/dev
+    pip install -r ../requirements.txt -r ../requirements-dev.txt
 
     set +e
     py.test -c /dev/null --cov=./ -vs --json=report.json ../test*/*/test_getters.py


### PR DESCRIPTION
Before the NAPALM tests were picked up when running from RTD.