### PR TITLE
fixes #640 junos ConnectionException

### DIFF
--- a/napalm/junos/junos.py
+++ b/napalm/junos/junos.py
@@ -102,11 +102,11 @@ class JunOSDriver(NetworkDriver):
         self.profile = ["junos"]
 
     def open(self):
-        """Open the connection wit the device."""
+        """Open the connection with the device."""
         try:
             self.device.open()
         except ConnectTimeoutError as cte:
-            raise ConnectionException(cte.message)
+            raise ConnectionException(cte.msg)
         self.device.timeout = self.timeout
         self.device._conn._session.transport.set_keepalive(self.keepalive)
         if hasattr(self.device, "cu"):


### PR DESCRIPTION
The named argument "msg" is now being returned (in this case the default of None).

before:
```
Traceback (most recent call last):
  File "./test.py", line 17, in <module>
    device.open()
  File "/home/cspeidel/git/napalm_venv/lib/python2.7/site-packages/napalm/junos/junos.py", line 109, in open
    raise ConnectionException(cte.message)
napalm.base.exceptions.ConnectionException
```

after:
```
Traceback (most recent call last):
  File "./test.py", line 17, in <module>
    device.open()
  File "/home/cspeidel/git/napalm_venv/lib/python2.7/site-packages/napalm/junos/junos.py", line 109, in open
    raise ConnectionException(cte.msg)
napalm.base.exceptions.ConnectionException: None
```