### PR TITLE
4500 get_mac_address_table() bug fix

### DIFF
--- a/napalm/ios/ios.py
+++ b/napalm/ios/ios.py
@@ -54,6 +54,7 @@ IPV6_ADDR_REGEX = "(?:{}|{}|{})".format(IPV6_ADDR_REGEX_1, IPV6_ADDR_REGEX_2, IP
 
 MAC_REGEX = r"[a-fA-F0-9]{4}\.[a-fA-F0-9]{4}\.[a-fA-F0-9]{4}"
 VLAN_REGEX = r"\d{1,4}"
+INT_REGEX = r"(^\w{1,2}\d{1,3}/\d{1,2}|^\w{1,2}\d{1,3})"
 RE_IPADDR = re.compile(r"{}".format(IP_ADDR_REGEX))
 RE_IPADDR_STRIP = re.compile(r"({})\n".format(IP_ADDR_REGEX))
 RE_MAC = re.compile(r"{}".format(MAC_REGEX))
@@ -1865,7 +1866,8 @@ class IOSDriver(NetworkDriver):
         RE_MACTABLE_6500_2 = r"^{}\s+{}\s+".format(VLAN_REGEX, MAC_REGEX)   # 6 fields
         RE_MACTABLE_6500_3 = r"^\s{51}\S+"                               # Fill down from prior
         RE_MACTABLE_4500_1 = r"^{}\s+{}\s+".format(VLAN_REGEX, MAC_REGEX)     # 5 fields
-        RE_MACTABLE_4500_2 = r"^\s{32}\S+"                               # Fill down from prior
+        RE_MACTABLE_4500_2 = r"^\s{32,34}\S+"                               # Fill down from prior
+        RE_MACTABLE_4500_3 = r"^{}\s+{}\s+".format(INT_REGEX, MAC_REGEX)    # Matches PHY interface in Mac Table
         RE_MACTABLE_2960_1 = r"^All\s+{}".format(MAC_REGEX)
         RE_MACTABLE_GEN_1 = r"^{}\s+{}\s+".format(VLAN_REGEX, MAC_REGEX)   # 4 fields (2960/4500)
 
@@ -1901,11 +1903,11 @@ class IOSDriver(NetworkDriver):
         # Skip the header lines
         output = re.split(r'^----.*', output, flags=re.M)[1:]
         output = "\n".join(output).strip()
-        # Strip any leading astericks
+        # Strip any leading asterisks
         output = re.sub(r"^\*", "", output, flags=re.M)
         fill_down_vlan = fill_down_mac = fill_down_mac_type = ''
         for line in output.splitlines():
-            # Cat6500 one off anf 4500 multicast format
+            # Cat6500 one off and 4500 multicast format
             if (re.search(RE_MACTABLE_6500_3, line) or re.search(RE_MACTABLE_4500_2, line)):
                 interface = line.strip()
                 if ',' in interface:
@@ -1953,6 +1955,11 @@ class IOSDriver(NetworkDriver):
             elif re.search(RE_MACTABLE_4500_1, line) and len(line.split()) == 5:
                 vlan, mac, mac_type, _, interface = line.split()
                 mac_address_table.append(process_mac_fields(vlan, mac, mac_type, interface))
+            # Cat4500 w/PHY interface in Mac Table. Vlan will be -1.
+            elif re.search(RE_MACTABLE_4500_3, line) and len(line.split()) == 5:
+                interface, mac, mac_type, _, _ = line.split()
+                vlan = '-1'
+                mac_address_table.append(process_mac_fields(vlan, mac, mac_type, interface))
             # Cat2960 format - ignore extra header line
             elif re.search(r"^Vlan\s+Mac Address\s+", line):
                 continue
@@ -1970,6 +1977,15 @@ class IOSDriver(NetworkDriver):
                                                                     single_interface))
                 else:
                     mac_address_table.append(process_mac_fields(vlan, mac, mac_type, interface))
+            # 4500 in case of unused Vlan.
+            elif re.search(RE_MACTABLE_4500_1, line) and len(line.split()) == 3:
+                vlan, mac, mac_type = line.split()
+                mac_address_table.append(process_mac_fields(vlan, mac, mac_type, interface=''))
+            #4500 w/PHY interface in Multicast table. Vlan will be -1.
+            elif re.search(RE_MACTABLE_4500_3,line) and len(line.split()) == 4:
+                vlan, mac, mac_type, interface = line.split()
+                vlan = '-1'
+                mac_address_table.append(process_mac_fields(vlan, mac, mac_type, interface))
             elif re.search(r"Total Mac Addresses", line):
                 continue
             elif re.search(r"Multicast Entries", line):

--- a/napalm/ios/ios.py
+++ b/napalm/ios/ios.py
@@ -1977,7 +1977,7 @@ class IOSDriver(NetworkDriver):
                                                                     single_interface))
                 else:
                     mac_address_table.append(process_mac_fields(vlan, mac, mac_type, interface))
-            # 4500 in case of unused Vlan.
+            # 4500 in case of unused Vlan 1.
             elif re.search(RE_MACTABLE_4500_1, line) and len(line.split()) == 3:
                 vlan, mac, mac_type = line.split()
                 mac_address_table.append(process_mac_fields(vlan, mac, mac_type, interface=''))


### PR DESCRIPTION
Corrected bug on 4500 series devices that prevented parsing of mac address tables. This bug is referenced in this issue: https://github.com/napalm-automation/napalm/issues/464.

Changes:
- Minor spelling fixes.
- Added variable INT_REGEX to check for Physical interfaces in mac address table.
- Added variable RE_MACTABLE_4500_3 to incorporate the INT_REGEX variable.
- Modified variable RE_MACTABLE_4500_2 to check for white space 32 to 34 spaces long.
- Added logic to account for multicast table entries that had Physical interfaces. vlan 1 if unused.
- Added logic to account for multicast table entries if vlan 1 if unused.