### PR TITLE
junos cli function: all pipes ignored ?

### DIFF
--- a/napalm/junos/junos.py
+++ b/napalm/junos/junos.py
@@ -887,7 +887,7 @@ class JunOSDriver(NetworkDriver):
             Process CLI output from Juniper device that
             doesn't allow piping the output.
             '''
-            if txt is not None:
+            if txt is None:
                 return txt
             _OF_MAP = OrderedDict()
             _OF_MAP['except'] = _except


### PR DESCRIPTION
That's strange but it would seem that with the current code, because of that one line, all pipes are ignored for junos `cli` function. 
I don't have access to any juniper device so I cannot test. If I'm right, it probably means that there should be unit tests with pipes for that `cli` function.