### PR TITLE
Adding Junos commit comment functionality

### DIFF
--- a/napalm/junos/junos.py
+++ b/napalm/junos/junos.py
@@ -235,9 +235,9 @@ class JunOSDriver(NetworkDriver):
         else:
             return diff.strip()
 
-    def commit_config(self):
+    def commit_config(self, message=None):
         """Commit configuration."""
-        self.device.cu.commit(ignore_warning=self.ignore_warning)
+        self.device.cu.commit(ignore_warning=self.ignore_warning, comment=message)
         if not self.config_lock:
             self._unlock()
 


### PR DESCRIPTION
Adding a commit comment to the junos driver is incredibly simply since the PyEZ commit() function takes a comment natively.

I noticed that in some other branches it seems napalm devs want to use "message" instead of "comment", so that's what I used. Have tested this locally already and works perfectly. 