### PR TITLE
Interface is always enabled, unless explicitly specified in config

### DIFF
--- a/napalm/iosxr/iosxr.py
+++ b/napalm/iosxr/iosxr.py
@@ -235,7 +235,8 @@ class IOSXRDriver(NetworkDriver):
             if not interface_name:
                 continue
             is_up = (napalm.base.helpers.find_txt(interface_tree, 'LineState') == 'IM_STATE_UP')
-            enabled = (napalm.base.helpers.find_txt(interface_tree, 'State') == 'IM_STATE_UP')
+            enabled = (napalm.base.helpers.find_txt(
+                        interface_tree, 'State') != 'IM_STATE_ADMINDOWN')
             raw_mac = napalm.base.helpers.find_txt(interface_tree, 'MACAddress/Address')
             mac_address = napalm.base.helpers.convert(
                 napalm.base.helpers.mac, raw_mac, raw_mac)

--- a/test/iosxr/mocked_data/test_get_interfaces/normal/expected_result.json
+++ b/test/iosxr/mocked_data/test_get_interfaces/normal/expected_result.json
@@ -1,6 +1,6 @@
 {
 	"TenGigE0/0/0/14": {
-		"is_enabled": false,
+		"is_enabled": true,
 		"description": "",
 		"last_flapped": -1.0,
 		"is_up": false,
@@ -16,7 +16,7 @@
 		"speed": 10000
 	},
 	"TenGigE0/0/0/13": {
-		"is_enabled": false,
+		"is_enabled": true,
 		"description": "",
 		"last_flapped": -1.0,
 		"is_up": false,


### PR DESCRIPTION
An interface should always be considered enabled, unless the `shutdown` stanza is used in the configuration. If that’s the case, the XML API will set the state as `IM_STATE_ADMINDOWN`, opposed to `IM_STATE_DOWN` when the port is enabled, but there is no physical connectivity.
  