### PR TITLE
Fix garbled docstrings in RTD and enable strict checking for Sphinx

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,4 @@
 .PHONY: doctest
 doctest:
 	cd docs && make clean
-	cd docs && sphinx-build -b html -d _build/doctrees . _build/html
-	#cd docs && sphinx-build -W -b html -d _build/doctrees . _build/html
+	cd docs && sphinx-build -W -b html -d _build/doctrees . _build/html

--- a/docs/support/ios.rst
+++ b/docs/support/ios.rst
@@ -113,7 +113,7 @@ In vim insert, you can also type <ctrl>+V, release only the V, then type C
 
 
 File Operation Prompts
-_____
+______________________
 
 By default IOS will prompt for confirmation on file operations. These prompts need to be disabled before the NAPALM-ios driver performs any such operation on the device.
 This can be controlled using the `auto_file_prompt` optional arguement:
@@ -126,7 +126,7 @@ This can be controlled using the `auto_file_prompt` optional arguement:
   otherwise a `CommandErrorException` will be raised when file operations are attempted.
 
 SCP File Transfers
-_____
+__________________
 
 The NAPALM-ios driver requires SCP to be enabled on the managed device. SCP
 server functionality is disabled in IOS by default, and is configured using

--- a/docs/tutorials/lab.rst
+++ b/docs/tutorials/lab.rst
@@ -33,7 +33,7 @@ Create a file named ``Vagrantfile`` (no file extension) in your working director
 .. literalinclude:: Vagrantfile
    :language: ruby
 
-The above content is also available on `GitHub <https://raw.githubusercontent.com/napalm-automation/napalm/master/docs/tutorials/Vagrantfile>`_.
+The above content is also available `on GitHub <https://raw.githubusercontent.com/napalm-automation/napalm/master/docs/tutorials/Vagrantfile>`_.
 
 This Vagrantfile creates a base box and a vEOS box when you call ``vagrant up``::
 

--- a/napalm/base/base.py
+++ b/napalm/base/base.py
@@ -253,6 +253,7 @@ class NetworkDriver(object):
         Returns a dictionary of dictionaries. The keys for the first dictionary will be the \
         interfaces in the devices. The inner dictionary will containing the following data for \
         each interface:
+
          * is_up (True/False)
          * is_enabled (True/False)
          * description (string)
@@ -373,36 +374,36 @@ class NetworkDriver(object):
             Note, if is_up is False and uptime has a positive value then this indicates the
             uptime of the last active BGP session.
 
-            Example response:
-            {
-              "global": {
-                "router_id": "10.0.1.1",
-                "peers": {
-                  "10.0.0.2": {
-                    "local_as": 65000,
-                    "remote_as": 65000,
-                    "remote_id": "10.0.1.2",
-                    "is_up": True,
-                    "is_enabled": True,
-                    "description": "internal-2",
-                    "uptime": 4838400,
-                    "address_family": {
-                      "ipv4": {
-                        "sent_prefixes": 637213,
-                        "accepted_prefixes": 3142,
-                        "received_prefixes": 3142
-                      },
-                      "ipv6": {
-                        "sent_prefixes": 36714,
-                        "accepted_prefixes": 148,
-                        "received_prefixes": 148
+            Example::
+
+                {
+                  "global": {
+                    "router_id": "10.0.1.1",
+                    "peers": {
+                      "10.0.0.2": {
+                        "local_as": 65000,
+                        "remote_as": 65000,
+                        "remote_id": "10.0.1.2",
+                        "is_up": True,
+                        "is_enabled": True,
+                        "description": "internal-2",
+                        "uptime": 4838400,
+                        "address_family": {
+                          "ipv4": {
+                            "sent_prefixes": 637213,
+                            "accepted_prefixes": 3142,
+                            "received_prefixes": 3142
+                          },
+                          "ipv6": {
+                            "sent_prefixes": 36714,
+                            "accepted_prefixes": 148,
+                            "received_prefixes": 148
+                          }
+                        }
                       }
                     }
                   }
                 }
-              }
-            }
-
         """
         raise NotImplementedError
 
@@ -542,6 +543,7 @@ class NetworkDriver(object):
 
         Main dictionary keys represent the group name and the values represent a dictionary having
         the keys below. Neighbors which aren't members of a group will be stored in a key named "_":
+
             * type (string)
             * description (string)
             * apply_groups (string list)
@@ -555,7 +557,9 @@ class NetworkDriver(object):
             * remove_private_as (True/False)
             * prefix_limit (dictionary)
             * neighbors (dictionary)
+
         Neighbors is a dictionary of dictionaries with the following keys:
+
             * description (string)
             * import_policy (string)
             * export_policy (string)
@@ -566,6 +570,7 @@ class NetworkDriver(object):
             * prefix_limit (dictionary)
             * route_reflector_client (True/False)
             * nhs (True/False)
+
         The inner dictionary prefix_limit has the same structure for both layers::
 
             {
@@ -865,6 +870,7 @@ class NetworkDriver(object):
         'ipv4' and 'ipv6' (one, both or none) which are themselvs dictionaries witht the IP
         addresses as keys.
         Each IP Address dictionary has the following keys:
+
             * prefix_length (int)
 
         Example::
@@ -914,6 +920,7 @@ class NetworkDriver(object):
         """
         Returns a lists of dictionaries. Each dictionary represents an entry in the MAC Address
         Table, having the following keys:
+
             * mac (string)
             * interface (string)
             * vlan (int)
@@ -1083,6 +1090,7 @@ class NetworkDriver(object):
         The keys of the main dictionary represent the name of the probes.
         Each probe consists on multiple tests, each test name being a key in the probe dictionary.
         A test has the following keys:
+
             * probe_type (str)
             * target (str)
             * source (str)
@@ -1118,6 +1126,7 @@ class NetworkDriver(object):
         The keys of the main dictionary represent the name of the probes.
         Each probe consists on multiple tests, each test name being a key in the probe dictionary.
         A test has the following keys:
+
             * target (str)
             * source (str)
             * probe_type (str)
@@ -1265,6 +1274,7 @@ class NetworkDriver(object):
 
         In case of success, the keys of the dictionary represent the hop ID, while values are
         dictionaries containing the probes results:
+
             * rtt (float)
             * ip_address (str)
             * host_name (str)
@@ -1360,6 +1370,7 @@ class NetworkDriver(object):
         Returns a dictionary with the configured users.
         The keys of the main dictionary represents the username. The values represent the details
         of the user, represented by the following keys:
+
             * level (int)
             * password (str)
             * sshkeys (list)
@@ -1414,39 +1425,39 @@ class NetworkDriver(object):
                                 * min (float)
                                 * max (float)
 
-        Example:
+        Example::
 
             {
-                    'et1': {
-                        'physical_channels': {
-                            'channel': [
-                                {
-                                    'index': 0,
-                                    'state': {
-                                        'input_power': {
-                                            'instant': 0.0,
-                                            'avg': 0.0,
-                                            'min': 0.0,
-                                            'max': 0.0,
-                                        },
-                                        'output_power': {
-                                            'instant': 0.0,
-                                            'avg': 0.0,
-                                            'min': 0.0,
-                                            'max': 0.0,
-                                        },
-                                        'laser_bias_current': {
-                                            'instant': 0.0,
-                                            'avg': 0.0,
-                                            'min': 0.0,
-                                            'max': 0.0,
-                                        },
-                                    }
+                'et1': {
+                    'physical_channels': {
+                        'channel': [
+                            {
+                                'index': 0,
+                                'state': {
+                                    'input_power': {
+                                        'instant': 0.0,
+                                        'avg': 0.0,
+                                        'min': 0.0,
+                                        'max': 0.0,
+                                    },
+                                    'output_power': {
+                                        'instant': 0.0,
+                                        'avg': 0.0,
+                                        'min': 0.0,
+                                        'max': 0.0,
+                                    },
+                                    'laser_bias_current': {
+                                        'instant': 0.0,
+                                        'avg': 0.0,
+                                        'min': 0.0,
+                                        'max': 0.0,
+                                    },
                                 }
-                            ]
-                        }
+                            }
+                        ]
                     }
                 }
+            }
         """
         raise NotImplementedError
 
@@ -1456,10 +1467,11 @@ class NetworkDriver(object):
 
         Args:
             retrieve(string): Which configuration type you want to populate, default is all of them.
-                The rest will be set to "".
+                              The rest will be set to "".
 
         Returns:
-          The object returned is a dictionary with the following keys:
+          The object returned is a dictionary with a key for each configuration store:
+
             - running(string) - Representation of the native running configuration
             - candidate(string) - Representation of the native candidate configuration. If the
               device doesnt differentiate between running and startup configuration this will an
@@ -1480,44 +1492,45 @@ class NetworkDriver(object):
         Returns:
             A dictionary of network instances in OC format:
             * name (dict)
-              * name (unicode)
-              * type (unicode)
-              * state (dict)
-                * route_distinguisher (unicode)
-              * interfaces (dict)
-                * interface (dict)
-                  * interface name: (dict)
+                * name (unicode)
+                * type (unicode)
+                * state (dict)
+                    * route_distinguisher (unicode)
+                * interfaces (dict)
+                    * interface (dict)
+                        * interface name: (dict)
 
-        Example:
-        {
-            u'MGMT': {
-                u'name': u'MGMT',
-                u'type': u'L3VRF',
-                u'state': {
-                    u'route_distinguisher': u'123:456',
+        Example::
+
+            {
+                u'MGMT': {
+                    u'name': u'MGMT',
+                    u'type': u'L3VRF',
+                    u'state': {
+                        u'route_distinguisher': u'123:456',
+                    },
+                    u'interfaces': {
+                        u'interface': {
+                            u'Management1': {}
+                        }
+                    }
                 },
-                u'interfaces': {
-                    u'interface': {
-                        u'Management1': {}
+                u'default': {
+                    u'name': u'default',
+                    u'type': u'DEFAULT_INSTANCE',
+                    u'state': {
+                        u'route_distinguisher': None,
+                    },
+                    u'interfaces: {
+                        u'interface': {
+                            u'Ethernet1': {}
+                            u'Ethernet2': {}
+                            u'Ethernet3': {}
+                            u'Ethernet4': {}
+                        }
                     }
                 }
             }
-            u'default': {
-                u'name': u'default',
-                u'type': u'DEFAULT_INSTANCE',
-                u'state': {
-                    u'route_distinguisher': None,
-                },
-                u'interfaces: {
-                    u'interface': {
-                        u'Ethernet1': {}
-                        u'Ethernet2': {}
-                        u'Ethernet3': {}
-                        u'Ethernet4': {}
-                    }
-                }
-            }
-        }
         """
         raise NotImplementedError
 
@@ -1542,23 +1555,23 @@ class NetworkDriver(object):
 
         Example::
 
-        {
-            'policy_name': [{
-                'position': 1,
-                'packet_hits': 200,
-                'byte_hits': 83883,
-                'id': '230',
-                'enabled': True,
-                'schedule': 'Always',
-                'log': 'all',
-                'l3_src': 'any',
-                'l3_dst': 'any',
-                'service': 'HTTP',
-                'src_zone': 'port2',
-                'dst_zone': 'port3',
-                'action': 'Permit'
-            }]
-        }
+            {
+                'policy_name': [{
+                    'position': 1,
+                    'packet_hits': 200,
+                    'byte_hits': 83883,
+                    'id': '230',
+                    'enabled': True,
+                    'schedule': 'Always',
+                    'log': 'all',
+                    'l3_src': 'any',
+                    'l3_dst': 'any',
+                    'service': 'HTTP',
+                    'src_zone': 'port2',
+                    'dst_zone': 'port3',
+                    'action': 'Permit'
+                }]
+            }
         """
         raise NotImplementedError
 
@@ -1567,6 +1580,7 @@ class NetworkDriver(object):
         Get IPv6 neighbors table information.
 
         Return a list of dictionaries having the following set of keys:
+
             * interface (string)
             * mac (string)
             * ip (string)
@@ -1574,6 +1588,7 @@ class NetworkDriver(object):
             * state (string)
 
         For example::
+
             [
                 {
                     'interface' : 'MgmtEth0/RSP0/CPU0/0',


### PR DESCRIPTION
There's currently a number of warnings generated by Sphinx as the documentation is built, this PR fixes the current issues and enable strict checking where the build will fail on a warning.

If you look in the current documentation you can see that a few of the getters have quite garbled data for the examples and such.