### PR TITLE
Enable debugging tests in pycharm

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -26,11 +26,6 @@ python_files =
     test_*.py
     *_test.py
     tests.py
-addopts =
-    --cov=napalm
-    --cov-report term-missing
-    -vs
-    --pylama
 json_report = report.json
 jsonapi = true
 

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ deps =
     -rrequirements.txt
     -rrequirements-dev.txt
 commands =
-    py.test {posargs}
+    py.test --cov=napalm --cov-report term-missing -vs --pylama {posargs}
 
 [testenv:sphinx]
 deps = 


### PR DESCRIPTION
I struggled some time already to get the debugger on PyCharm working when running the test suite. I found out thatb ecause of the `--cov` option in `setup.cfg` this doesn't work.

ref: https://stackoverflow.com/a/40906766/10756636

This PR is to prevent other contributors that also use PyCharm from going through the same google-quest.

To prevent having command line options on 2 places, I extracted all command line options from `setup.cfg` and added them to `tox.ini`