### PR TITLE
Delete the ip validation of the destination of get_route_to in junos

### DIFF
--- a/napalm/junos/junos.py
+++ b/napalm/junos/junos.py
@@ -1616,7 +1616,7 @@ class JunOSDriver(NetworkDriver):
             d = {}
             # next_hop = route[0]
             d = {elem[0]: elem[1] for elem in route[1]}
-            destination = napalm.base.helpers.ip(d.pop('destination', ''))
+            destination = d.pop('destination', '')
             prefix_length = d.pop('prefix_length', 32)
             destination = '{d}/{p}'.format(
                 d=destination,


### PR DESCRIPTION
#802 
Destination in get_route_to other than junos (eg iosxr / eos) does not validate ip.
Also, there is a possibility that non-IP will be included in destionation in any OS. (VPNv 4)

junos has already parsed the value you get from the rpc response using `junos_views.yaml`.(https://github.com/napalm-automation/napalm/blob/develop/napalm/junos/utils/junos_views.yml) 

I think it was not necessary to verify the IP here.