### PR TITLE
Fix issue with LLDP neighbors when remote device lacks system name on older IOS version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,8 @@ docs/_static/
 
 .idea
 .DS_Store
+.vagrant
+.venv
 
 env
 *.swp

--- a/napalm/ios/ios.py
+++ b/napalm/ios/ios.py
@@ -715,7 +715,8 @@ class IOSDriver(NetworkDriver):
         port_description = re.search(r"Port Description\s*?[:-]\s+(.+)", lldp_entry)
         chassis_id = re.search(r"Chassis id\s*?[:-]\s+(.+)", lldp_entry)
         system_name = re.search(r"System Name\s*?[:-]\s+(.+)", lldp_entry)
-        system_descr = re.search(r"System Description\s*?[:-]\s*(not advertised|\s*\n.+)", lldp_entry)
+        system_descr = re.search(r"System Description\s*?[:-]\s*(not advertised|\s*\n.+)",
+                                 lldp_entry)
         system_capab = re.search(r"System Capabilities\s*?[:-]\s+(.+)", lldp_entry)
         enabled_capab = re.search(r"Enabled Capabilities\s*?[:-]\s+(.+)", lldp_entry)
 

--- a/napalm/ios/ios.py
+++ b/napalm/ios/ios.py
@@ -739,6 +739,11 @@ class IOSDriver(NetworkDriver):
             lldp_brief = self._send_command(command)
             lldp_interfaces = textfsm_extractor(self, 'show_lldp_neighbors', lldp_brief)
             lldp_interfaces = [x['local_interface'] for x in lldp_interfaces]
+            if len(lldp_interfaces) != len(lldp_entries):
+                raise ValueError(
+                    "LLDP neighbor count has changed between commands. "
+                    "Interface: {}\nEntries: {}".format(lldp_interfaces, lldp_entries)
+                )
 
         for idx, lldp_entry in enumerate(lldp_entries):
             local_intf = lldp_entry.pop('local_interface') or lldp_interfaces[idx]

--- a/napalm/ios/ios.py
+++ b/napalm/ios/ios.py
@@ -701,9 +701,14 @@ class IOSDriver(NetworkDriver):
         for intf_name, entries in neighbors_detail.items():
             lldp[intf_name] = []
             for lldp_entry in entries:
+                hostname = lldp_entry['remote_system_name']
+                # Match IOS behaviour of taking remote chassis ID
+                # When lacking a system name (in show lldp neighbors)
+                if hostname == "N/A":
+                    hostname = lldp_entry['remote_chassis_id']
                 lldp_dict = {
                     'port': lldp_entry['remote_port'],
-                    'hostname': lldp_entry['remote_system_name'],
+                    'hostname': hostname,
                 }
                 lldp[intf_name].append(lldp_dict)
 
@@ -768,6 +773,7 @@ class IOSDriver(NetworkDriver):
                 lldp_interfaces = [x[20:20+15].strip() for x in lldp_brief.strip().splitlines()]
             except IndexError:
                 return {}
+
         for idx, lldp_entry in enumerate(lldp_entries):
             try:
                 if local_intf_detected:

--- a/napalm/ios/utils/textfsm_templates/show_lldp_neighbors.tpl
+++ b/napalm/ios/utils/textfsm_templates/show_lldp_neighbors.tpl
@@ -5,7 +5,8 @@ Start
   ^Device ID -> Record Neighbor
 
 Neighbor
-  # Skip 20 characters for the Device ID
-  ^.{20}${LOCAL_INTERFACE} -> Record
+  ^Total entries displayed -> End
   # Stop at the first empty line
   ^$$ -> End
+  # Skip 20 characters for the Device ID
+  ^.{20}${LOCAL_INTERFACE} -> Record

--- a/napalm/ios/utils/textfsm_templates/show_lldp_neighbors.tpl
+++ b/napalm/ios/utils/textfsm_templates/show_lldp_neighbors.tpl
@@ -1,0 +1,11 @@
+Value LOCAL_INTERFACE ([^\s]{1,15})
+
+Start
+  # Start capturing after the line that start the table
+  ^Device ID -> Record Neighbor
+
+Neighbor
+  # Skip 20 characters for the Device ID
+  ^.{20}${LOCAL_INTERFACE} -> Record
+  # Stop at the first empty line
+  ^$$ -> End

--- a/napalm/ios/utils/textfsm_templates/show_lldp_neighbors_detail.tpl
+++ b/napalm/ios/utils/textfsm_templates/show_lldp_neighbors_detail.tpl
@@ -1,0 +1,28 @@
+Value LOCAL_INTERFACE (.*)
+Value REMOTE_CHASSIS_ID (.*)
+Value REMOTE_PORT (.*)
+Value REMOTE_PORT_DESCRIPTION (.+)
+Value REMOTE_SYSTEM_NAME (.*)
+Value REMOTE_SYSTEM_DESCRIPTION (.+)
+Value REMOTE_SYSTEM_CAPAB (.*)
+Value REMOTE_SYSTEM_ENABLE_CAPAB (.*)
+
+Start
+  # A line of hyphens delimits neighbor records
+  ^------+ -> Record Neighbor
+
+Neighbor
+  ^Local Intf\s*?[:-]\s+${LOCAL_INTERFACE}
+  ^Chassis id\s*?[:-]\s+${REMOTE_CHASSIS_ID}
+  ^Port id\s*?[:-]\s+${REMOTE_PORT}
+  ^Port Description\s*?[:-]\s+${REMOTE_PORT_DESCRIPTION}
+  ^System Name\s*?[:-]\s+${REMOTE_SYSTEM_NAME}
+  # We need to change state to capture the entire next line
+  ^System Description: -> Description
+  ^System Description\s*-\s*${REMOTE_SYSTEM_DESCRIPTION}
+  ^System Capabilities\s*?[:-]\s+${REMOTE_SYSTEM_CAPAB}
+  ^Enabled Capabilities\s*?[:-]\s+${REMOTE_SYSTEM_ENABLE_CAPAB} -> Record
+
+Description
+  # Capture the entire line and go back to Neighbor state
+  ^${REMOTE_SYSTEM_DESCRIPTION} -> Neighbor

--- a/test/ios/mocked_data/test_get_lldp_neighbors/missing_hostname/expected_result.json
+++ b/test/ios/mocked_data/test_get_lldp_neighbors/missing_hostname/expected_result.json
@@ -1,0 +1,14 @@
+{
+    "FastEthernet0/24": [
+        {
+            "port": "Fa0/19",
+            "hostname": "switch1"
+        }
+    ],
+    "FastEthernet0/17": [
+        {
+            "port": "480f.cf28.8a1b",
+            "hostname": "480f.cf28.8a1b"
+        }
+    ]
+}

--- a/test/ios/mocked_data/test_get_lldp_neighbors/missing_hostname/show_lldp_neighbors.txt
+++ b/test/ios/mocked_data/test_get_lldp_neighbors/missing_hostname/show_lldp_neighbors.txt
@@ -1,0 +1,10 @@
+Capability codes:
+    (R) Router, (B) Bridge, (T) Telephone, (C) DOCSIS Cable Device
+    (W) WLAN Access Point, (P) Repeater, (S) Station, (O) Other
+
+Device ID           Local Intf     Hold-time  Capability      Port ID
+switch1             Fa0/24         120        B               Fa0/19
+480f.cf28.8a1b      Fa0/17         3601                       480f.cf28.8a1b
+
+Total entries displayed: 2
+

--- a/test/ios/mocked_data/test_get_lldp_neighbors/missing_hostname/show_lldp_neighbors_detail.txt
+++ b/test/ios/mocked_data/test_get_lldp_neighbors/missing_hostname/show_lldp_neighbors_detail.txt
@@ -1,0 +1,60 @@
+------------------------------------------------
+Chassis id: a40c.c3c1.3980
+Port id: Fa0/19
+Port Description: FastEthernet0/19
+System Name: switch1
+
+System Description:
+Cisco IOS Software, C2960 Software (C2960-LANBASEK9-M), Version 15.0(1)SE2, RELEASE SOFTWARE (fc3)
+Technical Support: http://www.cisco.com/techsupport
+Copyright (c) 1986-2011 by Cisco Systems, Inc.
+Compiled Thu 22-Dec-11 00:46 by prod_rel_team
+
+Time remaining: 113 seconds
+System Capabilities: B
+Enabled Capabilities: B
+Management Addresses:
+    IP: 10.127.15.129
+Auto Negotiation - supported, enabled
+Physical media capabilities:
+    100base-TX(FD)
+    100base-TX(HD)
+    10base-T(FD)
+    10base-T(HD)
+Media Attachment Unit type: 16
+Vlan ID: 1
+
+------------------------------------------------
+Chassis id: 480f.cf28.8a1b
+Port id: 480f.cf28.8a1b
+Port Description - not advertised
+System Name - not advertised
+System Description - not advertised
+
+Time remaining: 2787 seconds
+System Capabilities - not advertised
+Enabled Capabilities - not advertised
+Management Addresses - not advertised
+Auto Negotiation - supported, enabled
+Physical media capabilities:
+    1000baseT(FD)
+Media Attachment Unit type - not advertised
+Vlan ID: - not advertised
+
+MED Information:
+
+    MED Codes:
+          (NP) Network Policy, (LI) Location Identification
+          (PS) Power Source Entity, (PD) Power Device
+          (IN) Inventory
+
+    Inventory information - not advertised
+    Capabilities:
+    Device type: Endpoint Class I
+    Network Policies - not advertised
+    Power requirements - not advertised
+    Location - not advertised
+
+
+Total entries displayed: 2
+

--- a/test/ios/mocked_data/test_get_lldp_neighbors_detail/alternate2/expected_result.json
+++ b/test/ios/mocked_data/test_get_lldp_neighbors_detail/alternate2/expected_result.json
@@ -1,0 +1,26 @@
+{
+    "FastEthernet0/24": [
+        {
+            "parent_interface": "N/A",
+            "remote_chassis_id": "a40c.c3c1.3980",
+            "remote_port": "Fa0/19",
+            "remote_port_description": "FastEthernet0/19",
+            "remote_system_capab": "B",
+            "remote_system_description": "Cisco IOS Software, C2960 Software (C2960-LANBASEK9-M), Version 15.0(1)SE2, RELEASE SOFTWARE (fc3)",
+            "remote_system_enable_capab": "B",
+            "remote_system_name": "switch1"
+        }
+    ],
+    "FastEthernet0/17": [
+        {
+            "parent_interface": "N/A",
+            "remote_chassis_id": "480f.cf28.8a1b",
+            "remote_port": "480f.cf28.8a1b",
+            "remote_port_description": "N/A",
+            "remote_system_capab": "N/A",
+            "remote_system_description": "N/A",
+            "remote_system_enable_capab": "N/A",
+            "remote_system_name": "N/A"
+        }
+    ]
+}

--- a/test/ios/mocked_data/test_get_lldp_neighbors_detail/alternate2/show_lldp_neighbors.txt
+++ b/test/ios/mocked_data/test_get_lldp_neighbors_detail/alternate2/show_lldp_neighbors.txt
@@ -1,0 +1,10 @@
+Capability codes:
+    (R) Router, (B) Bridge, (T) Telephone, (C) DOCSIS Cable Device
+    (W) WLAN Access Point, (P) Repeater, (S) Station, (O) Other
+
+Device ID           Local Intf     Hold-time  Capability      Port ID
+switch1             Fa0/24         120        B               Fa0/19
+480f.cf28.8a1b      Fa0/17         3601                       480f.cf28.8a1b
+
+Total entries displayed: 3
+

--- a/test/ios/mocked_data/test_get_lldp_neighbors_detail/alternate2/show_lldp_neighbors.txt
+++ b/test/ios/mocked_data/test_get_lldp_neighbors_detail/alternate2/show_lldp_neighbors.txt
@@ -6,5 +6,5 @@ Device ID           Local Intf     Hold-time  Capability      Port ID
 switch1             Fa0/24         120        B               Fa0/19
 480f.cf28.8a1b      Fa0/17         3601                       480f.cf28.8a1b
 
-Total entries displayed: 3
+Total entries displayed: 2
 

--- a/test/ios/mocked_data/test_get_lldp_neighbors_detail/alternate2/show_lldp_neighbors_detail.txt
+++ b/test/ios/mocked_data/test_get_lldp_neighbors_detail/alternate2/show_lldp_neighbors_detail.txt
@@ -56,5 +56,5 @@ MED Information:
     Location - not advertised
 
 
-Total entries displayed: 3
+Total entries displayed: 2
 

--- a/test/ios/mocked_data/test_get_lldp_neighbors_detail/alternate2/show_lldp_neighbors_detail.txt
+++ b/test/ios/mocked_data/test_get_lldp_neighbors_detail/alternate2/show_lldp_neighbors_detail.txt
@@ -1,0 +1,60 @@
+------------------------------------------------
+Chassis id: a40c.c3c1.3980
+Port id: Fa0/19
+Port Description: FastEthernet0/19
+System Name: switch1
+
+System Description:
+Cisco IOS Software, C2960 Software (C2960-LANBASEK9-M), Version 15.0(1)SE2, RELEASE SOFTWARE (fc3)
+Technical Support: http://www.cisco.com/techsupport
+Copyright (c) 1986-2011 by Cisco Systems, Inc.
+Compiled Thu 22-Dec-11 00:46 by prod_rel_team
+
+Time remaining: 113 seconds
+System Capabilities: B
+Enabled Capabilities: B
+Management Addresses:
+    IP: 10.127.15.129
+Auto Negotiation - supported, enabled
+Physical media capabilities:
+    100base-TX(FD)
+    100base-TX(HD)
+    10base-T(FD)
+    10base-T(HD)
+Media Attachment Unit type: 16
+Vlan ID: 1
+
+------------------------------------------------
+Chassis id: 480f.cf28.8a1b
+Port id: 480f.cf28.8a1b
+Port Description - not advertised
+System Name - not advertised
+System Description - not advertised
+
+Time remaining: 2787 seconds
+System Capabilities - not advertised
+Enabled Capabilities - not advertised
+Management Addresses - not advertised
+Auto Negotiation - supported, enabled
+Physical media capabilities:
+    1000baseT(FD)
+Media Attachment Unit type - not advertised
+Vlan ID: - not advertised
+
+MED Information:
+
+    MED Codes:
+          (NP) Network Policy, (LI) Location Identification
+          (PS) Power Source Entity, (PD) Power Device
+          (IN) Inventory
+
+    Inventory information - not advertised
+    Capabilities:
+    Device type: Endpoint Class I
+    Network Policies - not advertised
+    Power requirements - not advertised
+    Location - not advertised
+
+
+Total entries displayed: 3
+

--- a/test/ios/utils/textfsm_templates/show_lldp_neighbors.tpl
+++ b/test/ios/utils/textfsm_templates/show_lldp_neighbors.tpl
@@ -5,7 +5,8 @@ Start
   ^Device ID -> Record Neighbor
 
 Neighbor
-  # Skip 20 characters for the Device ID
-  ^.{20}${LOCAL_INTERFACE} -> Record
+  ^Total entries displayed -> End
   # Stop at the first empty line
   ^$$ -> End
+  # Skip 20 characters for the Device ID
+  ^.{20}${LOCAL_INTERFACE} -> Record

--- a/test/ios/utils/textfsm_templates/show_lldp_neighbors.tpl
+++ b/test/ios/utils/textfsm_templates/show_lldp_neighbors.tpl
@@ -1,0 +1,11 @@
+Value LOCAL_INTERFACE ([^\s]{1,15})
+
+Start
+  # Start capturing after the line that start the table
+  ^Device ID -> Record Neighbor
+
+Neighbor
+  # Skip 20 characters for the Device ID
+  ^.{20}${LOCAL_INTERFACE} -> Record
+  # Stop at the first empty line
+  ^$$ -> End

--- a/test/ios/utils/textfsm_templates/show_lldp_neighbors_detail.tpl
+++ b/test/ios/utils/textfsm_templates/show_lldp_neighbors_detail.tpl
@@ -1,0 +1,28 @@
+Value LOCAL_INTERFACE (.*)
+Value REMOTE_CHASSIS_ID (.*)
+Value REMOTE_PORT (.*)
+Value REMOTE_PORT_DESCRIPTION (.+)
+Value REMOTE_SYSTEM_NAME (.*)
+Value REMOTE_SYSTEM_DESCRIPTION (.+)
+Value REMOTE_SYSTEM_CAPAB (.*)
+Value REMOTE_SYSTEM_ENABLE_CAPAB (.*)
+
+Start
+  # A line of hyphens delimits neighbor records
+  ^------+ -> Record Neighbor
+
+Neighbor
+  ^Local Intf\s*?[:-]\s+${LOCAL_INTERFACE}
+  ^Chassis id\s*?[:-]\s+${REMOTE_CHASSIS_ID}
+  ^Port id\s*?[:-]\s+${REMOTE_PORT}
+  ^Port Description\s*?[:-]\s+${REMOTE_PORT_DESCRIPTION}
+  ^System Name\s*?[:-]\s+${REMOTE_SYSTEM_NAME}
+  # We need to change state to capture the entire next line
+  ^System Description: -> Description
+  ^System Description\s*-\s*${REMOTE_SYSTEM_DESCRIPTION}
+  ^System Capabilities\s*?[:-]\s+${REMOTE_SYSTEM_CAPAB}
+  ^Enabled Capabilities\s*?[:-]\s+${REMOTE_SYSTEM_ENABLE_CAPAB} -> Record
+
+Description
+  # Capture the entire line and go back to Neighbor state
+  ^${REMOTE_SYSTEM_DESCRIPTION} -> Neighbor


### PR DESCRIPTION
There is a bug where LLDP neighbors end up on the same interface when the remove device didn't have a system name and the LLDP output was missing `Local Intf` on older IOS versions.

This example returns the neighbor of interface Fa0/17 as being connected to Fa0/24.
```
Capability codes:
    (R) Router, (B) Bridge, (T) Telephone, (C) DOCSIS Cable Device
    (W) WLAN Access Point, (P) Repeater, (S) Station, (O) Other

Device ID           Local Intf     Hold-time  Capability      Port ID
switch1             Fa0/24         120        B               Fa0/19
480f.cf28.8a1b      Fa0/17         3601                       480f.cf28.8a1b

Total entries displayed: 2
```
```
------------------------------------------------
Chassis id: a40c.c3c1.3980
Port id: Fa0/19
Port Description: FastEthernet0/19
System Name: switch1

System Description:
Cisco IOS Software, C2960 Software (C2960-LANBASEK9-M), Version 15.0(1)SE2, RELEASE SOFTWARE (fc3)
Technical Support: http://www.cisco.com/techsupport
Copyright (c) 1986-2011 by Cisco Systems, Inc.
Compiled Thu 22-Dec-11 00:46 by prod_rel_team

Time remaining: 113 seconds
System Capabilities: B
Enabled Capabilities: B
Management Addresses:
    IP: 10.127.15.129
Auto Negotiation - supported, enabled
Physical media capabilities:
    100base-TX(FD)
    100base-TX(HD)
    10base-T(FD)
    10base-T(HD)
Media Attachment Unit type: 16
Vlan ID: 1

------------------------------------------------
Chassis id: 480f.cf28.8a1b
Port id: 480f.cf28.8a1b
Port Description - not advertised
System Name - not advertised
System Description - not advertised

Time remaining: 2787 seconds
System Capabilities - not advertised
Enabled Capabilities - not advertised
Management Addresses - not advertised
Auto Negotiation - supported, enabled
Physical media capabilities:
    1000baseT(FD)
Media Attachment Unit type - not advertised
Vlan ID: - not advertised

MED Information:

    MED Codes:
          (NP) Network Policy, (LI) Location Identification
          (PS) Power Source Entity, (PD) Power Device
          (IN) Inventory

    Inventory information - not advertised
    Capabilities:
    Device type: Endpoint Class I
    Network Policies - not advertised
    Power requirements - not advertised
    Location - not advertised


Total entries displayed: 2
```
### Output
```
get_lldp_neighbors()
----------------------------------
{'FastEthernet0/24': [{'hostname': 'switch1', 'port': 'fa0/19'},
                      {'hostname': 'N/A', 'port': '40b0.34e2.bcac'}]}

get_lldp_neighbors_detail()
----------------------------------
{'FastEthernet0/24': [{'parent_interface': 'N/A',
                       'remote_chassis_id': 'a40c.c3c1.3980',
                       'remote_port': 'Fa0/19',
                       'remote_port_description': 'FastEthernet0/19',
                       'remote_system_capab': 'B',
                       'remote_system_description': 'Cisco IOS Software, C2960 '
                                                    'Software '
                                                    '(C2960-LANBASEK9-M), '
                                                    'Version 15.0(1)SE2, '
                                                    'RELEASE SOFTWARE (fc3)',
                       'remote_system_enable_capab': 'B',
                       'remote_system_name': 'switch1'},
                      {'parent_interface': 'N/A',
                       'remote_chassis_id': '40b0.34e2.bcac',
                       'remote_port': '40b0.34e2.bcac',
                       'remote_port_description': 'N/A',
                       'remote_system_capab': 'N/A',
                       'remote_system_description': 'N/A',
                       'remote_system_enable_capab': 'N/A',
                       'remote_system_name': 'N/A'}]}
```
### Expected Output
```
get_lldp_neighbors()
----------------------------------
{'FastEthernet0/16': [{'hostname': '40b0.34e2.bcac', 'port': '40b0.34e2.bcac'}],
 'FastEthernet0/24': [{'hostname': 'xwbs032101', 'port': 'Fa0/19'}]}

get_lldp_neighbors_detail()
----------------------------------
{'FastEthernet0/16': [{'parent_interface': 'N/A',
                       'remote_chassis_id': '40b0.34e2.bcac',
                       'remote_port': '40b0.34e2.bcac',
                       'remote_port_description': 'N/A',
                       'remote_system_capab': 'N/A',
                       'remote_system_description': 'N/A',
                       'remote_system_enable_capab': 'N/A',
                       'remote_system_name': 'N/A'}],
 'FastEthernet0/24': [{'parent_interface': 'N/A',
                       'remote_chassis_id': 'a40c.c3c1.3980',
                       'remote_port': 'Fa0/19',
                       'remote_port_description': 'FastEthernet0/19',
                       'remote_system_capab': 'B',
                       'remote_system_description': 'Cisco IOS Software, C2960 '
                                                    'Software '
                                                    '(C2960-LANBASEK9-M), '
                                                    'Version 15.0(1)SE2, '
                                                    'RELEASE SOFTWARE (fc3)',
                       'remote_system_enable_capab': 'B',
                       'remote_system_name': 'xwbs032101'}]}
```