### PR TITLE
Prevent validation_source modification in validation process

### DIFF
--- a/napalm/base/validate.py
+++ b/napalm/base/validate.py
@@ -180,6 +180,9 @@ def compliance_report(cls, validation_file=None, validation_source=None):
     if validation_file:
         validation_source = _get_validation_file(validation_file)
 
+    # Otherwise we are going to modify a "live" object
+    validation_source = copy.deepcopy(validation_source)
+
     for validation_check in validation_source:
         for getter, expected_results in validation_check.items():
             if getter == "get_config":

--- a/test/base/validate/test_validate.py
+++ b/test/base/validate/test_validate.py
@@ -143,6 +143,17 @@ class TestValidate:
 
         assert expected_report == actual_report, yaml.safe_dump(actual_report)
 
+    def test_immutable_validation_source(self):
+        """Test validation_source is not modified."""
+        mocked_data = os.path.join(BASEPATH, "mocked_data", "strict_pass_skip")
+
+        device = FakeDriver(mocked_data)
+        source = _read_yaml(os.path.join(mocked_data, "validate.yml"))
+        witness = _read_yaml(os.path.join(mocked_data, "validate.yml"))
+        device.compliance_report(validation_source=source)
+
+        assert source == witness, yaml.safe_dump(source)
+
 
 class FakeDriver(NetworkDriver):
     """This is a fake NetworkDriver."""


### PR DESCRIPTION
Fixes #827
The validation operations in ```napalm/base/validate.py``` were modifying the source dictionnary passed as argument of ```compliance_report```.
This PR copy the original dictionnary to keep it untouched.

I have not seen any interest in creating another dataset for the tests. I used an existing one.