### PR TITLE
Handle missing remote port in junos LLDP neighbors data

### DIFF
--- a/napalm/junos/junos.py
+++ b/napalm/junos/junos.py
@@ -804,7 +804,7 @@ class JunOSDriver(NetworkDriver):
                 lldp_neighbors[interface].append(
                     {
                         "parent_interface": item.parent_interface,
-                        "remote_port": item.remote_port,
+                        "remote_port": item.remote_port or "",
                         "remote_chassis_id": napalm.base.helpers.convert(
                             napalm.base.helpers.mac,
                             item.remote_chassis_id,

--- a/test/junos/mocked_data/test_get_lldp_neighbors_detail/missing_port_ids/expected_result.json
+++ b/test/junos/mocked_data/test_get_lldp_neighbors_detail/missing_port_ids/expected_result.json
@@ -7,8 +7,12 @@
       "remote_chassis_id": "0C:8D:DB:63:62:00",
       "remote_system_name": "Meraki MX64",
       "parent_interface": "-",
-      "remote_system_capab": "Router",
-      "remote_system_enable_capab": "Router"
+      "remote_system_capab": [
+        "router"
+      ],
+      "remote_system_enable_capab": [
+        "router"
+      ]
     }
   ]
 }

--- a/test/junos/mocked_data/test_get_lldp_neighbors_detail/missing_port_ids/expected_result.json
+++ b/test/junos/mocked_data/test_get_lldp_neighbors_detail/missing_port_ids/expected_result.json
@@ -1,0 +1,14 @@
+{
+  "fe-0/0/2.0": [
+    {
+      "remote_port_description": "lan port 0",
+      "remote_port": "",
+      "remote_system_description": "Meraki MX64 Cloud Managed Router",
+      "remote_chassis_id": "0C:8D:DB:63:62:00",
+      "remote_system_name": "Meraki MX64",
+      "parent_interface": "-",
+      "remote_system_capab": "Router",
+      "remote_system_enable_capab": "Router"
+    }
+  ]
+}

--- a/test/junos/mocked_data/test_get_lldp_neighbors_detail/missing_port_ids/facts.yml
+++ b/test/junos/mocked_data/test_get_lldp_neighbors_detail/missing_port_ids/facts.yml
@@ -1,0 +1,2 @@
+personality: SWITCH
+switch_style: VLAN

--- a/test/junos/mocked_data/test_get_lldp_neighbors_detail/missing_port_ids/get-lldp-interface-neighbors-information.xml
+++ b/test/junos/mocked_data/test_get_lldp_neighbors_detail/missing_port_ids/get-lldp-interface-neighbors-information.xml
@@ -1,0 +1,22 @@
+<lldp-neighbors-information style="detail">
+    <lldp-neighbor-information>
+        <lldp-index>2</lldp-index>
+        <lldp-ttl>120</lldp-ttl>
+        <lldp-timemark>Wed Dec 19 15:31:28 2018</lldp-timemark>
+        <lldp-age>31</lldp-age>
+        <lldp-local-interface>fe-0/0/2.0</lldp-local-interface>
+        <lldp-local-parent-interface-name>-</lldp-local-parent-interface-name>
+        <lldp-local-port-id>521</lldp-local-port-id>
+        <lldp-local-port-ageout-count>0</lldp-local-port-ageout-count>
+        <lldp-remote-chassis-id-subtype>Mac address</lldp-remote-chassis-id-subtype>
+        <lldp-remote-chassis-id>0c:8d:db:63:62:00</lldp-remote-chassis-id>
+        <lldp-remote-port-id-subtype>Interface alias</lldp-remote-port-id-subtype>
+        <lldp-remote-port-description>lan port 0</lldp-remote-port-description>
+        <lldp-remote-system-name>Meraki MX64</lldp-remote-system-name>
+        <lldp-system-description>
+            <lldp-remote-system-description>Meraki MX64 Cloud Managed Router</lldp-remote-system-description>
+        </lldp-system-description>
+        <lldp-remote-system-capabilities-supported>Router </lldp-remote-system-capabilities-supported>
+        <lldp-remote-system-capabilities-enabled>Router </lldp-remote-system-capabilities-enabled>
+    </lldp-neighbor-information>
+</lldp-neighbors-information>

--- a/test/junos/mocked_data/test_get_lldp_neighbors_detail/missing_port_ids/get-lldp-neighbors-information.xml
+++ b/test/junos/mocked_data/test_get_lldp_neighbors_detail/missing_port_ids/get-lldp-neighbors-information.xml
@@ -1,0 +1,10 @@
+<lldp-neighbors-information style="brief">
+    <lldp-neighbor-information>
+        <lldp-local-interface>fe-0/0/2.0</lldp-local-interface>
+        <lldp-local-parent-interface-name>-</lldp-local-parent-interface-name>
+        <lldp-remote-chassis-id-subtype>Mac address</lldp-remote-chassis-id-subtype>
+        <lldp-remote-chassis-id>0c:8d:db:63:62:00</lldp-remote-chassis-id>
+        <lldp-remote-port-description>lan port 0</lldp-remote-port-description>
+        <lldp-remote-system-name>Meraki MX64</lldp-remote-system-name>
+    </lldp-neighbor-information>
+</lldp-neighbors-information>


### PR DESCRIPTION
Handle missing remote port in junos LLDP neighbors data.
In case there's no remote port, it'll return `None` instead of an empty string `""`