### PR TITLE
Enforce Paramiko >= 2.4.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 setuptools>=38.4.0
 cffi>=1.11.3
+paramiko>=2.4.2
 future
 textfsm
 jinja2


### PR DESCRIPTION
This is due to CVE-2018-7750 and CVE-2018-1000805, and the underlying libraries may not have this requirement.

See https://nvd.nist.gov/vuln/detail/CVE-2018-7750 and https://nvd.nist.gov/vuln/detail/CVE-2018-1000805 for further details.