### PR TITLE
Add allow_agent optional argument support to junos

### DIFF
--- a/napalm/junos/junos.py
+++ b/napalm/junos/junos.py
@@ -84,8 +84,15 @@ class JunOSDriver(NetworkDriver):
         self.keepalive = optional_args.get('keepalive', 30)
         self.ssh_config_file = optional_args.get('ssh_config_file', None)
         self.ignore_warning = optional_args.get('ignore_warning', False)
+        self.allow_agent = optional_args.get('allow_agent', False)
 
-        if self.key_file:
+        if self.allow_agent:
+            self.device = Device(hostname,
+                                 user=username,
+                                 ssh_config=self.ssh_config_file,
+                                 port=self.port)
+
+        elif self.key_file:
             self.device = Device(hostname,
                                  user=username,
                                  password=password,


### PR DESCRIPTION
Situation here is a little different than with the netmiko-based drivers.

Junos driver uses python-eznc, which in turn uses ncclient for the netconf parts, which then uses paramiko for the ssh transport.

In order to pass the allow_agent to paramiko, we have to pass it somehow to python-eznc. 
Good thing it's already there, but gets activated only if both password and private key arguments are [None](https://github.com/Juniper/py-junos-eznc/blob/master/lib/jnpr/junos/device.py#L1232-L1239)

So, add an optional argument 'allow_agent' (default False), which, when enabled, will call eznc's Device without password or private key, to trigger allow_agent in python-eznc.

Tested in a qfx 5012, running junos 14.1X53-D35.3, with the following in a an ansible playbook:
```
  - name: get_facts
    napalm_get_facts:
      hostname="{{ inventory_hostname }}"
      username=costasd
      password=fake
      dev_os={{ os }}
      optional_args='ssh_config_file=ssh_config,allow_agent=True'
      filter='facts'
  - name: get_diff
    napalm_install_config:
      hostname="{{ inventory_hostname }}"
      username=costasd
      password=fake
      dev_os={{ os }}
      optional_args='ssh_config_file=ssh_config,allow_agent=True'
      config_file="confs/{{hostname}}/fullconfig.conf"
      commit_changes=0
```
