### PR TITLE
Fixing NX-OS rollback bug

### DIFF
--- a/napalm/nxos/nxos.py
+++ b/napalm/nxos/nxos.py
@@ -371,7 +371,7 @@ class NXOSDriver(NXOSDriverBase):
     def rollback(self):
         if self.changed:
             self.device.rollback(self.backup_file)
-            self.device.save()
+            self._copy_run_start()
             self.changed = False
 
     def get_facts(self):

--- a/napalm/nxos_ssh/nxos_ssh.py
+++ b/napalm/nxos_ssh/nxos_ssh.py
@@ -697,8 +697,7 @@ class NXOSSSHDriver(NXOSDriverBase):
             result = self.device.send_command(command)
             if 'completed' not in result.lower():
                 raise ReplaceConfigException(result)
-            if not self._save():
-                raise CommandErrorException('Unable to save running-config to startup!')
+            self._copy_run_start()
             self.changed = False
 
     def _apply_key_map(self, key_map, table):


### PR DESCRIPTION
`self._save()` method referenced in rollback doesn't exist any longer. Also make code more consistent between SSH and NX-API