### PR TITLE
IOS get_bgp_neighbors check for None type neighbor_entry - Fix #843

### DIFF
--- a/napalm/ios/ios.py
+++ b/napalm/ios/ios.py
@@ -1279,7 +1279,10 @@ class IOSDriver(NetworkDriver):
                         napalm.base.helpers.ip(neighbor['remote_addr']) == remote_addr):
                     neighbor_entry = neighbor
                     break
-            if not isinstance(neighbor_entry, dict):
+            # check for proper session data for the afi
+            if neighbor_entry is None:
+                continue
+            elif not isinstance(neighbor_entry, dict):
                 raise ValueError(msg="Couldn't find neighbor data for %s in afi %s" %
                                      (remote_addr, afi))
 


### PR DESCRIPTION
For IOS getter get_bgp_neighbors(), if a neighbor shows up with a supported AFI, but no info under that AFI, a ValueError is raised, which causes a TypeError since the neighbor_entry is None. Skipping the neighbor/afi seems like an acceptable solution.