### PR TITLE
Update EOS LLDP type constant map.  Fixes #903

### DIFF
--- a/napalm/eos/constants.py
+++ b/napalm/eos/constants.py
@@ -9,4 +9,5 @@ LLDP_CAPAB_TRANFORM_TABLE = {
     "telephone": "telephone",
     "docsis": "docsis-cable-device",
     "station": "station",
+    "stationonly": "station",
 }

--- a/test/eos/mocked_data/test_get_lldp_neighbors_detail/issue903/expected_result.json
+++ b/test/eos/mocked_data/test_get_lldp_neighbors_detail/issue903/expected_result.json
@@ -1,0 +1,21 @@
+{
+  "Ethernet22": [
+    {
+      "parent_interface": "Ethernet22",
+      "remote_port": "000c.297b.d2a8",
+      "remote_port_description": "eth0",
+      "remote_system_name": "linux",
+      "remote_system_description": "CentOS Linux 7 (Core) Linux 4.9.46 #1 SMP PREEMPT Wed Aug 30 15:24:09 UTC 2017 x86_64",
+      "remote_chassis_id": "00:0C:29:7B:D2:A8",
+      "remote_system_capab": [
+        "bridge",
+        "router",
+        "station",
+        "wlan-access-point"
+      ],
+      "remote_system_enable_capab": [
+        "station"
+      ]
+    }
+  ]
+}

--- a/test/eos/mocked_data/test_get_lldp_neighbors_detail/issue903/show_lldp_neighbors__detail.json
+++ b/test/eos/mocked_data/test_get_lldp_neighbors_detail/issue903/show_lldp_neighbors__detail.json
@@ -1,0 +1,52 @@
+{
+  "lldpNeighbors": {
+    "Ethernet22": {
+      "lldpNeighborInfo": [
+        {
+          "systemCapabilities": {
+            "bridge": false,
+            "wlanAccessPoint": false,
+            "router": false,
+            "stationOnly": true
+          },
+          "lastChangeTime": 1544636077.4653718,
+          "neighborInterfaceInfo": {
+            "portAndProtocolVlanEnabled": {},
+            "linkAggregationStatus": "capableAndDisabled",
+            "unknownTlvs": [],
+            "interfaceIdType": "macAddress",
+            "interfaceId": "000c.297b.d2a8",
+            "interfaceDescription": "eth0",
+            "autoNegCapability": "capableAndEnabled",
+            "autoNegAdvertisedCapabilities": [
+              "1000BASE-T (full-duplex)",
+              "Other"
+            ],
+            "protocolIdentityInfo": [],
+            "portAndProtocolVlanSupported": {},
+            "operMauType": "10GBASE-LR",
+            "vlanNames": {},
+            "linkAggregationInterfaceId": 0,
+            "unknownOrgDefinedTlvs": []
+          },
+          "neighborDiscoveryTime": 1544636077.4653718,
+          "lastContactTime": 1546981809.8182333,
+          "chassisId": "00c.297b.d2a8",
+          "systemName": "linux",
+          "systemDescription": "CentOS Linux 7 (Core) Linux 4.9.46 #1 SMP PREEMPT Wed Aug 30 15:24:09 UTC 2017 x86_64",
+          "ttl": 120,
+          "managementAddresses": [
+            {
+              "oidString": "",
+              "interfaceNumType": "ifIndex",
+              "interfaceNum": 2,
+              "address": "10.199.1.22",
+              "addressType": "ipv4"
+            }
+          ],
+          "chassisIdType": "macAddress"
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
If anyone has any additional device output that highlights the JSON keywords for the other station types, it would be appreciated.