### PR TITLE
Junos fix local_as in get_bgp_config()

### DIFF
--- a/napalm/junos/junos.py
+++ b/napalm/junos/junos.py
@@ -1003,6 +1003,13 @@ class JunOSDriver(NetworkDriver):
             is_nhs, boolean = is_nhs_list[0]
             nhs_policies[policy_name] = boolean if boolean is not None else False
 
+        # Get local AS number under routing-options
+        bgp_as = junos_views.junos_routing_options_autonomous_system(self.device)
+        bgp_as.get()
+        # asnumber contains a list with a single element
+        # Example: [('65002', [('as', '65002')])]
+        asnumber = bgp_as.items()[0][0]
+
         for bgp_group in bgp_items:
             bgp_group_name = bgp_group[0]
             bgp_group_details = bgp_group[1]
@@ -1109,14 +1116,8 @@ class JunOSDriver(NetworkDriver):
             # Fix local autonomous-system (local_as) in each BGP group
             # if local-as is 0 in the BGP group means we are not using local-as comand
             # but the AS number from routing-options/autonomous-system
-            bgp_as = junos_views.junos_routing_options_autonomous_system(self.device)
-            bgp_as.get()
-            # asnumber contains a list with a single element
-            # Example: [('65002', [('as', '65002')])]
-            asnumber = bgp_as.items()[0][0]
-            for group in bgp_config.keys():
-                if bgp_config[group]['local_as'] == 0:
-                    bgp_config[group]['local_as'] = int(asnumber)
+            if bgp_config[bgp_group_name]['local_as'] == 0:
+                bgp_config[bgp_group_name]['local_as'] = int(asnumber)
 
         return bgp_config
 

--- a/napalm/junos/junos.py
+++ b/napalm/junos/junos.py
@@ -1106,6 +1106,18 @@ class JunOSDriver(NetworkDriver):
                 # we do not want cluster in the output
                 del bgp_config[bgp_group_name]['cluster']
 
+            # Fix local autonomous-system (local_as) in each BGP group
+            # if local-as is 0 in the BGP group means we are not using local-as comand
+            # but the AS number from routing-options/autonomous-system
+            bgp_as = junos_views.junos_routing_options_autonomous_system(self.device)
+            bgp_as.get()
+            # asnumber contains a list with a single element
+            # Example: [('65002', [('as', '65002')])]
+            asnumber = bgp_as.items()[0][0]
+            for group in bgp_config.keys():
+                if bgp_config[group]['local_as'] == 0:
+                    bgp_config[group]['local_as'] = int(asnumber)
+
         return bgp_config
 
     def get_bgp_neighbors_detail(self, neighbor_address=''):

--- a/napalm/junos/utils/junos_views.yml
+++ b/napalm/junos/utils/junos_views.yml
@@ -39,6 +39,14 @@ junos_logical_iface_view:
 ####
 #### BGP tables
 ####
+junos_routing_options_autonomous_system:
+  get: routing-options/autonomous-system
+  key: as-number
+  view: junos_routing_options_autonomous_system_view
+
+junos_routing_options_autonomous_system_view:
+  fields:
+    as: { as-number: int }
 
 junos_route_instance_table:
   rpc: get-instance-information

--- a/test/junos/mocked_data/test_get_bgp_config/nhs/_configuration__routing_options__autonomous_system____routing_options___configuration_.xml
+++ b/test/junos/mocked_data/test_get_bgp_config/nhs/_configuration__routing_options__autonomous_system____routing_options___configuration_.xml
@@ -1,0 +1,7 @@
+<configuration>
+        <routing-options>
+            <autonomous-system>
+                <as-number>0</as-number>
+            </autonomous-system>
+        </routing-options>
+</configuration>

--- a/test/junos/mocked_data/test_get_bgp_config/normal/_configuration__routing_options__autonomous_system____routing_options___configuration_.xml
+++ b/test/junos/mocked_data/test_get_bgp_config/normal/_configuration__routing_options__autonomous_system____routing_options___configuration_.xml
@@ -1,0 +1,7 @@
+<configuration>
+        <routing-options>
+            <autonomous-system>
+                <as-number>13335</as-number>
+            </autonomous-system>
+        </routing-options>
+</configuration>


### PR DESCRIPTION
I believe the `local_as` field in `get_bgp_config()` should contain the local AS number no matter the way it has been configured. In Junos the local AS number can be configured via:
	1) `local-as` statement
	2) or via `routing-options/autonomous-system`

In case the `local-as` statement is not used, the `local-as` number reported by the junos driver is 0, which is not true as we will be using the AS number configured under `routing-options`. Example:
```
carles@vmx2# show protocols bgp 
group external {
    type external;
    family inet {
        unicast;
    }
    peer-as 64999;
    neighbor 192.168.2.16;
}
```
The session is established:
```
carles@vmx2# run show bgp neighbor                                            
Peer: 192.168.2.16+52738 AS 64999 Local: 192.168.2.17+179 AS 65002
  Type: External    State: Established    Flags: <Sync>
```
But the junos driver reports `0` in the `local_as`
```
{
    "external": {
        "apply_groups": [],
        "description": "",
        "export_policy": "",
        "import_policy": "",
        "local_address": "",
        "local_as": 0,
        "multihop_ttl": 0,
        "multipath": false,
        "neighbors": {
            "192.168.2.16": {
                "authentication_key": "",
                "description": "",
                "export_policy": "",
                "import_policy": "",
                "local_address": "",
                "local_as": 0,
                "nhs": false,
                "prefix_limit": {},
                "remote_as": 0,
                "route_reflector_client": false
            }
        },
        "prefix_limit": {},
        "remote_as": 64999,
        "remove_private_as": false,
        "type": "external"
    }
}
```
This PR will retrieve the AS number from the `routing-options` and update the `local_as` only if `local_as` value reported in the group is zero
```
{
    "external": {
        "apply_groups": [],
        "description": "",
        "export_policy": "",
        "import_policy": "",
        "local_address": "",
        "local_as": 65002,
        "multihop_ttl": 0,
        "multipath": false,
        "neighbors": {
            "192.168.2.16": {
                "authentication_key": "",
                "description": "",
                "export_policy": "",
                "import_policy": "",
                "local_address": "",
                "local_as": 0,
                "nhs": false,
                "prefix_limit": {},
                "remote_as": 0,
                "route_reflector_client": false
            }
        },
        "prefix_limit": {},
        "remote_as": 64999,
        "remove_private_as": false,
        "type": "external"
    }
}
```
Thanks