### PR TITLE
Fix TypeError in mock driver initialization

### DIFF
--- a/docs/tutorials/mock_driver.rst
+++ b/docs/tutorials/mock_driver.rst
@@ -38,7 +38,7 @@ And instantiate it with any host and credentials::
 
 Like other drivers, ``mock`` takes optional arguments:
 
-- ``path`` - Required. Directory where results files are located
+- ``path`` - Optional directory where results files are located (defaults to the current directory).
 
 Open the driver::
 

--- a/napalm/base/mock.py
+++ b/napalm/base/mock.py
@@ -105,7 +105,7 @@ class MockDriver(NetworkDriver):
         self.hostname = hostname
         self.username = username
         self.password = password
-        self.path = optional_args["path"]
+        self.path = optional_args.get("path", "")
         self.profile = optional_args.get("profile", [])
         self.fail_on_open = optional_args.get("fail_on_open", False)
 


### PR DESCRIPTION
I stumbled upon this error during my tests:
`TypeError: 'NoneType' object is not subscriptable`

This is due to the fact that I was initializing the `MockDriver` without specifying a `path` to mock data in the `optional_args`. Or at this point in my tests I don't need the mock data so I'd like to be able to instantiate the driver with a default value.