### PR TITLE
update docs with load conf methods not supported for vEOS < 4.15

### DIFF
--- a/docs/support/eos.rst
+++ b/docs/support/eos.rst
@@ -4,7 +4,7 @@ EOS
 Minimum Version
 ~~~~~~~~~~~~~~~
 
-To be able to support the ``compare_config`` method you will require to run at least EOS version `4.15.0F`.
+To be able to support the ``compare_config``, ``load_merge_candidate`` or ``load_replace_candidate`` methods you will require to run at least EOS version `4.15.0F`.
 
 Multi-line/HEREDOC
 ~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
On vEOS 4.14.6M we get the following error with ``load candidate`` methods:
```pyeapi.eapilib.CommandError: Error [1003]: CLI command 2 of 2 'show configuration sessions' failed: unconverted command```