### PR TITLE
Fix temperature for 3850 in 16.06 #582

### DIFF
--- a/test/ios/mocked_data/test_get_environment/3850_16.06/expected_result.json
+++ b/test/ios/mocked_data/test_get_environment/3850_16.06/expected_result.json
@@ -1,0 +1,35 @@
+{
+	"fans": {
+		"invalid": {
+			"status": true
+		}
+	},
+	"temperature": {
+		"inlet": {
+			"is_alert": false,
+			"temperature": 25,
+			"is_critical": false
+		},
+		"hotspot": {
+			"is_alert": false,
+			"temperature": 38,
+			"is_critical": false
+		}
+	},
+	"cpu": {
+		"0": {
+			"%usage": 19
+		}
+	},
+	"power": {
+		"invalid": {
+			"status": true,
+			"output": -1.0,
+			"capacity": -1.0
+		}
+	},
+	"memory": {
+		"available_ram": 577102464,
+		"used_ram": 302937960
+	}
+}

--- a/test/ios/mocked_data/test_get_environment/3850_16.06/show_env_temperature_status.txt
+++ b/test/ios/mocked_data/test_get_environment/3850_16.06/show_env_temperature_status.txt
@@ -1,0 +1,9 @@
+Inlet Temperature Value: 25 Degree Celsius
+Temperature State: GREEN
+Yellow Threshold : 46 Degree Celsius
+Red Threshold : 56 Degree Celsius
+
+Hotspot Temperature Value: 38 Degree Celsius
+Temperature State: GREEN
+Yellow Threshold : 105 Degree Celsius
+Red Threshold : 125 Degree Celsius

--- a/test/ios/mocked_data/test_get_environment/3850_16.06/show_memory_statistics.txt
+++ b/test/ios/mocked_data/test_get_environment/3850_16.06/show_memory_statistics.txt
@@ -1,0 +1,5 @@
+Tracekey : 1#bfcda4e05e635ef59d927d2feb906f16
+
+                Head    Total(b)     Used(b)     Free(b)   Lowest(b)  Largest(b)
+Processor  FF89570010   873745296   296643656   577101640   574894944   577041700
+ lsmpi_io  FF888CE1A8     6295128     6294304         824         824         412

--- a/test/ios/mocked_data/test_get_environment/3850_16.06/show_proc_cpu.txt
+++ b/test/ios/mocked_data/test_get_environment/3850_16.06/show_proc_cpu.txt
@@ -1,0 +1,90 @@
+CPU utilization for five seconds: 29%/15%; one minute: 19%; five minutes: 19%
+ PID Runtime(ms)     Invoked      uSecs   5Sec   1Min   5Min TTY Process
+   1           2          29         68  0.00%  0.00%  0.00%   0 Chunk Manager
+   2      108537      170701        635  0.00%  0.00%  0.00%   0 Load Meter
+   3           0           1          0  0.00%  0.00%  0.00%   0 PKI Trustpool
+   4         371         337       1100  0.00%  0.00%  0.00%   0 RF Slave Main Th
+   5           3         225         13  0.00%  0.00%  0.00%   0 Retransmission o
+   6           0           3          0  0.00%  0.00%  0.00%   0 IPC ISSU Dispatc
+   7           0           1          0  0.00%  0.00%  0.00%   0 RO Notify Timers
+   8         529       28451         18  0.00%  0.00%  0.00%   0 VIDB BACKGD MGR
+   9     1389415      144062       9644  0.00%  0.15%  0.12%   0 Check heaps
+  10        1541       14241        108  0.00%  0.00%  0.00%   0 Pool Manager
+  11           0           1          0  0.00%  0.00%  0.00%   0 DiscardQ Backgro
+  12           0           2          0  0.00%  0.00%  0.00%   0 Timers
+  13          28        1534         18  0.00%  0.00%  0.00%   0 WATCH_AFS
+  14       12575      426725         29  0.00%  0.00%  0.00%   0 IOSXE heartbeat
+  15       24947      297407         83  0.00%  0.00%  0.00%   0 DB Lock Manager
+  16           0           1          0  0.00%  0.00%  0.00%   0 DB Notification
+  17           7          22        318  0.00%  0.00%  0.00%   0 ifIndex Receive
+  18           0           1          0  0.00%  0.00%  0.00%   0 CEF MIB API
+  19          12          84        142  0.00%  0.00%  0.00%   0 IPC Apps Task
+  20        3152      170690         18  0.00%  0.00%  0.00%   0 IPC Event Notifi
+  21       22364      833376         26  0.00%  0.00%  0.00%   0 IPC Mcast Pendin
+  22           0           1          0  0.00%  0.00%  0.00%   0 Platform appsess
+  23         239       14226         16  0.00%  0.00%  0.00%   0 IPC Dynamic Cach
+  24        3293      170690         19  0.00%  0.00%  0.00%   0 IPC Service NonC
+  25           0           1          0  0.00%  0.00%  0.00%   0 IPC Zone Manager
+  26       23801      833377         28  0.00%  0.00%  0.00%   0 IPC Periodic Tim
+  27       19999      833376         23  0.00%  0.00%  0.00%   0 IPC Deferred Por
+  28           0           1          0  0.00%  0.00%  0.00%   0 IPC Process leve
+  29       23520      215608        109  0.00%  0.00%  0.00%   0 IPC Seat Manager
+  30         986       48772         20  0.00%  0.00%  0.00%   0 IPC Check Queue
+  31          81         448        180  0.00%  0.00%  0.00%   0 IPC Seat RX Cont
+  32           0           1          0  0.00%  0.00%  0.00%   0 IPC Seat TX Cont
+  33        8124       85351         95  0.00%  0.00%  0.00%   0 IPC Keep Alive M
+  34       37755      170690        221  0.00%  0.00%  0.00%   0 IPC Loadometer
+  35           0           1          0  0.00%  0.00%  0.00%   0 IPC Session Deta
+  36           0           1          0  0.00%  0.00%  0.00%   0 SENSOR-MGR event
+  37        1368        8780        155  0.00%  0.00%  0.00%   0 ARP Input
+  38       31089      890369         34  0.00%  0.00%  0.00%   0 ARP Background
+  39           0           2          0  0.00%  0.00%  0.00%   0 ATM Idle Timer
+  40           0           1          0  0.00%  0.00%  0.00%   0 ATM ASYNC PROC
+  41           0           1          0  0.00%  0.00%  0.00%   0 AAA_SERVER_DEADT
+  42           0           1          0  0.00%  0.00%  0.00%   0 Policy Manager
+  43           0           2          0  0.00%  0.00%  0.00%   0 DDR Timers
+  44          63          36       1750  0.00%  0.00%  0.00%   0 Entity MIB API
+  45           0           1          0  0.00%  0.00%  0.00%   0 IFS Agent Manage
+  46          23          35        657  0.00%  0.00%  0.00%   0 PrstVbl
+  47           0           2          0  0.00%  0.00%  0.00%   0 Serial Backgroun
+  48           0           1          0  0.00%  0.00%  0.00%   0 RMI RM Notify Wa
+  49           0           1          0  0.00%  0.00%  0.00%   0 IOSXE signals IO
+  50       21452      853500         25  0.00%  0.00%  0.00%   0 GraphIt
+  51       23826      853341         27  0.00%  0.00%  0.00%   0 Dynamic ARP Insp
+  52        1597       16147         98  0.00%  0.00%  0.00%   0 ARP Snoop
+  53           0           1          0  0.00%  0.00%  0.00%   0 License IPC stat
+  54           0           1          0  0.00%  0.00%  0.00%   0 License IPC serv
+  55           1          60         16  0.00%  0.00%  0.00%   0 Net Input
+  56           0           2          0  0.00%  0.00%  0.00%   0 SMART
+  57           8          11        727  0.00%  0.00%  0.00%   0 client_entity_se
+  58           0           1          0  0.00%  0.00%  0.00%   0 SERIAL A'detect
+  59        5998         574      10449  0.00%  0.00%  0.00%   0 crypto sw pk pro
+  60           0           2          0  0.00%  0.00%  0.00%   0 XML Proxy Client
+  61           0           2          0  0.00%  0.00%  0.00%   0 License Client N
+  62           0           1          0  0.00%  0.00%  0.00%   0 Image License br
+  63         274       14226         19  0.00%  0.00%  0.00%   0 Licensing Auto U
+  64           0           1          0  0.00%  0.00%  0.00%   0 License HA Consi
+  65           0           1          0  0.00%  0.00%  0.00%   0 Token Daemon
+  66           0           1          0  0.00%  0.00%  0.00%   0 Critical Bkgnd
+  67       33686      440327         76  0.00%  0.00%  0.00%   0 Net Background
+  68           3          29        103  0.00%  0.00%  0.00%   0 IDB Work
+  69        9301      196411         47  0.00%  0.00%  0.00%   0 Logger
+  70       49695      853359         58  0.00%  0.01%  0.00%   0 TTY Background
+  71           0           3          0  0.00%  0.00%  0.00%   0 CTS CORE
+  72           3          42         71  0.00%  0.00%  0.00%   0 SXP CORE
+  73           3         234         12  0.00%  0.00%  0.00%   0 BACK CHECK
+  74      916578     5528879        165  0.15%  0.13%  0.14%   0 IOSD ipc task
+  75        8734      221884         39  0.00%  0.00%  0.00%   0 IOSD chasfs task
+  76           0           4          0  0.00%  0.00%  0.00%   0 NGWC OIR CC Proc
+  77           0           1          0  0.00%  0.00%  0.00%   0 MATM SPI client
+  78           4          11        363  0.00%  0.00%  0.00%   0 STACK MGR Proces
+  79      548504      183322       2992  0.00%  0.06%  0.07%   0 Crimson flush tr
+  80          78          11       7090  0.00%  0.00%  0.00%   0 NGWC_OIRSHIM_TAS
+  81           0           1          0  0.00%  0.00%  0.00%   0 Ng3k envvar sync
+  82           3          12        250  0.00%  0.00%  0.00%   0 CTS HA
+  83           0           5          0  0.00%  0.00%  0.00%   0 CTS HA IPC flow
+  84        3612      121961         29  0.00%  0.00%  0.00%   0 REDUNDANCY FSM
+  85           0           1          0  0.00%  0.00%  0.00%   0 Punt FP Stats Du
+  86       92337      426666        216  0.00%  0.01%  0.00%   0 PuntInject Keepa
+  87           9          37        243  0.00%  0.00%  0.00%   0 IF-MGR control p
+  88           1          71         14  0.00%  0.00%  0.00%   0 IF-MGR event pro


### PR DESCRIPTION
This PR fix #582 by reading the temperature sensor name instead of searching for a sensor named System.
All the temperature informations are return, keyed by their name.