### PR TITLE
Update pynxos to 0.0.4 and add verify optional_args to nxos

### DIFF
--- a/docs/support/index.rst
+++ b/docs/support/index.rst
@@ -128,6 +128,7 @@ ____________________________________
 * :code:`transport` (eos, ios, nxos) - Protocol to connect with (see `The transport argument`_ for more information).
 * :code:`use_keys` (ios, iosxr, nxos_ssh) - Paramiko argument, enable searching for discoverable private key files in ``~/.ssh/`` (default: ``False``).
 * :code:`eos_autoComplete` (eos) - Allows to set `autoComplete` when running commands. (default: ``None`` equivalent to ``False``)
+* :code:`verify` (nxos) - Requests argument, enable the SSL certificates verification. See requests ssl-cert-verification for valide values (default: ``None`` equivalent to ``False``).
 
 The transport argument
 ______________________

--- a/docs/support/index.rst
+++ b/docs/support/index.rst
@@ -125,10 +125,10 @@ ____________________________________
 * :code:`secret` (ios, nxos_ssh) - Password required to enter privileged exec (enable) (default: ``''``).
 * :code:`ssh_config_file` (ios, iosxr, junos, nxos_ssh) - File name of OpenSSH configuration file.
 * :code:`ssh_strict` (ios, iosxr, nxos_ssh) - Automatically reject unknown SSH host keys (default: ``False``, which means unknown SSH host keys will be accepted).
+* :code:`ssl_verify` (nxos) - Requests argument, enable the SSL certificates verification. See requests ssl-cert-verification for valide values (default: ``None`` equivalent to ``False``).
 * :code:`transport` (eos, ios, nxos) - Protocol to connect with (see `The transport argument`_ for more information).
 * :code:`use_keys` (ios, iosxr, nxos_ssh) - Paramiko argument, enable searching for discoverable private key files in ``~/.ssh/`` (default: ``False``).
 * :code:`eos_autoComplete` (eos) - Allows to set `autoComplete` when running commands. (default: ``None`` equivalent to ``False``)
-* :code:`verify` (nxos) - Requests argument, enable the SSL certificates verification. See requests ssl-cert-verification for valide values (default: ``None`` equivalent to ``False``).
 
 The transport argument
 ______________________

--- a/napalm/nxos/nxos.py
+++ b/napalm/nxos/nxos.py
@@ -199,6 +199,8 @@ class NXOSDriver(NXOSDriverBase):
         elif self.transport == 'http':
             self.port = optional_args.get('port', 80)
 
+        self.verify = optional_args.get('verify', False)
+
     def open(self):
         try:
             self.device = NXOSDevice(self.hostname,
@@ -206,7 +208,8 @@ class NXOSDriver(NXOSDriverBase):
                                      self.password,
                                      timeout=self.timeout,
                                      port=self.port,
-                                     transport=self.transport)
+                                     transport=self.transport,
+                                     verify=self.verify)
             self.device.show('show hostname')
             self.up = True
         except (CLIError, ValueError):

--- a/napalm/nxos/nxos.py
+++ b/napalm/nxos/nxos.py
@@ -199,7 +199,7 @@ class NXOSDriver(NXOSDriverBase):
         elif self.transport == 'http':
             self.port = optional_args.get('port', 80)
 
-        self.verify = optional_args.get('verify', False)
+        self.ssl_verify = optional_args.get('verify', False)
 
     def open(self):
         try:
@@ -209,7 +209,7 @@ class NXOSDriver(NXOSDriverBase):
                                      timeout=self.timeout,
                                      port=self.port,
                                      transport=self.transport,
-                                     verify=self.verify)
+                                     verify=self.ssl_verify)
             self.device.show('show hostname')
             self.up = True
         except (CLIError, ValueError):

--- a/napalm/nxos/nxos.py
+++ b/napalm/nxos/nxos.py
@@ -199,7 +199,7 @@ class NXOSDriver(NXOSDriverBase):
         elif self.transport == 'http':
             self.port = optional_args.get('port', 80)
 
-        self.ssl_verify = optional_args.get('verify', False)
+        self.ssl_verify = optional_args.get('ssl_verify', False)
 
     def open(self):
         try:

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,5 +9,5 @@ pyeapi
 netmiko>=2.1.1
 pyIOSXR>=0.53
 junos-eznc>=2.1.5
-pynxos==0.0.3
+pynxos>=0.0.4
 scp


### PR DESCRIPTION
Update current version of pynxos >= 0.0.4: #784
Verify argument is exposed via ``verify`` key in ``optional_args``. It defaults to ``False`` for compatibility and can be set to ``True`` or any value allowed by requests library.
I kept the InsecureRequestWarning warnings from urllib3on purpose. These warnings can be easily blacked out.

I don't knwo how this code can be tested as the mocked driver use for the test bypass the open method.
I have just tested it against a live device.