### PR TITLE
Junos vrf support in get_arp()

### DIFF
--- a/napalm/junos/junos.py
+++ b/napalm/junos/junos.py
@@ -1199,7 +1199,11 @@ class JunOSDriver(NetworkDriver):
         arp_table = []
 
         arp_table_raw = junos_views.junos_arp_table(self.device)
-        arp_table_raw.get()
+        if vrf:
+            arp_table_raw.get(vpn=vrf)
+        else:
+            arp_table_raw.get()
+
         arp_table_items = arp_table_raw.items()
 
         for arp_table_entry in arp_table_items:

--- a/napalm/junos/utils/junos_views.yml
+++ b/napalm/junos/utils/junos_views.yml
@@ -415,6 +415,8 @@ junos_arp_table:
   args:
     expiration-time: true
     no-resolve: true
+  args_key:
+    vpn
   item: arp-table-entry
   key: interface-name
   view: junos_arp_view


### PR DESCRIPTION
Support for VRF in get_arp() following #512 in Junos
```
ckishimo@ex9208> show arp vpn VRF | display xml rpc    
<rpc-reply xmlns:junos="http://xml.juniper.net/junos/16.1R5/junos">
    <rpc>
        <get-arp-table-information>
                <vpn>VRF</vpn>
        </get-arp-table-information>
    </rpc>
    <cli>
        <banner>[edit]</banner>
    </cli>
</rpc-reply>
```
```
ckishimo@ex9208> show arp vpn VRF                      
MAC Address       Address         Name                      Interface               Flags
2c:21:31:a5:14:84 192.168.60.2    192.168.60.2              ge-3/1/3.0              none
```
```
[
    {
        "age": 882.0, 
        "interface": "ge-3/1/3.0", 
        "ip": "192.168.60.2", 
        "mac": "2C:21:31:A5:14:84"
    }
]
```