### PR TITLE
Junos force mtu to integer in get_interfaces()

### DIFF
--- a/napalm/junos/junos.py
+++ b/napalm/junos/junos.py
@@ -291,9 +291,11 @@ class JunOSDriver(NetworkDriver):
                     interfaces[iface]['mac_address'],
                     py23_compat.text_type(interfaces[iface]['mac_address'])),
                 'speed': -1,
-                'mtu': interfaces[iface]['mtu']
+                'mtu': -1
             }
             # result[iface]['last_flapped'] = float(result[iface]['last_flapped'])
+            if interfaces[iface]['mtu'] != 'Unlimited':
+                result[iface]['mtu'] = int(interfaces[iface]['mtu'])
 
             match = re.search(r'(\d+)(\w*)', interfaces[iface]['speed'] or u'')
             if match is None:


### PR DESCRIPTION
In Junos the mtu can be reported as `Unlimited`, force mtu to be `int` and return `-1` if `Unlimited`
```
<interface-information>
    <physical-interface>
        <name>lo0</name>
        <admin-status junos:format="Enabled">up</admin-status>
        <oper-status>up</oper-status>
        <local-index>6</local-index>
        <snmp-index>6</snmp-index>
        <if-type>Loopback</if-type>
        <mtu>Unlimited</mtu>
```
```
    "lo0": {
        "description": "", 
        "is_enabled": true, 
        "is_up": true, 
        "last_flapped": -1.0, 
        "mac_address": "Unspecified", 
        "mtu": -1, 
        "speed": -1
    }, 
```