### PR TITLE
The EX4300-48P has issues with LLDP information tags

### DIFF
--- a/napalm/junos/junos.py
+++ b/napalm/junos/junos.py
@@ -749,6 +749,7 @@ class JunOSDriver(NetworkDriver):
                 'default': rpc_call_with_information,
                 'EX9208': rpc_call_without_information,
                 'EX3400': rpc_call_without_information,
+                'EX4300-48P': rpc_call_without_information,
                 'EX4600-40F': rpc_call_without_information,
                 'QFX5110-48S-4C': rpc_call_without_information,
                 'QFX10002-36Q': rpc_call_without_information,


### PR DESCRIPTION
The same issue has been described before in `junos.py` and is an issue on multiple platforms. I tested the before and after on a EX4300-48P with success.

Concrete error before:
```
[lldp_neighbors_detail] cannot retrieve device data: RpcError(severity: error, bad_element: get-lldp-interface-neighbors-information, message: error: syntax error
```