### PR TITLE
Raise exception instead of returning string in `e.E.get_route_to()`

### DIFF
--- a/napalm/eos/eos.py
+++ b/napalm/eos/eos.py
@@ -1067,12 +1067,9 @@ class EOSDriver(NetworkDriver):
         if protocol.lower() == 'direct':
             protocol = 'connected'
 
-        try:
-            ipv = ''
-            if IPNetwork(destination).version == 6:
-                ipv = 'v6'
-        except AddrFormatError:
-            return 'Please specify a valid destination!'
+        ipv = ''
+        if IPNetwork(destination).version == 6:
+            ipv = 'v6'
 
         commands = []
         for _vrf in vrfs:


### PR DESCRIPTION
If a bad destination is provided, raise an exception instead of returning a string.