### PR TITLE
replacing `message` with cast to `str`

### DIFF
--- a/napalm/base/helpers.py
+++ b/napalm/base/helpers.py
@@ -81,9 +81,9 @@ def load_template(cls, template_name, template_source=None, template_path=None,
         )
     except (jinja2.exceptions.UndefinedError, jinja2.exceptions.TemplateSyntaxError) as jinjaerr:
         raise napalm.base.exceptions.TemplateRenderException(
-            "Unable to render the Jinja config template {template_name}: {error}".format(
+            "Unable to render the Jinja config template {template_name}: {error!s}".format(
                 template_name=template_name,
-                error=jinjaerr.message
+                error=jinjaerr
             )
         )
     return cls.load_merge_candidate(config=configuration)

--- a/napalm/base/helpers.py
+++ b/napalm/base/helpers.py
@@ -81,9 +81,9 @@ def load_template(cls, template_name, template_source=None, template_path=None,
         )
     except (jinja2.exceptions.UndefinedError, jinja2.exceptions.TemplateSyntaxError) as jinjaerr:
         raise napalm.base.exceptions.TemplateRenderException(
-            "Unable to render the Jinja config template {template_name}: {error!s}".format(
+            "Unable to render the Jinja config template {template_name}: {error}".format(
                 template_name=template_name,
-                error=jinjaerr
+                error=jinjaerr.message
             )
         )
     return cls.load_merge_candidate(config=configuration)

--- a/napalm/eos/eos.py
+++ b/napalm/eos/eos.py
@@ -124,7 +124,7 @@ class EOSDriver(NetworkDriver):
             # and this is raised either if device not avaiable
             # either if HTTP(S) agent is not enabled
             # show management api http-commands
-            raise ConnectionException(ce.message)
+            raise ConnectionException(str(ce))
 
     def close(self):
         """Implementation of NAPALM method close."""
@@ -232,9 +232,9 @@ class EOSDriver(NetworkDriver):
         except pyeapi.eapilib.CommandError as e:
             self.discard_config()
             if replace:
-                raise ReplaceConfigException(e.message)
+                raise ReplaceConfigException(str(e))
             else:
-                raise MergeConfigException(e.message)
+                raise MergeConfigException(str(e))
 
     def load_replace_candidate(self, filename=None, config=None):
         """Implementation of NAPALM method load_replace_candidate."""

--- a/napalm/junos/junos.py
+++ b/napalm/junos/junos.py
@@ -665,12 +665,11 @@ class JunOSDriver(NetworkDriver):
         lldp = junos_views.junos_lldp_table(self.device)
         try:
             lldp.get()
-        except RpcError as rpcerr:
+        except RpcError:
             # this assumes the library runs in an environment
             # able to handle logs
             # otherwise, the user just won't see this happening
-            log.error('Unable to retrieve the LLDP neighbors information:')
-            log.error(rpcerr.message)
+            log.exception('Unable to retrieve the LLDP neighbors information')
             return {}
         result = lldp.items()
 
@@ -689,12 +688,11 @@ class JunOSDriver(NetworkDriver):
         lldp_table = junos_views.junos_lldp_neighbors_detail_table(self.device)
         try:
             lldp_table.get()
-        except RpcError as rpcerr:
+        except RpcError:
             # this assumes the library runs in an environment
             # able to handle logs
             # otherwise, the user just won't see this happening
-            log.error('Unable to retrieve the LLDP neighbors information:')
-            log.error(rpcerr.message)
+            log.exception('Unable to retrieve the LLDP neighbors information')
             return {}
         interfaces = lldp_table.get().keys()
 

--- a/napalm/junos/junos.py
+++ b/napalm/junos/junos.py
@@ -106,7 +106,7 @@ class JunOSDriver(NetworkDriver):
         try:
             self.device.open()
         except ConnectTimeoutError as cte:
-            raise ConnectionException(cte.message)
+            raise ConnectionException(str(cte))
         self.device.timeout = self.timeout
         self.device._conn._session.transport.set_keepalive(self.keepalive)
         if hasattr(self.device, "cu"):

--- a/napalm/nxos/nxos.py
+++ b/napalm/nxos/nxos.py
@@ -264,7 +264,7 @@ class NXOSDriver(NXOSDriverBase):
                 self.device.config_list(commands)
                 self.fc.send()
         except NXOSFileTransferError as fte:
-            raise ReplaceConfigException(fte.message)
+            raise ReplaceConfigException(str(fte))
 
     def _create_sot_file(self):
         """Create Source of Truth file to compare."""


### PR DESCRIPTION
As noted [here ](https://github.com/napalm-automation/napalm/issues/652#issuecomment-366434168)

le old perl to the rescue `find . -type f -a -name '*py' -exec egrep -l 'raise.*\.message' {} + | xargs -I{} perl -wlpi -e 's/(raise.*?\()(\w+)\.message/$1str($2)/g' {}`