### PR TITLE
fix getting ip interface from vrf for NXOS_SSH driver

### DIFF
--- a/napalm/nxos_ssh/nxos_ssh.py
+++ b/napalm/nxos_ssh/nxos_ssh.py
@@ -1140,8 +1140,8 @@ class NXOSSSHDriver(NXOSDriverBase):
         }
         """
         interfaces_ip = {}
-        ipv4_command = 'show ip interface vrf default'
-        ipv6_command = 'show ipv6 interface vrf default'
+        ipv4_command = 'show ip interface vrf all'
+        ipv6_command = 'show ipv6 interface vrf all'
         output_v4 = self.device.send_command(ipv4_command)
         output_v6 = self.device.send_command(ipv6_command)
 

--- a/test/nxos_ssh/mocked_data/test_get_interfaces_ip/normal/expected_result.json
+++ b/test/nxos_ssh/mocked_data/test_get_interfaces_ip/normal/expected_result.json
@@ -10,38 +10,45 @@
         "ipv4": {
             "2.2.2.2": {
                 "prefix_length": 27
-            }, 
+            },
             "3.3.3.3": {
                 "prefix_length": 25
             }
         }
-    }, 
+    },
     "Ethernet2/3": {
         "ipv4": {
             "4.4.4.4": {
                 "prefix_length": 16
             }
-        }, 
+        },
         "ipv6": {
             "fe80::2ec2:60ff:fe4f:feb2": {
                 "prefix_length": 64
-            }, 
+            },
             "2001:db8::1": {
                 "prefix_length": 10
             }
         }
-    }, 
+    },
     "Ethernet2/4": {
         "ipv6": {
             "fe80::2ec2:60ff:fe4f:feb2": {
                 "prefix_length": 64
-            }, 
+            },
             "2001:11:2233::a1": {
                 "prefix_length": 24
-            }, 
+            },
             "2001:cc11:22bb:0:2ec2:60ff:fe4f:feb2": {
                 "prefix_length": 64
             }
         }
-    } 
+    },
+    "mgmt0": {
+        "ipv4": {
+            "5.5.5.5": {
+                "prefix_length": 24
+            }
+        }
+    }
 }

--- a/test/nxos_ssh/mocked_data/test_get_interfaces_ip/normal/show_ip_interface_vrf_all.txt
+++ b/test/nxos_ssh/mocked_data/test_get_interfaces_ip/normal/show_ip_interface_vrf_all.txt
@@ -1,0 +1,119 @@
+IP Interface Status for VRF "default"
+Ethernet2/1, Interface status: protocol-up/link-up/admin-up, iod: 37,
+  IP address: 1.1.1.1, IP subnet: 1.1.1.0/24 route-preference: 0, tag: 0
+  IP broadcast address: 255.255.255.255
+  IP multicast groups locally joined: none
+  IP MTU: 1500 bytes (using link MTU)
+  IP primary address route-preference: 0, tag: 0
+  IP proxy ARP : disabled
+  IP Local Proxy ARP : disabled
+  IP multicast routing: disabled
+  IP icmp redirects: enabled
+  IP directed-broadcast: disabled
+  IP Forwarding: disabled
+  IP icmp unreachables (except port): disabled
+  IP icmp port-unreachable: enabled
+  IP unicast reverse path forwarding: none
+  IP load sharing: none
+  IP interface statistics last reset: never
+  IP interface software stats: (sent/received/forwarded/originated/consumed)
+    Unicast packets    : 59/57/0/237/292
+    Unicast bytes      : 4829/3619/0/15823/18232
+    Multicast packets  : 0/0/0/0/0
+    Multicast bytes    : 0/0/0/0/0
+    Broadcast packets  : 0/0/0/0/0
+    Broadcast bytes    : 0/0/0/0/0
+    Labeled packets    : 0/0/0/0/0
+    Labeled bytes      : 0/0/0/0/0
+  WCCP Redirect outbound: disabled
+  WCCP Redirect inbound: disabled
+  WCCP Redirect exclude: disabled
+Ethernet2/2, Interface status: protocol-up/link-up/admin-up, iod: 38,
+  IP address: 2.2.2.2, IP subnet: 2.2.2.0/27 route-preference: 0, tag: 0
+  IP address: 3.3.3.3, IP subnet: 3.3.3.0/25 secondary route-preference: 0, tag: 0
+  IP broadcast address: 255.255.255.255
+  IP multicast groups locally joined: none
+  IP MTU: 1500 bytes (using link MTU)
+  IP primary address route-preference: 0, tag: 0
+  IP proxy ARP : disabled
+  IP Local Proxy ARP : disabled
+  IP multicast routing: disabled
+  IP icmp redirects: disabled
+  IP directed-broadcast: disabled
+  IP Forwarding: disabled
+  IP icmp unreachables (except port): disabled
+  IP icmp port-unreachable: enabled
+  IP unicast reverse path forwarding: none
+  IP load sharing: none
+  IP interface statistics last reset: never
+  IP interface software stats: (sent/received/forwarded/originated/consumed)
+    Unicast packets    : 0/0/0/0/0
+    Unicast bytes      : 0/0/0/0/0
+    Multicast packets  : 0/0/0/0/0
+    Multicast bytes    : 0/0/0/0/0
+    Broadcast packets  : 0/0/0/0/0
+    Broadcast bytes    : 0/0/0/0/0
+    Labeled packets    : 0/0/0/0/0
+    Labeled bytes      : 0/0/0/0/0
+  WCCP Redirect outbound: disabled
+  WCCP Redirect inbound: disabled
+  WCCP Redirect exclude: disabled
+Ethernet2/3, Interface status: protocol-up/link-up/admin-up, iod: 39,
+  IP address: 4.4.4.4, IP subnet: 4.4.0.0/16 route-preference: 0, tag: 0
+  IP broadcast address: 255.255.255.255
+  IP multicast groups locally joined: none
+  IP MTU: 1500 bytes (using link MTU)
+  IP primary address route-preference: 0, tag: 0
+  IP proxy ARP : disabled
+  IP Local Proxy ARP : disabled
+  IP multicast routing: disabled
+  IP icmp redirects: enabled
+  IP directed-broadcast: disabled
+  IP Forwarding: disabled
+  IP icmp unreachables (except port): disabled
+  IP icmp port-unreachable: enabled
+  IP unicast reverse path forwarding: none
+  IP load sharing: none
+  IP interface statistics last reset: never
+  IP interface software stats: (sent/received/forwarded/originated/consumed)
+    Unicast packets    : 4/4/0/14/18
+    Unicast bytes      : 408/336/0/1248/1512
+    Multicast packets  : 0/0/0/0/0
+    Multicast bytes    : 0/0/0/0/0
+    Broadcast packets  : 0/0/0/0/0
+    Broadcast bytes    : 0/0/0/0/0
+    Labeled packets    : 0/0/0/0/0
+    Labeled bytes      : 0/0/0/0/0
+  WCCP Redirect outbound: disabled
+  WCCP Redirect inbound: disabled
+  WCCP Redirect exclude: disabled
+
+IP Interface Status for VRF "management"
+mgmt0, Interface status: protocol-up/link-up/admin-up, iod: 3,
+  IP address: 5.5.5.5, IP subnet: 5.5.5.0/24
+  IP broadcast address: 255.255.255.255
+  IP multicast groups locally joined: none
+  IP MTU: 1500 bytes (using link MTU)
+  IP primary address route-preference: 0, tag: 0
+  IP proxy ARP : disabled
+  IP Local Proxy ARP : disabled
+  IP multicast routing: disabled
+  IP icmp redirects: enabled
+  IP directed-broadcast: disabled
+  IP icmp unreachables (except port): disabled
+  IP icmp port-unreachable: enabled
+  IP unicast reverse path forwarding: none
+  IP load sharing: none
+  IP interface statistics last reset: never
+  IP interface software stats: (sent/received/forwarded/originated/consumed)
+    Unicast packets    : 64114002/62340045/0/64114002/62335801
+    Unicast bytes      : 9961838580/5704397290/0/9961838580/5701382407
+    Multicast packets  : 0/36659372/0/0/0
+    Multicast bytes    : 0/1877212780/0/0/0
+    Broadcast packets  : 0/3776644/0/0/0
+    Broadcast bytes    : 0/979621040/0/0/0
+    Labeled packets    : 0/0/0/0/0
+    Labeled bytes      : 0/0/0/0/0
+  WCCP Redirect outbound: disabled
+  WCCP Redirect inbound: disabled
+  WCCP Redirect exclude: disabled

--- a/test/nxos_ssh/mocked_data/test_get_interfaces_ip/normal/show_ipv6_interface_vrf_all.txt
+++ b/test/nxos_ssh/mocked_data/test_get_interfaces_ip/normal/show_ipv6_interface_vrf_all.txt
@@ -1,0 +1,47 @@
+IPv6 Interface Status for VRF "default"
+Ethernet2/3, Interface status: protocol-up/link-up/admin-up, iod: 39
+  IPv6 address:
+    2001:db8::1/10 [VALID]
+  IPv6 subnet:  2000::/10
+  IPv6 link-local address: fe80::2ec2:60ff:fe4f:feb2 (default) [VALID]
+  IPv6 virtual addresses configured: none
+  IPv6 multicast routing: disabled
+  IPv6 report link local: disabled
+  IPv6 Forwarding feature: disabled
+  IPv6 multicast groups locally joined:
+      ff02::2  ff02::1  ff02::1:ff00:1  ff02::1:ff4f:feb2
+      ff02::1:ff00:0
+  IPv6 multicast (S,G) entries joined: none
+  IPv6 MTU: 1500 (using link MTU)
+  IPv6 unicast reverse path forwarding: none
+  IPv6 load sharing: none
+  IPv6 interface statistics last reset: never
+  IPv6 interface RP-traffic statistics: (forwarded/originated/consumed)
+    Unicast packets:      0/0/0
+    Unicast bytes:        0/0/0
+    Multicast packets:    0/15/0
+    Multicast bytes:      0/1590/0
+Ethernet2/4, Interface status: protocol-up/link-up/admin-up, iod: 40
+  IPv6 address:
+    2001:11:2233::a1/24 [VALID]
+    2001:cc11:22bb:0:2ec2:60ff:fe4f:feb2/64 [VALID]
+  IPv6 subnet:  2001::/24
+  IPv6 link-local address: fe80::2ec2:60ff:fe4f:feb2 (default) [VALID]
+  IPv6 virtual addresses configured: none
+  IPv6 multicast routing: disabled
+  IPv6 report link local: disabled
+  IPv6 Forwarding feature: disabled
+  IPv6 multicast groups locally joined:
+      ff02::1:ff4f:feb2  ff02::2  ff02::1  ff02::1:ff00:a1
+      ff02::1:ff4f:feb2  ff02::1:ff00:0
+  IPv6 multicast (S,G) entries joined: none
+  IPv6 MTU: 1500 (using link MTU)
+  IPv6 unicast reverse path forwarding: none
+  IPv6 load sharing: none
+  IPv6 interface statistics last reset: never
+  IPv6 interface RP-traffic statistics: (forwarded/originated/consumed)
+    Unicast packets:      0/0/0
+    Unicast bytes:        0/0/0
+    Multicast packets:    0/18/0
+    Multicast bytes:      0/2076/0
+


### PR DESCRIPTION
IP interfaces outside of the 'default' routing instance are missed. This looks intentional from the code of the original developer but isn't consistent with the IOS and Junos drivers tested.

No changes to parsing logic were required.