### PR TITLE
New Feature: Added new get_vrrp_groups() method

### DIFF
--- a/napalm/base/base.py
+++ b/napalm/base/base.py
@@ -1644,6 +1644,83 @@ class NetworkDriver(object):
         """
         raise NotImplementedError
 
+    def get_vrrp_groups(self):
+        """
+        Return a list of dictionaries. Each dictionary represents a VRRP group/interface pair.
+        The returned dictionary has the following keys:
+
+            * interface (string)
+            * group (string)
+            * state (string)
+            * vip (string)
+            * vmac (string)
+            * interval (string)
+            * preempt (string)
+            * priority (string)
+            * master (dict)
+
+        The 'master' child dictionary has the following keys:
+
+            *  ip (string)
+            *  prio (string)
+            *  advert_interval (string)
+            *  down_interval (string)
+
+        Example::
+
+            [
+                {
+                    "vmac": "0000.5e00.0101",
+                    "group": "1",
+                    "preempt": "enabled",
+                    "interval": "1.000 sec",
+                    "vip": "100.0.100.254",
+                    "priority": "250 ",
+                    "state": "Master",
+                    "master": {
+                        "ip": "100.0.100.1 (local)",
+                        "advert_interval": "1.000 sec",
+                        "prio": "250 ",
+                        "down_interval": "3.023 sec"
+                    },
+                    "interface": "GigabitEthernet2"
+                },
+                {
+                    "vmac": "0000.5e00.0102",
+                    "group": "2",
+                    "preempt": "enabled",
+                    "interval": "1.000 sec",
+                    "vip": "100.0.101.254",
+                    "priority": "100 ",
+                    "state": "Master",
+                    "master": {
+                        "ip": "100.0.100.1 (local)",
+                        "advert_interval": "1.000 sec",
+                        "prio": "100 ",
+                        "down_interval": "3.609 sec"
+                    },
+                    "interface": "GigabitEthernet2"
+                },
+                {
+                    "vmac": "0000.5e00.0102",
+                    "group": "2",
+                    "preempt": "enabled",
+                    "interval": "1.000 sec",
+                    "vip": "100.1.1.1",
+                    "priority": "100 ",
+                    "state": "Init (interface down)",
+                    "master": {
+                        "ip": "unknown",
+                        "advert_interval": "unknown",
+                        "prio": "unknown",
+                        "down_interval": "3.609 sec"
+                    },
+                    "interface": "GigabitEthernet3"
+                }
+            ]
+        """
+        raise NotImplementedError
+
     def compliance_report(self, validation_file=None, validation_source=None):
         """
         Return a compliance report.

--- a/napalm/ios/ios.py
+++ b/napalm/ios/ios.py
@@ -2438,8 +2438,11 @@ class IOSDriver(NetworkDriver):
 
     def get_vrrp_groups(self):
         """
-        Returns a list of dictionaries. Each dictionary represents a block of VRRP group/interface pair informations.
-        Most values are stored as strings including the VRRP intervals. Use of Regex were limited for speed efficiency.
+        Returns a list of dictionaries, earch represents a block of VRRP
+        group/interface pair informations.
+
+        Most values are stored as strings including the VRRP intervals.
+        Use of Regex were limited for speed efficiency.
 
         The dictionary has the following keys:
             interface (string)

--- a/napalm/ios/ios.py
+++ b/napalm/ios/ios.py
@@ -2504,42 +2504,39 @@ class IOSDriver(NetworkDriver):
                 if len(line.split(" - ")) == 2:
                     interface, group = line.split(" - ")
                     vrrp_groups.append(
-                        {
-                            "interface": interface,
-                            "group": group.split()[1],
-                        }
+                        {"interface": interface, "group": group.split()[1]}
                     )
                 else:
                     raise ValueError("Unexpected output from: {}".format(line.split()))
 
             # State
             if line.startswith(VRRPSTATE_STR):
-                vrrp_groups[index]["state"] = line[len(VRRPSTATE_STR):]
+                vrrp_groups[index]["state"] = line[len(VRRPSTATE_STR) :]
 
             # Virtual IP Address
             if line.startswith(VRRPVIP_STR):
-                vrrp_groups[index]["vip"] = line[len(VRRPVIP_STR):]
+                vrrp_groups[index]["vip"] = line[len(VRRPVIP_STR) :]
 
             # Virtual MAC Address
             if line.startswith(VRRPVMAC_STR):
-                vrrp_groups[index]["vmac"] = line[len(VRRPVMAC_STR):]
+                vrrp_groups[index]["vmac"] = line[len(VRRPVMAC_STR) :]
 
             # Advertisement Interval
             if line.startswith(VRRPINT_STR):
-                vrrp_groups[index]["interval"] = line[len(VRRPINT_STR):]
+                vrrp_groups[index]["interval"] = line[len(VRRPINT_STR) :]
 
             # Preemption
             if line.startswith(VRRPPREEMPT_STR):
-                vrrp_groups[index]["preempt"] = line[len(VRRPPREEMPT_STR):]
+                vrrp_groups[index]["preempt"] = line[len(VRRPPREEMPT_STR) :]
 
             # Priority
             if line.startswith(VRRPPRIORITY_STR):
-                vrrp_groups[index]["priority"] = line[len(VRRPPRIORITY_STR):]
+                vrrp_groups[index]["priority"] = line[len(VRRPPRIORITY_STR) :]
 
             # Master Router
             if line.startswith(VRRPMASTER_STR):
                 vrrp_groups[index]["master"] = {}
-                vrrp_master_str = line[len(VRRPMASTER_STR):]
+                vrrp_master_str = line[len(VRRPMASTER_STR) :]
                 vrrp_master_ip = vrrp_master_str.split(",")[0]
                 vrrp_master_prio = vrrp_master_str.split("priority is ")[1]
                 vrrp_groups[index]["master"]["ip"] = vrrp_master_ip
@@ -2548,14 +2545,18 @@ class IOSDriver(NetworkDriver):
             # Master Advertisement Interval
             if line.startswith(VRRPMASTERADV_STR):
                 try:
-                    vrrp_groups[index]["master"]["advert_interval"] = line[len(VRRPMASTERADV_STR):]
+                    vrrp_groups[index]["master"]["advert_interval"] = line[
+                        len(VRRPMASTERADV_STR) :
+                    ]
                 except Exception:
                     continue
 
             # Master Down Interval
             if line.startswith(VRRPMASTERDWN_STR):
                 try:
-                    vrrp_groups[index]["master"]["down_interval"] = line[len(VRRPMASTERDWN_STR):]
+                    vrrp_groups[index]["master"]["down_interval"] = line[
+                        len(VRRPMASTERDWN_STR) :
+                    ]
                 except Exception:
                     continue
 

--- a/napalm/ios/ios.py
+++ b/napalm/ios/ios.py
@@ -2438,28 +2438,11 @@ class IOSDriver(NetworkDriver):
 
     def get_vrrp_groups(self):
         """
-        Returns a list of dictionaries, earch represents a block of VRRP
+        Returns a list of dictionaries, each represents a block of VRRP
         group/interface pair informations.
 
         Most values are stored as strings including the VRRP intervals.
         Use of Regex were limited for speed efficiency.
-
-        The dictionary has the following keys:
-            interface (string)
-            group (string)
-            state (string)
-            vip (string)
-            vmac (string)
-            interval (string)
-            preempt (string)
-            priority (string)
-            master (dict)
-
-        The 'master' dictionary has the following keys:
-            ip (string)
-            prio (string)
-            advert_interval (string)
-            down_interval (string)
 
         Format 1 - show vrrp all (Cisco IOS XE Software, Version 16.10.01a):
          GigabitEthernet2 - Group 1

--- a/test/ios/mocked_data/test_get_vrrp_groups/normal/expected_result.json
+++ b/test/ios/mocked_data/test_get_vrrp_groups/normal/expected_result.json
@@ -1,0 +1,50 @@
+[
+    {
+        "vmac": "0000.5e00.0101", 
+        "group": "1", 
+        "preempt": "enabled", 
+        "interval": "1.000 sec", 
+        "vip": "100.0.100.254", 
+        "priority": "250 ", 
+        "state": "Master", 
+        "master": {
+            "ip": "100.0.100.1 (local)", 
+            "advert_interval": "1.000 sec", 
+            "prio": "250 ", 
+            "down_interval": "3.023 sec"
+        }, 
+        "interface": "GigabitEthernet2"
+    }, 
+    {
+        "vmac": "0000.5e00.0102", 
+        "group": "2", 
+        "preempt": "enabled", 
+        "interval": "1.000 sec", 
+        "vip": "100.0.101.254", 
+        "priority": "100 ", 
+        "state": "Master", 
+        "master": {
+            "ip": "100.0.100.1 (local)", 
+            "advert_interval": "1.000 sec", 
+            "prio": "100 ", 
+            "down_interval": "3.609 sec"
+        }, 
+        "interface": "GigabitEthernet2"
+    }, 
+    {
+        "vmac": "0000.5e00.0102", 
+        "group": "2", 
+        "preempt": "enabled", 
+        "interval": "1.000 sec", 
+        "vip": "100.1.1.1", 
+        "priority": "100 ", 
+        "state": "Init (interface down)", 
+        "master": {
+            "ip": "unknown", 
+            "advert_interval": "unknown", 
+            "prio": "unknown", 
+            "down_interval": "3.609 sec"
+        }, 
+        "interface": "GigabitEthernet3"
+    }
+]

--- a/test/ios/mocked_data/test_get_vrrp_groups/normal/show_vrrp_all.txt
+++ b/test/ios/mocked_data/test_get_vrrp_groups/normal/show_vrrp_all.txt
@@ -1,0 +1,36 @@
+GigabitEthernet2 - Group 1  
+  State is Master
+  Virtual IP address is 100.0.100.254
+  Virtual MAC address is 0000.5e00.0101
+  Advertisement interval is 1.000 sec
+  Preemption enabled
+  Priority is 250 
+  Master Router is 100.0.100.1 (local), priority is 250 
+  Master Advertisement interval is 1.000 sec
+  Master Down interval is 3.023 sec
+  FLAGS: 1/1
+
+GigabitEthernet2 - Group 2  
+  State is Master
+  Virtual IP address is 100.0.101.254
+  Virtual MAC address is 0000.5e00.0102
+  Advertisement interval is 1.000 sec
+  Preemption enabled
+  Priority is 100 
+  Master Router is 100.0.100.1 (local), priority is 100 
+  Master Advertisement interval is 1.000 sec
+  Master Down interval is 3.609 sec
+  FLAGS: 1/1
+          
+GigabitEthernet3 - Group 2  
+  State is Init (interface down)
+  Virtual IP address is 100.1.1.1
+  Virtual MAC address is 0000.5e00.0102
+  Advertisement interval is 1.000 sec
+  Preemption enabled
+  Priority is 100 
+  Master Router is unknown, priority is unknown
+  Master Advertisement interval is unknown
+  Master Down interval is unknown
+  Master Down interval is 3.609 sec
+  FLAGS: 0/1


### PR DESCRIPTION
Hello,

Here's a new getter to pull VRRP information from Cisco IOS devices. It has been tested on a recent IOS-XE platform, with multiple VRRP groups per interface. I think this may be useful as VRRP is one of the most prevalent and used FHRPs.

Let me know if there is anything I can do to improve the code, in regards to the data structure returned, the speed or code readability. I can also provide similar feature for Junos and NX-OS (if applicable).