### PR TITLE
Add test for sphinx documentation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,16 @@ python:
   - 3.5
   - 3.6
 
+matrix:
+  include:
+      - python: 3.6
+        env: TOXENV=sphinx
+
 install:
+  - pip install tox
   - pip install tox-travis
   - pip install coveralls
+
 deploy:
   provider: pypi
   user: dbarroso

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,7 @@ matrix:
         env: TOXENV=sphinx
 
 install:
-  - pip install tox
-  - pip install tox-travis
-  - pip install coveralls
+  - pip install tox tox-travis coveralls
 
 deploy:
   provider: pypi

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,5 @@
+.PHONY: doctest
+doctest:
+	cd docs && make clean
+	cd docs && sphinx-build -b html -d _build/doctrees . _build/html
+	#cd docs && sphinx-build -W -b html -d _build/doctrees . _build/html

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py34,py35,py36
+envlist = py27,py34,py35,py36,docs
 
 [testenv]
 deps = 
@@ -7,3 +7,14 @@ deps =
     -rrequirements-dev.txt
 commands =
     py.test {posargs}
+
+[testenv:docs]
+deps = 
+    -rrequirements.txt
+    -rrequirements-dev.txt
+    -rdocs/requirements.txt
+changedir = docs
+commands =
+    make html
+whitelist_externals =
+    make

--- a/tox.ini
+++ b/tox.ini
@@ -5,9 +5,16 @@ envlist = py27,py34,py35,py36
 deps = 
     -rrequirements.txt
     -rrequirements-dev.txt
-    -rdocs/requirements.txt
 commands =
     py.test {posargs}
+
+[testenv:sphinx]
+deps = 
+    -rdocs/requirements.txt
+
+basepython = python3.6
+
+commands =
     make doctest
 
 whitelist_externals =

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py34,py35,py36,docs
+envlist = py27,py34,py35,py36
 
 [testenv]
 deps = 
@@ -7,14 +7,8 @@ deps =
     -rrequirements-dev.txt
 commands =
     py.test {posargs}
+    make doctest
 
-[testenv:docs]
-deps = 
-    -rrequirements.txt
-    -rrequirements-dev.txt
-    -rdocs/requirements.txt
-changedir = docs
-commands =
-    make html
 whitelist_externals =
     make
+

--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,7 @@ envlist = py27,py34,py35,py36
 deps = 
     -rrequirements.txt
     -rrequirements-dev.txt
+    -rdocs/requirements.txt
 commands =
     py.test {posargs}
     make doctest


### PR DESCRIPTION
This PR adds an environment to test that the documentation in Sphinx is generated correctly.

In this first PR the `make html` test ignores warnings. The idea is to later change this and fail on warnings. There are currently a number of warnings generated when creating the documentation.

An example can be seen when looking at get_firewall_policies:
https://napalm.readthedocs.io/en/latest/base.html#napalm.base.base.NetworkDriver.get_firewall_policies

Compare the example of that function to get_interfaces:
https://napalm.readthedocs.io/en/latest/base.html#napalm.base.base.NetworkDriver.get_interfaces

If accepted I can look at those warnings and start to fix then and then set the test to fail on warnings.