### PR TITLE
Add driver_path to make it easier to find templates

### DIFF
--- a/napalm/base/base.py
+++ b/napalm/base/base.py
@@ -1629,3 +1629,8 @@ class NetworkDriver(object):
             return napalm.base.helpers.canonical_interface_name(interface, addl_name_map=None)
         else:
             return interface
+
+    @staticmethod
+    def _driver_path():
+        """Return the path to the current driver."""
+        raise NotImplementedError

--- a/napalm/base/helpers.py
+++ b/napalm/base/helpers.py
@@ -102,8 +102,7 @@ def textfsm_extractor(cls, template_name, raw_text):
     :return: table-like list of entries
     """
     textfsm_data = list()
-    cls.__class__.__name__.replace('Driver', '')
-    current_dir = os.path.dirname(os.path.abspath(sys.modules[cls.__module__].__file__))
+    current_dir = cls._driver_path()
     template_dir_path = '{current_dir}/utils/textfsm_templates'.format(
         current_dir=current_dir
     )

--- a/napalm/eos/eos.py
+++ b/napalm/eos/eos.py
@@ -21,6 +21,7 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 # std libs
+import os
 import re
 import time
 
@@ -1783,3 +1784,8 @@ class EOSDriver(NetworkDriver):
                     })
             ping_dict['success'].update({'results': results_array})
         return ping_dict
+
+    @staticmethod
+    def _driver_path():
+        """Return the path to the current driver."""
+        return os.path.dirname(__file__)

--- a/napalm/ios/ios.py
+++ b/napalm/ios/ios.py
@@ -2424,3 +2424,8 @@ class IOSDriver(NetworkDriver):
         if self.device and self._dest_file_system is None:
             self._dest_file_system = self._discover_file_system()
         return self._dest_file_system
+
+    @staticmethod
+    def _driver_path():
+        """Return the path to the current driver."""
+        return os.path.dirname(__file__)

--- a/napalm/nxos/nxos.py
+++ b/napalm/nxos/nxos.py
@@ -16,6 +16,7 @@
 from __future__ import unicode_literals
 
 # import stdlib
+import os
 import re
 import time
 import tempfile
@@ -1111,3 +1112,8 @@ class NXOSDriver(NXOSDriverBase):
             _cmd = 'show startup-config'
             config['startup'] = py23_compat.text_type(self.cli([_cmd]).get(_cmd))
         return config
+
+    @staticmethod
+    def _driver_path():
+        """Return the path to the current driver."""
+        return os.path.dirname(__file__)

--- a/napalm/nxos_ssh/nxos_ssh.py
+++ b/napalm/nxos_ssh/nxos_ssh.py
@@ -1516,3 +1516,8 @@ class NXOSSSHDriver(NXOSDriverBase):
             command = 'show startup-config'
             config['startup'] = py23_compat.text_type(self.device.send_command(command))
         return config
+
+    @staticmethod
+    def _driver_path():
+        """Return the path to the current driver."""
+        return os.path.dirname(__file__)

--- a/test/base/test_helpers.py
+++ b/test/base/test_helpers.py
@@ -538,3 +538,8 @@ class FakeNetworkDriver(NetworkDriver):
         will return True instead of raising NotImplementedError exception.
         """
         return True
+
+    @staticmethod
+    def _driver_path():
+        """Return the path to the current driver."""
+        return os.path.dirname(__file__)


### PR DESCRIPTION
The path for the textfsm templates was wrong when you inherited from
a driver class.

As I mentioned regarding the problem I saw with napalm-inspector and anyone who would want to extend a driver might experience. Looks like ios was the only driver that needed the new method for the tests to run, but I added it to all the drivers which had a textfsm folder under the utils directory.