### PR TITLE
#732: Unable to load banner MOTD on Arista

### DIFF
--- a/napalm/eos/eos.py
+++ b/napalm/eos/eos.py
@@ -154,7 +154,7 @@ class EOSDriver(NetworkDriver):
                 depth = depth - 1
         except ValueError:  # Couldn't find end, abort
             return ret
-        ret[s] = {'cmd': ret[s], 'input': "\n".join(ret[s+1:e])}
+        ret[s] = {'cmd': ret[s], 'input': "\n".join([ele['input'] for ele in ret[s+1:e]])}
         del ret[s + 1:e + 1]
 
         return ret


### PR DESCRIPTION
This PR attempts to fix #732, however I am surprised that nobody noticed this
issue before, which makes me questions what changed when (and why)? Without this
patch, loading a multiline banner motd fails (at least with the configuration I
tried to load):

```python
>>> config = '''banner motd
... !!aaaa
... EOF
... '''
>>> e.load_merge_candidate(config=config)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/lib/python2.7/dist-packages/napalm/eos/eos.py", line 245, in load_merge_candidate
    self._load_config(filename, config, False)
  File "/usr/local/lib/python2.7/dist-packages/napalm/eos/eos.py", line 225, in _load_config
    commands = self._multiline_convert(commands, start=start, depth=depth)
  File "/usr/local/lib/python2.7/dist-packages/napalm/eos/eos.py", line 157, in _multiline_convert
    ret[s] = {'cmd': ret[s], 'input': "\n".join(ret[s+1:e])}
TypeError: sequence item 0: expected string or Unicode, dict found
```