### PR TITLE
Fixes for CAM and ARP parsing issues in nxos_ssh.py

### DIFF
--- a/napalm/nxos_ssh/nxos_ssh.py
+++ b/napalm/nxos_ssh/nxos_ssh.py
@@ -1054,10 +1054,8 @@ class NXOSSSHDriver(NXOSDriverBase):
 
         arp_entries = arp_list[1].strip()
         for line in arp_entries.splitlines():
-            if len(line.split()) == 4:
-                address, age, mac, interface = line.split()
-            elif len(line.split()) == 5:
-                address, age, mac, interface, flag = line.split()
+            if len(line.split()) >= 4:
+                address, age, mac, interface = line.split()[:4]
             else:
                 raise ValueError("Unexpected output from: {}".format(line.split()))
 

--- a/napalm/nxos_ssh/nxos_ssh.py
+++ b/napalm/nxos_ssh/nxos_ssh.py
@@ -1056,6 +1056,8 @@ class NXOSSSHDriver(NXOSDriverBase):
         for line in arp_entries.splitlines():
             if len(line.split()) == 4:
                 address, age, mac, interface = line.split()
+            elif len(line.split()) == 5:
+                address, age, mac, interface, flag = line.split()
             else:
                 raise ValueError("Unexpected output from: {}".format(line.split()))
 
@@ -1282,6 +1284,7 @@ class NXOSSSHDriver(NXOSDriverBase):
         output = re.sub(r"^\(R\)", "", output, flags=re.M)
         output = re.sub(r"^\(T\)", "", output, flags=re.M)
         output = re.sub(r"^\(F\)", "", output, flags=re.M)
+        output = re.sub(r"vPC Peer-Link", "vPC-Peer-Link", output, flags=re.M)
 
         for line in output.splitlines():
 

--- a/test/nxos_ssh/mocked_data/test_get_arp_table/normal/show_ip_arp_vrf_default___exc_INCOMPLETE.txt
+++ b/test/nxos_ssh/mocked_data/test_get_arp_table/normal/show_ip_arp_vrf_default___exc_INCOMPLETE.txt
@@ -8,4 +8,4 @@ IP ARP Table for context default
 Total number of entries: 2
 Address         Age       MAC Address     Interface
 10.0.0.2        00:00:04  2cc2.60ff.0021  mgmt0           
-10.0.0.72       00:02:20  2cc2.6036.3221  mgmt0 
+10.0.0.72       00:02:20  2cc2.6036.3221  mgmt0          *

--- a/test/nxos_ssh/mocked_data/test_get_mac_address_table/normal/expected_result.json
+++ b/test/nxos_ssh/mocked_data/test_get_mac_address_table/normal/expected_result.json
@@ -74,7 +74,7 @@
   {
     "vlan": 17,
     "last_move": -1,
-    "interface": "po2",
+    "interface": "vPC-Peer-Link",
     "mac": "00:26:98:0A:DF:44",
     "static": false,
     "active": true,

--- a/test/nxos_ssh/mocked_data/test_get_mac_address_table/normal/show_mac_address_table.txt
+++ b/test/nxos_ssh/mocked_data/test_get_mac_address_table/normal/show_mac_address_table.txt
@@ -12,7 +12,7 @@ age - seconds since last seen,+ - primary entry using vPC Peer-Link,
 * 16       0050.56bb.2577    dynamic      -       F    F    po2
 * 16       0050.56bb.cccf    dynamic      -       F    F    po2
 * 33       0050.56bb.cccf    dynamic      -       F    F    po2
-* 17       0026.980a.df44    dynamic      -       F    F    po2
+* 17       0026.980a.df44    dynamic      -       F    F    vPC Peer-Link
 * 17       0050.56bb.ba9a    dynamic      -       F    F    po2
 * 40       0050.56bb.f532    dynamic      -       F    F    po2
 * 13       90e2.ba5a.9f30    dynamic      -       F    F    eth1/2


### PR DESCRIPTION
I happened to hit both of these today and saw an old issue open on one (#441) and created a new issue for discussion on the other (#633).  Attached are simple fixes for each that I patched into my local instance...  