### PR TITLE
add get_environment to nxos_ssh

### DIFF
--- a/napalm/nxos_ssh/nxos_ssh.py
+++ b/napalm/nxos_ssh/nxos_ssh.py
@@ -807,10 +807,9 @@ class NXOSSSHDriver(NXOSDriverBase):
         environment['cpu'][0]['%usage'] = 0.0
         system_resources_cpu = napalm.base.helpers.textfsm_extractor(self, 'system_resources',
                                                                      sys_resources)
-        from decimal import Decimal
         for cpu in system_resources_cpu:
-            cpu_dict = {cpu.get('cpu_id'): {'%usage': float(Decimal(100) -
-                        Decimal(cpu.get('cpu_idle')))}}
+            cpu_dict = {cpu.get('cpu_id'): {
+                        '%usage': round(100 - float(cpu.get('cpu_idle')), 2)}}
             environment['cpu'].update(cpu_dict)
 
         # memory

--- a/napalm/nxos_ssh/nxos_ssh.py
+++ b/napalm/nxos_ssh/nxos_ssh.py
@@ -788,6 +788,73 @@ class NXOSSSHDriver(NXOSDriverBase):
             cli_output[py23_compat.text_type(command)] = output
         return cli_output
 
+    def get_environment(self):
+        """
+        Get environment facts.
+
+        power and fan are currently not implemented
+        cpu is using 1-minute average
+        """
+
+        environment = {}
+        # sys_resources contains cpu and mem output
+        sys_resources = self._send_command('show system resources')
+        temp_cmd = 'show env temp'
+
+        # cpu
+        environment.setdefault('cpu', {})
+        environment['cpu'][0] = {}
+        environment['cpu'][0]['%usage'] = 0.0
+        for line in sys_resources.splitlines():
+            # Load average:   1 minute: 0.14   5 minutes: 0.18   15 minutes: 0.21
+            match = re.search(r'1 minute: [0-9]+(.[0-9]+)?', line)
+            if match is not None:
+                cpu = match.group(0).split(':')[1]
+                cpu = '{0:.2f}'.format(float(cpu))
+                environment['cpu'][0]['%usage'] = float(cpu)
+                break
+        else:
+            raise ValueError("Unexpected output from: {}".format(line))
+
+        # memory
+        for line in sys_resources.splitlines():
+            # Memory usage:   16401224K total,   4798280K used,   11602944K free
+            if 'Memory usage:' in line:
+                proc_total_mem, proc_used_mem, _ = line.split(',')
+                proc_used_mem = re.search(r'\d+', proc_used_mem).group(0)
+                proc_total_mem = re.search(r'\d+', proc_total_mem).group(0)
+                break
+        else:
+            raise ValueError("Unexpected output from: {}".format(line))
+        environment.setdefault('memory', {})
+        environment['memory']['used_ram'] = int(proc_used_mem)
+        environment['memory']['available_ram'] = int(proc_total_mem)
+
+        # temperature
+        output = self._send_command(temp_cmd)
+        environment.setdefault('temperature', {})
+        for line in output.splitlines():
+            # Module   Sensor        MajorThresh   MinorThres   CurTemp     Status
+            # 1        Intake          70              42          28         Ok
+            if re.match(r'^[0-9]', line):
+                _, _, is_critical, is_alert, temp, _ = line.split()
+                is_critical = float(is_critical)
+                is_alert = float(is_alert)
+                temp = float(temp)
+                env_value = {'is_alert': temp >= is_alert,
+                             'is_critical': temp >= is_critical,
+                             'temperature': temp}
+                location = line.split()[1]
+                environment['temperature'][location] = env_value
+
+        # Initialize 'power' and 'fan' to default values (not implemented)
+        environment.setdefault('power', {})
+        environment['power']['invalid'] = {'status': True, 'output': -1.0, 'capacity': -1.0}
+        environment.setdefault('fans', {})
+        environment['fans']['invalid'] = {'status': True}
+
+        return environment
+
     def get_arp_table(self):
         """
         Get arp table information.

--- a/napalm/nxos_ssh/nxos_ssh.py
+++ b/napalm/nxos_ssh/nxos_ssh.py
@@ -837,14 +837,14 @@ class NXOSSSHDriver(NXOSDriverBase):
             # Module   Sensor        MajorThresh   MinorThres   CurTemp     Status
             # 1        Intake          70              42          28         Ok
             if re.match(r'^[0-9]', line):
-                _, _, is_critical, is_alert, temp, _ = line.split()
+                module, sensor, is_critical, is_alert, temp, _ = line.split()
                 is_critical = float(is_critical)
                 is_alert = float(is_alert)
                 temp = float(temp)
                 env_value = {'is_alert': temp >= is_alert,
                              'is_critical': temp >= is_critical,
                              'temperature': temp}
-                location = line.split()[1]
+                location = '{0}-{1}'.format(sensor, module)
                 environment['temperature'][location] = env_value
 
         # Initialize 'power' and 'fan' to default values (not implemented)

--- a/napalm/nxos_ssh/utils/textfsm_templates/system_resources.tpl
+++ b/napalm/nxos_ssh/utils/textfsm_templates/system_resources.tpl
@@ -1,0 +1,5 @@
+Value CPU_ID (\d+)
+Value CPU_IDLE ([0-9]+\.[0-9]+)
+
+Start
+  ^\s+CPU${CPU_ID} states  :.*kernel,\s+${CPU_IDLE}% idle -> Record

--- a/test/nxos_ssh/mocked_data/test_get_environment/normal/expected_result.json
+++ b/test/nxos_ssh/mocked_data/test_get_environment/normal/expected_result.json
@@ -1,0 +1,45 @@
+{
+  "power": {
+    "invalid": {
+      "status": true,
+      "output": -1.0,
+      "capacity": -1.0
+    }
+  },
+  "fans": {
+    "invalid": {
+      "status": true
+    }
+  },
+  "cpu": {
+    "0": {
+      "%usage": 0.05
+    }
+  },
+  "temperature": {
+    "Exhaust": {
+      "is_alert": false,
+      "temperature": 33.0,
+      "is_critical": false
+    },
+    "Intake": {
+      "is_alert": false,
+      "temperature": 28.0,
+      "is_critical": false
+    },
+    "Davos": {
+      "is_alert": false,
+      "temperature": 49.0,
+      "is_critical": false
+    },
+    "CPU": {
+      "is_alert": false,
+      "temperature": 44.0,
+      "is_critical": false
+    }
+  },
+  "memory": {
+    "available_ram": 16401224,
+    "used_ram": 4798280
+  }
+}

--- a/test/nxos_ssh/mocked_data/test_get_environment/normal/expected_result.json
+++ b/test/nxos_ssh/mocked_data/test_get_environment/normal/expected_result.json
@@ -17,22 +17,22 @@
     }
   },
   "temperature": {
-    "Exhaust": {
+    "Exhaust-1": {
       "is_alert": false,
       "temperature": 33.0,
       "is_critical": false
     },
-    "Intake": {
+    "Intake-1": {
       "is_alert": false,
       "temperature": 28.0,
       "is_critical": false
     },
-    "Davos": {
+    "Davos-1": {
       "is_alert": false,
       "temperature": 49.0,
       "is_critical": false
     },
-    "CPU": {
+    "CPU-1": {
       "is_alert": false,
       "temperature": 44.0,
       "is_critical": false

--- a/test/nxos_ssh/mocked_data/test_get_environment/normal/expected_result.json
+++ b/test/nxos_ssh/mocked_data/test_get_environment/normal/expected_result.json
@@ -11,10 +11,19 @@
       "status": true
     }
   },
-  "cpu": {
-    "0": {
-      "%usage": 0.05
-    }
+   "cpu": {
+     "0": {
+       "%usage": 1.04
+     },
+     "1": {
+       "%usage": 8.43
+     },
+     "2": {
+       "%usage": 1.05
+     },
+     "3": {
+       "%usage": 1.04
+     }
   },
   "temperature": {
     "Exhaust-1": {

--- a/test/nxos_ssh/mocked_data/test_get_environment/normal/show_env_fan.txt
+++ b/test/nxos_ssh/mocked_data/test_get_environment/normal/show_env_fan.txt
@@ -1,0 +1,12 @@
+Fan:
+---------------------------------------------------------------------------
+Fan             Model                Hw     Direction       Status
+---------------------------------------------------------------------------
+Fan1(sys_fan1)  NXA-FAN-30CFM-B      --     front-to-back   Ok  
+Fan2(sys_fan2)  NXA-FAN-30CFM-B      --     front-to-back   Ok  
+Fan3(sys_fan3)  NXA-FAN-30CFM-B      --     front-to-back   Ok  
+Fan4(sys_fan4)  NXA-FAN-30CFM-B      --     front-to-back   Ok  
+Fan_in_PS1      --                   --     front-to-back   Shutdown
+Fan_in_PS2      --                   --     front-to-back   Ok
+Fan Zone Speed: Zone 1: 0x80
+Fan Air Filter : NotSupported

--- a/test/nxos_ssh/mocked_data/test_get_environment/normal/show_env_power.txt
+++ b/test/nxos_ssh/mocked_data/test_get_environment/normal/show_env_power.txt
@@ -1,0 +1,23 @@
+Power Supply:
+Voltage: 12 Volts
+Power                             Actual      Actual        Total
+Supply    Model                   Output      Input      Capacity    Status
+                                (Watts )    (Watts )     (Watts )
+-------  -------------------  ----------  ----------  ----------  --------------
+1        NXA-PAC-650W-PI             0 W         0 W         0 W     Shutdown  
+2        NXA-PAC-650W-PI            95 W       110 W       650 W     Ok        
+
+
+Power Usage Summary:
+--------------------
+Power Supply redundancy mode (configured)                PS-Redundant
+Power Supply redundancy mode (operational)               Non-Redundant
+
+Total Power Capacity (based on configured mode)             650.00 W
+Total Grid-A (first half of PS slots) Power Capacity          0.00 W
+Total Grid-B (second half of PS slots) Power Capacity       650.00 W
+Total Power of all Inputs (cumulative)                      650.00 W
+Total Power Output (actual draw)                             95.00 W
+Total Power Input (actual draw)                             110.00 W
+Total Power Allocated (budget)                                N/A   
+Total Power Available for additional modules                  N/A

--- a/test/nxos_ssh/mocked_data/test_get_environment/normal/show_env_temp.txt
+++ b/test/nxos_ssh/mocked_data/test_get_environment/normal/show_env_temp.txt
@@ -1,0 +1,9 @@
+Temperature:
+--------------------------------------------------------------------
+Module   Sensor        MajorThresh   MinorThres   CurTemp     Status
+                       (Celsius)     (Celsius)    (Celsius)
+--------------------------------------------------------------------
+1        Intake          70              42          28         Ok
+1        Exhaust         90              80          33         Ok
+1        CPU             100             90          44         Ok
+1        Davos           110             90          49         Ok 

--- a/test/nxos_ssh/mocked_data/test_get_environment/normal/show_system_resources.txt
+++ b/test/nxos_ssh/mocked_data/test_get_environment/normal/show_system_resources.txt
@@ -1,0 +1,9 @@
+Load average:   1 minute: 0.05   5 minutes: 0.07   15 minutes: 0.14
+Processes   :   627 total, 1 running
+CPU states  :   2.31% user,   1.28% kernel,   96.39% idle
+        CPU0 states  :   0.00% user,   1.03% kernel,   98.96% idle
+        CPU1 states  :   6.31% user,   2.10% kernel,   91.57% idle
+        CPU2 states  :   1.04% user,   0.00% kernel,   98.95% idle
+        CPU3 states  :   0.00% user,   1.03% kernel,   98.96% idle
+Memory usage:   16401224K total,   4798280K used,   11602944K free
+Current memory status: OK


### PR DESCRIPTION
power and fan are not currently implemented (they aren't implemented in the ios driver either).