### PR TITLE
Added getters get_vlan function

### DIFF
--- a/napalm/base/base.py
+++ b/napalm/base/base.py
@@ -1644,6 +1644,41 @@ class NetworkDriver(object):
         """
         raise NotImplementedError
 
+    def get_vlans(self):
+        """
+        Returns a dictionary of dictionaries. The keys for the first dictionary will be the \
+        id of the vlan. The inner dictionary will containing the following data for \
+        each vlan:
+
+         * id (int)
+         * name (string)
+         * ports (list)
+
+        Example::
+
+            {
+            1:
+                {
+                'id': 1,
+                'name': 'default',
+                'ports': ['None'],
+                },
+            10:
+                {
+                'id': 10,
+                'name': 'FW_Uplinks',
+                'ports': ['Hu1/0/1,', 'Hu1/0/2'],
+                },
+            100:
+                {
+                'id': 100,
+                'name': 'WLAN_Clients',
+                'ports': ['None'],
+                }
+            }
+        """
+        raise NotImplementedError
+
     def compliance_report(self, validation_file=None, validation_source=None):
         """
         Return a compliance report.

--- a/napalm/ios/ios.py
+++ b/napalm/ios/ios.py
@@ -2775,6 +2775,57 @@ class IOSDriver(NetworkDriver):
             )
         return ipv6_neighbors_table
 
+    def get_vlans(self):
+        """
+        Get vlan details.
+        Example Output:
+        {
+        1: {   'id': 1,
+                      'name': "default",
+                      'ports': ['None']},
+        10: {   'id': 10,
+                      'name': "FW_Uplinks",
+                      'ports': ['Hu1/0/1,', 'Hu1/0/2']},
+        100: {   'id': 100,
+                      'name': "WLAN_Clients",
+                      'ports': ['None']}}
+        """
+
+        command = "show vlan brief"
+        output = self._send_command(command)
+
+        vlan = name = status = ""
+        ports = []
+        vlan_dict = {}
+
+        for line in output.splitlines():
+            if line[0].isdigit() is False:
+                continue
+
+            vlan_info = line.split()
+            vlan = int(vlan_info[0])
+            name = vlan_info[1]
+            status = vlan_info[2]
+            # skip default vlans (fddi, token-ring)
+            if status != "active":
+                continue
+            if len(vlan_info) > 3:
+                for port in range(3, len(vlan_info)):
+                    ports.append(vlan_info[port])
+            else:
+                ports.append("None")
+
+            vlan_dict[vlan] = {
+                    "id": vlan,
+                    "name": name,
+                    "ports": ports,
+            }
+
+            vlan = name = status = ""
+            ports = []
+
+        return vlan_dict
+
     @property
     def dest_file_system(self):
         # The self.device check ensures napalm has an open connection

--- a/napalm/ios/ios.py
+++ b/napalm/ios/ios.py
@@ -2815,11 +2815,7 @@ class IOSDriver(NetworkDriver):
             else:
                 ports.append("None")
 
-            vlan_dict[vlan] = {
-                    "id": vlan,
-                    "name": name,
-                    "ports": ports,
-            }
+            vlan_dict[vlan] = {"id": vlan, "name": name, "ports": ports}
 
             vlan = name = status = ""
             ports = []


### PR DESCRIPTION
Add funtion to get VLAN details (sh vlan brief) from ios. Excluding default Cisco VLANs (1002-1005, fddi + tokenring)


```
Python 3.6.6 (default, Jan 26 2019, 16:53:05)
[GCC 4.8.5 20150623 (Red Hat 4.8.5-36)] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import napalm
>>> driver = napalm.get_network_driver('ios')
>>> dev = driver('IOS-SW1','admin','admin')
>>> dev.open()

>>> b = dev.get_vlans()
>>> print(b)
{1: {'id': 1, 'name': 'default', 'ports': ['None']}, 10: {'id': 10, 'name': 'FW_Uplinks', 'ports': ['Hu1/0/1,', 'Hu1/0/2']}, 100: {'id': 100, 'name': 'WLAN_Clients', 'ports': ['None']}}
>>>
```