### PR TITLE
namespace fix for napalm cli

### DIFF
--- a/napalm/base/clitools/cl_napalm.py
+++ b/napalm/base/clitools/cl_napalm.py
@@ -146,6 +146,9 @@ def build_help():
     )
     args = parser.parse_args()
 
+    if not hasattr(args, "which"):
+        args.which = None
+
     if args.password is None:
         password = getpass.getpass("Enter password: ")
         setattr(args, "password", password)


### PR DESCRIPTION
Tiny fix for [napalm command line tools fails with 'Namespace' object has no attribute 'which'](https://github.com/napalm-automation/napalm/issues/936).