### PR TITLE
Creating generic way in napalm to create and close a netmiko connection

### DIFF
--- a/napalm/base/base.py
+++ b/napalm/base/base.py
@@ -18,11 +18,12 @@ from __future__ import unicode_literals
 
 # local modules
 import napalm.base.exceptions
+from napalm.base.exceptions import ConnectionException
 import napalm.base.helpers
-
 from napalm.base import constants as c
-
 from napalm.base import validate
+
+from netmiko import ConnectHandler, NetMikoTimeoutException
 
 
 class NetworkDriver(object):
@@ -68,6 +69,28 @@ class NetworkDriver(object):
                 self.close()
         except Exception:
             pass
+
+    def _netmiko_open(self, device_type, netmiko_optional_args=None):
+        """Standardized method of creating a Netmiko connection using napalm attributes."""
+        if netmiko_optional_args is None:
+            netmiko_optional_args = {}
+        try:
+            self._netmiko_device = ConnectHandler(device_type=device_type,
+                                                  host=self.hostname,
+                                                  username=self.username,
+                                                  password=self.password,
+                                                  **netmiko_optional_args)
+        # ensure in enable mode
+        except NetMikoTimeoutException:
+            raise ConnectionException('Cannot connect to {}'.format(self.hostname))
+        self._netmiko_device.enable()
+        return self._netmiko_device
+
+    def _netmiko_close(self):
+        """Standardized method of closing a Netmiko connection."""
+        self.device.disconnect()
+        self._netmiko_device = None
+        self.device = None
 
     def open(self):
         """

--- a/napalm/base/base.py
+++ b/napalm/base/base.py
@@ -80,9 +80,10 @@ class NetworkDriver(object):
                                                   username=self.username,
                                                   password=self.password,
                                                   **netmiko_optional_args)
-        # ensure in enable mode
         except NetMikoTimeoutException:
             raise ConnectionException('Cannot connect to {}'.format(self.hostname))
+
+        # ensure in enable mode
         self._netmiko_device.enable()
         return self._netmiko_device
 

--- a/napalm/ios/ios.py
+++ b/napalm/ios/ios.py
@@ -25,7 +25,7 @@ import tempfile
 import telnetlib
 import copy
 
-from netmiko import ConnectHandler, FileTransfer, InLineTransfer
+from netmiko import FileTransfer, InLineTransfer
 from napalm.base.base import NetworkDriver
 from napalm.base.netmiko_helpers import netmiko_args
 from napalm.base.exceptions import ReplaceConfigException, MergeConfigException, \
@@ -118,13 +118,10 @@ class IOSDriver(NetworkDriver):
         device_type = 'cisco_ios'
         if self.transport == 'telnet':
             device_type = 'cisco_ios_telnet'
-        self.device = ConnectHandler(device_type=device_type,
-                                     host=self.hostname,
-                                     username=self.username,
-                                     password=self.password,
-                                     **self.netmiko_optional_args)
-        # ensure in enable mode
-        self.device.enable()
+        self.device = self._netmiko_open(
+            device_type,
+            netmiko_optional_args=self.netmiko_optional_args,
+        )
 
     def _discover_file_system(self):
         try:
@@ -136,7 +133,7 @@ class IOSDriver(NetworkDriver):
 
     def close(self):
         """Close the connection to the device."""
-        self.device.disconnect()
+        self._netmiko_close()
 
     def _send_command(self, command):
         """Wrapper for self.device.send.command().

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,8 +6,8 @@ jinja2
 netaddr
 pyYAML
 pyeapi
-netmiko>=1.4.3
-pyIOSXR>=0.51
+netmiko>=2.1.1
+pyIOSXR>=0.53
 junos-eznc>=2.1.5
-pynxos
+pynxos==0.0.3
 scp


### PR DESCRIPTION
This will allow for the following in the future:

1. Making secure copy methods inside NAPALM that utilize Netmiko's file_transfer method.

2. Creates more consistency between drivers that use Netmiko.

3. Allow some of the config operations in 'nxos' and 'nxos_ssh' drivers to share common code. Basically, replace the different Secure Copy operations that are inside these two NX-OS drivers and use a standardized Netmiko Secure Copy operation. There are some other advantages we get out of this (for example, would allow usage of SSH keys and usage of SSH config file).