### PR TITLE
Convert over to safe form of YAML load

### DIFF
--- a/napalm/base/validate.py
+++ b/napalm/base/validate.py
@@ -22,7 +22,7 @@ def _get_validation_file(validation_file):
     try:
         with open(validation_file, 'r') as stream:
             try:
-                validation_source = yaml.load(stream)
+                validation_source = yaml.safe_load(stream)
             except yaml.YAMLError as exc:
                 raise ValidationException(exc)
     except IOError:

--- a/napalm/junos/utils/junos_views.py
+++ b/napalm/junos/utils/junos_views.py
@@ -17,7 +17,7 @@ def _preprocess_yml(path):
 
 def _loadyaml_bypass(yaml_str):
     """Bypass Juniper's loadyaml and directly call FactoryLoader"""
-    return FactoryLoader().load(yaml.load(yaml_str))
+    return FactoryLoader().load(yaml.safe_load(yaml_str))
 
 
 _YAML_ = splitext(__file__)[0] + '.yml'

--- a/test/junos/conftest.py
+++ b/test/junos/conftest.py
@@ -86,7 +86,7 @@ class FakeJunOSDevice(BaseTestDouble):
             self._facts = self.default_facts
             return self._facts
         with open(alt_facts_filepath, 'r') as alt_facts:
-            self._facts.update(yaml.load(alt_facts))
+            self._facts.update(yaml.safe_load(alt_facts))
         return self._facts
 
     @property


### PR DESCRIPTION
The default version of yaml.load allows you to load arbitrary python code (which we don't need/don't want).

Converting over to the safe_load which doesn't allow this.