### PR TITLE
junos: support edit/top keywords in set based configs

### DIFF
--- a/napalm/junos/junos.py
+++ b/napalm/junos/junos.py
@@ -190,6 +190,8 @@ class JunOSDriver(NetworkDriver):
             'protect',
             'rename',
             'unprotect',
+            'edit',
+            'top',
         ]
         if config.strip().startswith('<'):
             return 'xml'


### PR DESCRIPTION
This PR adds support for `edit` and `top` keywords in `set` based configuration in Junos. The `edit` is used instead of `set` if one needs to add comments using the `annotate` statement as you need to be at the right hierarchy level 

For instance:
```
top edit system ntp
annotate peer 1.1.1.1 "Test ntp server"

system {
    ntp {
        /* Test ntp server */
        peer 1.1.1.1;
        peer 2.2.2.2;
    }
}
```
One cannot add a comment with a single set command

