### PR TITLE
Resolve issues in `get_interfaces()`

### DIFF
--- a/napalm/base/base.py
+++ b/napalm/base/base.py
@@ -278,7 +278,7 @@ class NetworkDriver(object):
                 'is_up': False,
                 'is_enabled': False,
                 'description': '',
-                'last_flapped': -1,
+                'last_flapped': -1.0,
                 'speed': 1000,
                 'mac_address': 'FA:16:3E:57:33:61',
                 },
@@ -305,7 +305,7 @@ class NetworkDriver(object):
                 'is_up': False,
                 'is_enabled': True,
                 'description': 'bar',
-                'last_flapped': -1,
+                'last_flapped': -1.0,
                 'speed': 1000,
                 'mac_address': 'FA:16:3E:57:33:64',
                 }

--- a/napalm/base/base.py
+++ b/napalm/base/base.py
@@ -266,7 +266,7 @@ class NetworkDriver(object):
          * is_up (True/False)
          * is_enabled (True/False)
          * description (string)
-         * last_flapped (int in seconds)
+         * last_flapped (float in seconds)
          * speed (int in Mbit)
          * mac_address (string)
 

--- a/napalm/eos/eos.py
+++ b/napalm/eos/eos.py
@@ -367,7 +367,7 @@ class EOSDriver(NetworkDriver):
             interfaces[interface]["description"] = values["description"]
 
             interfaces[interface]["last_flapped"] = values.pop(
-                "lastStatusChangeTimestamp", None
+                "lastStatusChangeTimestamp", -1.0
             )
 
             interfaces[interface]["speed"] = int(values["bandwidth"] * 1e-6)


### PR DESCRIPTION
Correct docstring regarding `last_flapped` key in return dictionary, and update EOS driver to return correct sentinel value of `-1.0` if data is not present.