### PR TITLE
improved exceptions - added new base exception

### DIFF
--- a/napalm/base/exceptions.py
+++ b/napalm/base/exceptions.py
@@ -16,6 +16,7 @@
 from __future__ import print_function
 from __future__ import unicode_literals
 
+
 class NapalmException(Exception):
     '''
     Base Exception Class.

--- a/napalm/base/exceptions.py
+++ b/napalm/base/exceptions.py
@@ -22,6 +22,7 @@ class NapalmException(Exception):
     '''
     pass
 
+
 class ModuleImportError(NapalmException):
     pass
 

--- a/napalm/base/exceptions.py
+++ b/napalm/base/exceptions.py
@@ -16,12 +16,17 @@
 from __future__ import print_function
 from __future__ import unicode_literals
 
+class NapalmException(Exception):
+    '''
+    Base Exception Class.
+    '''
+    pass
 
-class ModuleImportError(Exception):
+class ModuleImportError(NapalmException):
     pass
 
 
-class ConnectionException(Exception):
+class ConnectionException(NapalmException):
     '''
     Unable to connect to the network device.
     '''
@@ -59,15 +64,15 @@ class ConnectionClosedException(ConnectionException):
     pass
 
 
-class ReplaceConfigException(Exception):
+class ReplaceConfigException(NapalmException):
     pass
 
 
-class MergeConfigException(Exception):
+class MergeConfigException(NapalmException):
     pass
 
 
-class CommitError(Exception):
+class CommitError(NapalmException):
     '''
     Raised when unable to commit the candidate config
     into the running config.
@@ -75,43 +80,43 @@ class CommitError(Exception):
     pass
 
 
-class LockError(Exception):
+class LockError(NapalmException):
     '''
     Unable to lock the candidate config.
     '''
     pass
 
 
-class UnlockError(Exception):
+class UnlockError(NapalmException):
     '''
     Unable to unlock the candidate config.
     '''
     pass
 
 
-class SessionLockedException(Exception):
+class SessionLockedException(NapalmException):
     pass
 
 
-class CommandTimeoutException(Exception):
+class CommandTimeoutException(NapalmException):
     pass
 
 
-class CommandErrorException(Exception):
+class CommandErrorException(NapalmException):
     pass
 
 
-class DriverTemplateNotImplemented(Exception):
+class DriverTemplateNotImplemented(NapalmException):
     pass
 
 
-class TemplateNotImplemented(Exception):
+class TemplateNotImplemented(NapalmException):
     pass
 
 
-class TemplateRenderException(Exception):
+class TemplateRenderException(NapalmException):
     pass
 
 
-class ValidationException(Exception):
+class ValidationException(NapalmException):
     pass


### PR DESCRIPTION
Hi! I just had first go at writing a network automation script using napalm; I wanted to wrap my execution block in a try/except block, catching napalm-specific exceptions so that it would not exit the script, but to exit on other exceptions. In order to do this, I would have had to catch almost every listed exception class defined in base/exceptions.py individually.

I wrote a simple patch here to create a new generic NapalmException class, which inherits from Exception, and then modified each other exception class to subclass NapalmException instead. This way, I can list NapalmException as the only exception I need to catch, and then interrogate further for specific exception types if needed.

I've run the docs/test.sh script and all is good; let me know if there's further testing I should be doing before submitting a pull request. Thanks!