### PR TITLE
support n9k ipv6 ints for interfaces_ip getter

### DIFF
--- a/napalm/nxos/nxos.py
+++ b/napalm/nxos/nxos.py
@@ -1103,6 +1103,10 @@ class NXOSDriver(NXOSDriverBase):
                 interfaces_ip[interface_name] = {}
             if "ipv6" not in interfaces_ip[interface_name].keys():
                 interfaces_ip[interface_name]["ipv6"] = {}
+            if "addr" not in interface.keys():
+                # Handle nexus 9000 ipv6 interface output
+                addrs = [addr["addr"] for addr in interface["TABLE_addr"]["ROW_addr"]]
+                interface["addr"] = addrs
 
             if type(interface.get("addr", "")) is list:
                 for ipv6_address in interface.get("addr", ""):

--- a/test/nxos/mocked_data/test_get_interfaces_ip/ipv6_n9k/expected_result.json
+++ b/test/nxos/mocked_data/test_get_interfaces_ip/ipv6_n9k/expected_result.json
@@ -1,0 +1,54 @@
+{
+    "Ethernet1/1": {
+        "ipv4": {
+            "172.16.100.1": {
+                "prefix_length": 24
+            }
+        }
+    },
+    "Ethernet1/128": {
+        "ipv6": {
+            "2001:dead:beef::1": {
+                "prefix_length": 128
+            },
+            "2001:c0ff:ee::1": {
+                "prefix_length": 128
+            }
+        }
+    },
+    "loopback103": {
+        "ipv4": {
+            "192.168.3.100": {
+                "prefix_length": 24
+            }
+        }
+    },
+    "loopback102": {
+        "ipv4": {
+            "192.168.2.100": {
+                "prefix_length": 24
+            }
+        }
+    },
+    "loopback101": {
+        "ipv4": {
+            "192.168.1.100": {
+                "prefix_length": 24
+            }
+        }
+    },
+    "loopback100": {
+        "ipv4": {
+            "10.0.0.100": {
+                "prefix_length": 24
+            }
+        }
+    },
+    "Ethernet2/5": {
+        "ipv4": {
+            "1.1.1.1": {
+                "prefix_length": 24
+            }
+        }
+    }
+}

--- a/test/nxos/mocked_data/test_get_interfaces_ip/ipv6_n9k/show_ip_interface.json
+++ b/test/nxos/mocked_data/test_get_interfaces_ip/ipv6_n9k/show_ip_interface.json
@@ -1,0 +1,204 @@
+{
+    "TABLE_vrf": [
+        {
+            "ROW_vrf": {
+                "vrf-name-out": "default"
+            }
+        },
+        {
+            "ROW_vrf": {
+                "vrf-name-out": "default"
+            }
+        },
+        {
+            "ROW_vrf": {
+                "vrf-name-out": "default"
+            }
+        },
+        {
+            "ROW_vrf": {
+                "vrf-name-out": "default"
+            }
+        },
+        {
+            "ROW_vrf": {
+                "vrf-name-out": "default"
+            }
+        },
+        {
+            "ROW_vrf": {
+                "vrf-name-out": "default"
+            }
+        }
+    ],
+    "TABLE_intf": [
+        {
+            "ROW_intf": {
+                "intf-name": "loopback100",
+                "proto-state": "up",
+                "link-state": "up",
+                "admin-state": "up",
+                "iod": "82",
+                "prefix": "10.0.0.100",
+                "subnet": "10.0.0.0",
+                "masklen": "24",
+                "num-addr": "1",
+                "ip-disabled": "FALSE",
+                "bcast-addr": "255.255.255.255",
+                "num-maddr": "0",
+                "mtu": "1500",
+                "pref": "0",
+                "tag": "0",
+                "proxy-arp": "disabled",
+                "lcl-proxy-arp": "disabled",
+                "mrouting": "disabled",
+                "icmp-redirect": "enabled",
+                "dir-bcast": "disabled",
+                "ip-unreach": "disabled",
+                "port-unreach": "enabled",
+                "urpf-mode": "none",
+                "ip-ls-type": "none"
+            }
+        },
+        {
+            "ROW_intf": {
+                "intf-name": "loopback101",
+                "proto-state": "up",
+                "link-state": "up",
+                "admin-state": "up",
+                "iod": "83",
+                "prefix": "192.168.1.100",
+                "subnet": "192.168.1.0",
+                "masklen": "24",
+                "num-addr": "1",
+                "ip-disabled": "FALSE",
+                "bcast-addr": "255.255.255.255",
+                "num-maddr": "0",
+                "mtu": "1500",
+                "pref": "0",
+                "tag": "0",
+                "proxy-arp": "disabled",
+                "lcl-proxy-arp": "disabled",
+                "mrouting": "disabled",
+                "icmp-redirect": "enabled",
+                "dir-bcast": "disabled",
+                "ip-unreach": "disabled",
+                "port-unreach": "enabled",
+                "urpf-mode": "none",
+                "ip-ls-type": "none"
+            }
+        },
+        {
+            "ROW_intf": {
+                "intf-name": "loopback102",
+                "proto-state": "up",
+                "link-state": "up",
+                "admin-state": "up",
+                "iod": "84",
+                "prefix": "192.168.2.100",
+                "subnet": "192.168.2.0",
+                "masklen": "24",
+                "num-addr": "1",
+                "ip-disabled": "FALSE",
+                "bcast-addr": "255.255.255.255",
+                "num-maddr": "0",
+                "mtu": "1500",
+                "pref": "0",
+                "tag": "0",
+                "proxy-arp": "disabled",
+                "lcl-proxy-arp": "disabled",
+                "mrouting": "disabled",
+                "icmp-redirect": "enabled",
+                "dir-bcast": "disabled",
+                "ip-unreach": "disabled",
+                "port-unreach": "enabled",
+                "urpf-mode": "none",
+                "ip-ls-type": "none"
+            }
+        },
+        {
+            "ROW_intf": {
+                "intf-name": "loopback103",
+                "proto-state": "up",
+                "link-state": "up",
+                "admin-state": "up",
+                "iod": "85",
+                "prefix": "192.168.3.100",
+                "subnet": "192.168.3.0",
+                "masklen": "24",
+                "num-addr": "1",
+                "ip-disabled": "FALSE",
+                "bcast-addr": "255.255.255.255",
+                "num-maddr": "0",
+                "mtu": "1500",
+                "pref": "0",
+                "tag": "0",
+                "proxy-arp": "disabled",
+                "lcl-proxy-arp": "disabled",
+                "mrouting": "disabled",
+                "icmp-redirect": "enabled",
+                "dir-bcast": "disabled",
+                "ip-unreach": "disabled",
+                "port-unreach": "enabled",
+                "urpf-mode": "none",
+                "ip-ls-type": "none"
+            }
+        },
+        {
+            "ROW_intf": {
+                "intf-name": "Ethernet1/1",
+                "proto-state": "up",
+                "link-state": "up",
+                "admin-state": "up",
+                "iod": "5",
+                "prefix": "172.16.100.1",
+                "subnet": "172.16.100.0",
+                "masklen": "24",
+                "num-addr": "1",
+                "ip-disabled": "FALSE",
+                "bcast-addr": "255.255.255.255",
+                "num-maddr": "0",
+                "mtu": "1500",
+                "pref": "0",
+                "tag": "0",
+                "proxy-arp": "disabled",
+                "lcl-proxy-arp": "disabled",
+                "mrouting": "disabled",
+                "icmp-redirect": "enabled",
+                "dir-bcast": "disabled",
+                "ip-unreach": "disabled",
+                "port-unreach": "enabled",
+                "urpf-mode": "none",
+                "ip-ls-type": "none"
+            }
+        },
+        {
+            "ROW_intf": {
+                "intf-name": "Ethernet2/5",
+                "proto-state": "down",
+                "link-state": "down",
+                "admin-state": "down",
+                "iod": "57",
+                "prefix": "1.1.1.1",
+                "subnet": "1.1.1.0",
+                "masklen": "24",
+                "num-addr": "1",
+                "ip-disabled": "FALSE",
+                "bcast-addr": "255.255.255.255",
+                "num-maddr": "0",
+                "mtu": "1500",
+                "pref": "0",
+                "tag": "0",
+                "proxy-arp": "disabled",
+                "lcl-proxy-arp": "disabled",
+                "mrouting": "disabled",
+                "icmp-redirect": "enabled",
+                "dir-bcast": "disabled",
+                "ip-unreach": "disabled",
+                "port-unreach": "enabled",
+                "urpf-mode": "none",
+                "ip-ls-type": "none"
+            }
+        }
+    ]
+}

--- a/test/nxos/mocked_data/test_get_interfaces_ip/ipv6_n9k/show_ipv6_interface.json
+++ b/test/nxos/mocked_data/test_get_interfaces_ip/ipv6_n9k/show_ipv6_interface.json
@@ -1,0 +1,64 @@
+{
+    "TABLE_intf": {
+        "ROW_intf": {
+            "vrf-name-out": "default",
+            "intf-name": "Ethernet1/128",
+            "proto-state": "down",
+            "link-state": "down",
+            "admin-state": "up",
+            "prefix": "2001:dead:beef::1/128",
+            "linklocal-addr": "fe80::5054:ff:fe12:345d",
+            "linklocal-configured": "FALSE",
+            "mrouting-enabled": "disabled",
+            "mgroup-locally-joined": "TRUE",
+            "mtu": 1500,
+            "urpf-mode": "none",
+            "ipv6-lstype": "none",
+            "stats-last-reset": "never",
+            "upkt-fwd": 0,
+            "upkt-orig": 0,
+            "upkt-consumed": 0,
+            "ubyte-fwd": 0,
+            "ubyte-orig": 0,
+            "ubyte-consumed": 0,
+            "mpkt-fwd": 0,
+            "mpkt-orig": 0,
+            "mpkt-consumed": 0,
+            "mbyte-fwd": 0,
+            "mbyte-orig": 0,
+            "mbyte-consumed": 0,
+            "TABLE_addr": {
+                "ROW_addr": [
+                    {
+                        "addr": "2001:dead:beef::1/128"
+                    },
+                    {
+                        "addr": "2001:c0ff:ee::1/128"
+                    }
+                ]
+            },
+            "TABLE_maddr": {
+                "ROW_maddr": [
+                    {
+                        "m-addr": "ff02::1:ff00:1"
+                    },
+                    {
+                        "m-addr": "ff02::2"
+                    },
+                    {
+                        "m-addr": "ff02::1"
+                    },
+                    {
+                        "m-addr": "ff02::1:ff00:1"
+                    },
+                    {
+                        "m-addr": "ff02::1:ff12:345d"
+                    },
+                    {
+                        "m-addr": "ff02::1:ff00:1"
+                    }
+                ]
+            }
+        }
+    }
+}


### PR DESCRIPTION
on at least nxos.9.2.3 the output has changed for ipv6 addresses. "addr" is no longer a top level key for each interface though "prefix" is. If multiple ipv6 addresses on an interface there is only one represented in "prefix" however.