### PR TITLE
Replace jtextfsm with textfsm

### DIFF
--- a/napalm/base/helpers.py
+++ b/napalm/base/helpers.py
@@ -11,7 +11,7 @@ import itertools
 
 # third party libs
 import jinja2
-import jtextfsm as textfsm
+import textfsm
 from netaddr import EUI
 from netaddr import mac_unix
 from netaddr import IPAddress

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 setuptools>=38.4.0
 cffi>=1.11.3
 future
-jtextfsm
+textfsm
 jinja2
 netaddr
 pyYAML

--- a/test/base/test_helpers.py
+++ b/test/base/test_helpers.py
@@ -19,7 +19,7 @@ except ImportError:
     HAS_JINJA = False
 
 try:
-    import jtextfsm as textfsm  # noqa
+    import textfsm  # noqa
     HAS_TEXTFSM = True
 except ImportError:
     HAS_TEXTFSM = False


### PR DESCRIPTION
Replace jtextfsm with textfsm.

jtextfsm has some Python3 compatibility issues in texttable.py. Also textfsm is now being supported again by Google.
