### PR TITLE
QFX5100-48S-6Q to use rpc_call_without_information

### DIFF
--- a/napalm/junos/junos.py
+++ b/napalm/junos/junos.py
@@ -760,6 +760,7 @@ class JunOSDriver(NetworkDriver):
                 'EX3400': rpc_call_without_information,
                 'EX4300-48P': rpc_call_without_information,
                 'EX4600-40F': rpc_call_without_information,
+                'QFX5100-48S-6Q': rpc_call_without_information,
                 'QFX5110-48S-4C': rpc_call_without_information,
                 'QFX10002-36Q': rpc_call_without_information,
                 'QFX10008': rpc_call_without_information,


### PR DESCRIPTION
Include SW model QFX5100-48S-6Q to use rpc_call_without_information.
I encountered problems using lldp_neighbors_detail() for this switch model using Junos 17.3R3.9.
Modifying the RPC call fixes the issue like in other models.