### PR TITLE
Quick fix for the recently added docs

### DIFF
--- a/docs/contributing/index.rst
+++ b/docs/contributing/index.rst
@@ -49,6 +49,12 @@ Just do it! :)
 Proposing a new driver
 ----------------------
 
-This is a but more complex but completely doable. You can find more information `here <https://github.com/napalm-automation/napalm-skeleton>`_.
+This is a more complex process but completely doable. You can find more information `here <https://github.com/napalm-automation/napalm-skeleton>`_.
 
 Please check :ref:`contributing-drivers` to understand the process.
+
+.. toctree::
+   :maxdepth: 1
+
+   core
+   drivers

--- a/docs/support/index.rst
+++ b/docs/support/index.rst
@@ -1,3 +1,5 @@
+.. _supported-devices:
+
 Supported Devices
 =================
 


### PR DESCRIPTION
Didn't build cleanly:

```
pickling environment... done
checking consistency... /Users/mirucha/napalm/docs/contributing/core.rst: WARNING: document isn't included in any toctree
/Users/mirucha/napalm/docs/contributing/drivers.rst: WARNING: document isn't included in any toctree
done
preparing documents... done
writing output... [100%] yang
/Users/mirucha/napalm/docs/contributing/core.rst:6: WARNING: undefined label: supported-devices (if the link has no caption the label must precede a section header)
```