### PR TITLE
NXOS - Have get_mac_address_table return the same interface names as get_interfaces

### DIFF
--- a/napalm/nxos_ssh/nxos_ssh.py
+++ b/napalm/nxos_ssh/nxos_ssh.py
@@ -998,7 +998,7 @@ class NXOSSSHDriver(NXOSDriverBase):
                 active = False
             return {
                 "mac": helpers.mac(mac),
-                "interface": interface,
+                "interface": helpers.canonical_interface_name(interface),
                 "vlan": int(vlan),
                 "static": static,
                 "active": active,

--- a/test/nxos_ssh/mocked_data/test_get_mac_address_table/alternate/expected_result.json
+++ b/test/nxos_ssh/mocked_data/test_get_mac_address_table/alternate/expected_result.json
@@ -2,7 +2,7 @@
   {
     "vlan": 110,
     "last_move": -1,
-    "interface": "Po28",
+    "interface": "Port-channel28",
     "mac": "00:18:74:1C:40:00",
     "static": false,
     "active": true,
@@ -11,7 +11,7 @@
   {
     "vlan": 202,
     "last_move": -1,
-    "interface": "Eth51/1/11",
+    "interface": "Ethernet51/1/11",
     "mac": "00:50:56:9A:7B:6B",
     "static": false,
     "active": true,
@@ -20,7 +20,7 @@
   {
     "vlan": 986,
     "last_move": -1,
-    "interface": "Po28",
+    "interface": "Port-channel28",
     "mac": "00:00:0C:07:AC:F0",
     "static": false,
     "active": true,
@@ -29,7 +29,7 @@
   {
     "vlan": 989,
     "last_move": -1,
-    "interface": "Po28",
+    "interface": "Port-channel28",
     "mac": "00:00:0C:07:AC:EF",
     "static": false,
     "active": true,
@@ -38,7 +38,7 @@
   {
     "vlan": 989,
     "last_move": -1,
-    "interface": "Po28",
+    "interface": "Port-channel28",
     "mac": "00:18:74:1C:40:00",
     "static": false,
     "active": true,
@@ -47,7 +47,7 @@
   {
     "vlan": 393,
     "last_move": -1,
-    "interface": "Eth51/1/16",
+    "interface": "Ethernet51/1/16",
     "mac": "00:1B:4F:03:56:20",
     "static": false,
     "active": true,
@@ -56,7 +56,7 @@
   {
     "vlan": 393,
     "last_move": -1,
-    "interface": "Eth51/1/16",
+    "interface": "Ethernet51/1/16",
     "mac": "00:1B:4F:11:2C:7C",
     "static": false,
     "active": true,
@@ -65,7 +65,7 @@
   {
     "vlan": 299,
     "last_move": -1,
-    "interface": "Eth52/1/29",
+    "interface": "Ethernet52/1/29",
     "mac": "00:CA:FE:19:47:76",
     "static": false,
     "active": true,
@@ -74,7 +74,7 @@
   {
     "vlan": 358,
     "last_move": -1,
-    "interface": "Eth52/1/4",
+    "interface": "Ethernet52/1/4",
     "mac": "00:CA:FE:31:68:82",
     "static": false,
     "active": true,
@@ -83,7 +83,7 @@
   {
     "vlan": 393,
     "last_move": -1,
-    "interface": "Eth51/1/16",
+    "interface": "Ethernet51/1/16",
     "mac": "00:CA:FE:54:21:07",
     "static": false,
     "active": true,
@@ -92,7 +92,7 @@
   {
     "vlan": 388,
     "last_move": -1,
-    "interface": "Po28",
+    "interface": "Port-channel28",
     "mac": "00:50:56:9F:79:30",
     "static": false,
     "active": true,
@@ -101,7 +101,7 @@
   {
     "vlan": 299,
     "last_move": -1,
-    "interface": "Eth52/1/30",
+    "interface": "Ethernet52/1/30",
     "mac": "00:50:56:9F:7A:74",
     "static": false,
     "active": true,
@@ -110,7 +110,7 @@
   {
     "vlan": 388,
     "last_move": -1,
-    "interface": "Po28",
+    "interface": "Port-channel28",
     "mac": "00:50:56:9F:7B:98",
     "static": false,
     "active": true,
@@ -119,7 +119,7 @@
   {
     "vlan": 299,
     "last_move": -1,
-    "interface": "Eth52/1/26",
+    "interface": "Ethernet52/1/26",
     "mac": "00:50:56:9F:7B:A2",
     "static": false,
     "active": true,
@@ -128,7 +128,7 @@
   {
     "vlan": 388,
     "last_move": -1,
-    "interface": "Po28",
+    "interface": "Port-channel28",
     "mac": "00:50:56:9F:7E:9A",
     "static": false,
     "active": true,
@@ -137,7 +137,7 @@
   {
     "vlan": 388,
     "last_move": -1,
-    "interface": "Po28",
+    "interface": "Port-channel28",
     "mac": "00:50:56:9F:7E:E5",
     "static": false,
     "active": true,
@@ -146,7 +146,7 @@
   {
     "vlan": 388,
     "last_move": -1,
-    "interface": "Po28",
+    "interface": "Port-channel28",
     "mac": "00:50:56:9F:7F:02",
     "static": false,
     "active": true,

--- a/test/nxos_ssh/mocked_data/test_get_mac_address_table/multiple_interfaces/expected_result.json
+++ b/test/nxos_ssh/mocked_data/test_get_mac_address_table/multiple_interfaces/expected_result.json
@@ -5,7 +5,7 @@
 		"active": true,
 		"mac": "A0:36:9F:44:5A:F1",
 		"static": false,
-		"interface": "Po1",
+		"interface": "Port-channel1",
 		"moves": -1
 	}, {
 		"vlan": 3,
@@ -13,7 +13,7 @@
 		"active": true,
 		"mac": "A6:02:07:6B:8B:0D",
 		"static": false,
-		"interface": "Po2",
+		"interface": "Port-channel2",
 		"moves": -1
 	}, {
 		"vlan": 3,
@@ -21,7 +21,7 @@
 		"active": true,
 		"mac": "F6:0C:BE:90:7A:07",
 		"static": false,
-		"interface": "Po2",
+		"interface": "Port-channel2",
 		"moves": -1
 	}, {		
         "vlan": 3,
@@ -29,7 +29,7 @@
 		"active": true,
 		"mac": "F6:0C:BE:90:7A:07",
 		"static": false,
-		"interface": "Eth1/1",
+		"interface": "Ethernet1/1",
 		"moves": -1
 	}, {
 		"vlan": 110,
@@ -37,7 +37,7 @@
 		"active": false,
 		"mac": "01:00:5E:00:01:18",
 		"static": false,
-		"interface": "Po1",
+		"interface": "Port-channel1",
 		"moves": -1
 	}, {
 		"vlan": 110,
@@ -45,7 +45,7 @@
 		"active": false,
 		"mac": "01:00:5E:00:01:18",
 		"static": false,
-		"interface": "Po2",
+		"interface": "Port-channel2",
 		"moves": -1
 	}, {
 		"vlan": 110,
@@ -53,7 +53,7 @@
 		"active": false,
 		"mac": "01:00:5E:00:01:18",
 		"static": false,
-		"interface": "Eth142/1/1",
+		"interface": "Ethernet142/1/1",
 		"moves": -1
 	}, {
 		"vlan": 110,
@@ -61,7 +61,7 @@
 		"active": false,
 		"mac": "01:00:5E:00:01:18",
 		"static": false,
-		"interface": "Eth112/1/6",
+		"interface": "Ethernet112/1/6",
 		"moves": -1
 	}, {
 		"vlan": 110,
@@ -69,7 +69,7 @@
 		"active": false,
 		"mac": "01:00:5E:00:01:18",
 		"static": false,
-		"interface": "Eth122/1/5",
+		"interface": "Ethernet122/1/5",
 		"moves": -1
 	}, {
 		"vlan": 96,
@@ -77,7 +77,7 @@
 		"active": false,
 		"mac": "01:00:5E:05:06:07",
 		"static": false,
-		"interface": "Po1",
+		"interface": "Port-channel1",
 		"moves": -1
 	}, {
 		"vlan": 96,
@@ -85,7 +85,7 @@
 		"active": false,
 		"mac": "01:00:5E:05:06:07",
 		"static": false,
-		"interface": "Po2",
+		"interface": "Port-channel2",
 		"moves": -1
 	}, {
 		"vlan": 96,
@@ -93,7 +93,7 @@
 		"active": false,
 		"mac": "01:00:5E:05:06:07",
 		"static": false,
-		"interface": "Eth142/1/2",
+		"interface": "Ethernet142/1/2",
 		"moves": -1
 	}, {
 		"vlan": 96,
@@ -101,7 +101,7 @@
 		"active": false,
 		"mac": "01:00:5E:05:06:07",
 		"static": false,
-		"interface": "Eth142/1/3",
+		"interface": "Ethernet142/1/3",
 		"moves": -1
 	}, {
 		"vlan": 96,
@@ -109,7 +109,7 @@
 		"active": false,
 		"mac": "01:00:5E:05:06:07",
 		"static": false,
-		"interface": "Eth121/1/2",
+		"interface": "Ethernet121/1/2",
 		"moves": -1
 	}, {
 		"vlan": 96,
@@ -117,7 +117,7 @@
 		"active": false,
 		"mac": "01:00:5E:05:06:07",
 		"static": false,
-		"interface": "Eth132/1/1",
+		"interface": "Ethernet132/1/1",
 		"moves": -1
 	}, {
 		"vlan": 96,
@@ -125,7 +125,7 @@
 		"active": false,
 		"mac": "01:00:5E:05:06:07",
 		"static": false,
-		"interface": "Eth132/1/4",
+		"interface": "Ethernet132/1/4",
 		"moves": -1
 	}, {
 		"vlan": 96,
@@ -133,7 +133,7 @@
 		"active": false,
 		"mac": "01:00:5E:05:06:07",
 		"static": false,
-		"interface": "Eth141/1/1",
+		"interface": "Ethernet141/1/1",
 		"moves": -1
 	}, {
 		"vlan": 96,
@@ -141,7 +141,7 @@
 		"active": false,
 		"mac": "01:00:5E:05:06:07",
 		"static": false,
-		"interface": "Eth141/1/2",
+		"interface": "Ethernet141/1/2",
 		"moves": -1
 	}, {
 		"vlan": 96,
@@ -149,7 +149,7 @@
 		"active": false,
 		"mac": "01:00:5E:05:06:07",
 		"static": false,
-		"interface": "Eth112/1/6",
+		"interface": "Ethernet112/1/6",
 		"moves": -1
 	}, {
 		"vlan": 96,
@@ -157,7 +157,7 @@
 		"active": false,
 		"mac": "01:00:5E:05:06:07",
 		"static": false,
-		"interface": "Eth131/1/1",
+		"interface": "Ethernet131/1/1",
 		"moves": -1
 	}, {
 		"vlan": 96,
@@ -165,7 +165,7 @@
 		"active": false,
 		"mac": "01:00:5E:05:06:07",
 		"static": false,
-		"interface": "Eth152/1/2",
+		"interface": "Ethernet152/1/2",
 		"moves": -1
 	}, {
 		"vlan": 96,
@@ -173,7 +173,7 @@
 		"active": false,
 		"mac": "01:00:5E:05:06:07",
 		"static": false,
-		"interface": "Eth152/1/3",
+		"interface": "Ethernet152/1/3",
 		"moves": -1
 	}, {
 		"vlan": 96,
@@ -181,7 +181,7 @@
 		"active": false,
 		"mac": "01:00:5E:05:06:07",
 		"static": false,
-		"interface": "Eth151/1/2",
+		"interface": "Ethernet151/1/2",
 		"moves": -1
 	}, {
 		"vlan": 96,
@@ -189,7 +189,7 @@
 		"active": false,
 		"mac": "01:00:5E:05:06:07",
 		"static": false,
-		"interface": "Eth151/1/3",
+		"interface": "Ethernet151/1/3",
 		"moves": -1
 	}, {
 		"vlan": 96,
@@ -197,7 +197,7 @@
 		"active": false,
 		"mac": "01:00:5E:05:06:07",
 		"static": false,
-		"interface": "Eth151/1/6",
+		"interface": "Ethernet151/1/6",
 		"moves": -1
 	}, {
 		"vlan": 96,
@@ -205,7 +205,7 @@
 		"active": false,
 		"mac": "01:00:5E:7F:FF:FD",
 		"static": false,
-		"interface": "Po1",
+		"interface": "Port-channel1",
 		"moves": -1
 	}, {
 		"vlan": 96,
@@ -213,7 +213,7 @@
 		"active": false,
 		"mac": "01:00:5E:7F:FF:FD",
 		"static": false,
-		"interface": "Po2",
+		"interface": "Port-channel2",
 		"moves": -1
 	}, {
 		"vlan": 96,
@@ -221,7 +221,7 @@
 		"active": false,
 		"mac": "01:00:5E:7F:FF:FD",
 		"static": false,
-		"interface": "Eth112/1/4",
+		"interface": "Ethernet112/1/4",
 		"moves": -1
 	}, {
 		"vlan": 96,
@@ -229,7 +229,7 @@
 		"active": false,
 		"mac": "01:00:5E:7F:FF:FD",
 		"static": false,
-		"interface": "Eth111/1/4",
+		"interface": "Ethernet111/1/4",
 		"moves": -1
 	}, {
 		"vlan": 40,
@@ -237,7 +237,7 @@
 		"active": false,
 		"mac": "01:00:5E:05:68:49",
 		"static": false,
-		"interface": "Po1",
+		"interface": "Port-channel1",
 		"moves": -1
 	}, {
 		"vlan": 40,
@@ -245,7 +245,7 @@
 		"active": false,
 		"mac": "01:00:5E:05:68:49",
 		"static": false,
-		"interface": "Po2",
+		"interface": "Port-channel2",
 		"moves": -1
 	}, {
 		"vlan": 40,
@@ -253,7 +253,7 @@
 		"active": false,
 		"mac": "01:00:5E:05:68:49",
 		"static": false,
-		"interface": "Eth112/1/2",
+		"interface": "Ethernet112/1/2",
 		"moves": -1
 	}
 ]


### PR DESCRIPTION
On NXOS SSH, the `get_interfaces()` method returns interfaces like `Ethernet1/2/3` while `get_mac_address_table()` returns them like `Eth1/2/3`.

For being able to relate the mac table to the interfaces the two should be the same.