### PR TITLE
Add GitHub issue template, as we used to have before

### DIFF
--- a/.github/ISSUE_TEMPLATE
+++ b/.github/ISSUE_TEMPLATE
@@ -1,0 +1,36 @@
+### Description of Issue/Question
+
+*Note*: Please check https://guides.github.com/features/mastering-markdown/
+to see how to properly format your request.
+
+### Did you follow the steps from https://github.com/napalm-automation/napalm#faq
+(Place an ``x`` between the square brackets where applicable)
+
+- [ ] Yes
+- [ ] No
+
+
+### Setup
+
+### napalm version
+(Paste verbatim output from `pip freeze | grep napalm` between quotes below)
+
+```
+
+```
+
+### Network operating system version
+(Paste verbatim output from `show version` - or equivalent - between quotes below)
+
+```
+
+```
+
+### Steps to Reproduce the Issue
+
+### Error Traceback
+(Paste the complete traceback of the exception between quotes below)
+
+```
+
+```


### PR DESCRIPTION
When we used to maintain separare NAPALM drivers, we had an issue template
looking like this:
https://github.com/napalm-automation/napalm-junos/commit/110fec4bc9c50da43701b5019ecd859cc3c35f54#diff-faa36bc26a21ed93c8de974753b71507.

I was looking today through the issues we currently have open, and
I found some of them a bit chaotic, and hard to understand the context
/ environment the user runs. Additionally, some, e.g., #960, is really
hard to follow, and I've included a note to invite the user to check the
HitGub markdown manual.