### PR TITLE
additional options for get_config()

### DIFF
--- a/napalm/base/base.py
+++ b/napalm/base/base.py
@@ -90,9 +90,7 @@ class NetworkDriver(object):
             raise ConnectionException("Cannot connect to {}".format(self.hostname))
 
         # ensure in enable mode if not force disable
-        if (
-            not self.force_no_enable
-        ):
+        if not self.force_no_enable:
             self._netmiko_device.enable()
         return self._netmiko_device
 

--- a/napalm/base/base.py
+++ b/napalm/base/base.py
@@ -89,8 +89,8 @@ class NetworkDriver(object):
         except NetMikoTimeoutException:
             raise ConnectionException("Cannot connect to {}".format(self.hostname))
 
-        # ensure in enable mode
-        self._netmiko_device.enable()
+        if 'secret' in netmiko_optional_args:  # ensure in enable mode only if we get secret
+            self._netmiko_device.enable()
         return self._netmiko_device
 
     def _netmiko_close(self):

--- a/napalm/base/base.py
+++ b/napalm/base/base.py
@@ -89,7 +89,9 @@ class NetworkDriver(object):
         except NetMikoTimeoutException:
             raise ConnectionException("Cannot connect to {}".format(self.hostname))
 
-        if 'secret' in netmiko_optional_args:  # ensure in enable mode only if we get secret
+        if (
+            "secret" in netmiko_optional_args
+        ):  # ensure in enable mode only if we get secret
             self._netmiko_device.enable()
         return self._netmiko_device
 

--- a/napalm/base/base.py
+++ b/napalm/base/base.py
@@ -89,9 +89,10 @@ class NetworkDriver(object):
         except NetMikoTimeoutException:
             raise ConnectionException("Cannot connect to {}".format(self.hostname))
 
+        # ensure in enable mode if not force disable
         if (
-            "secret" in netmiko_optional_args
-        ):  # ensure in enable mode only if we get secret
+            not self.force_no_enable
+        ):
             self._netmiko_device.enable()
         return self._netmiko_device
 

--- a/napalm/ios/ios.py
+++ b/napalm/ios/ios.py
@@ -2959,24 +2959,26 @@ class IOSDriver(NetworkDriver):
             }
         return instances if not name else instances[name]
 
-    def get_config(self, retrieve="all"):
+    def get_config(self, retrieve="all", extra_arg=""):
         """Implementation of get_config for IOS.
 
         Returns the startup or/and running configuration as dictionary.
         The keys of the dictionary represent the type of configuration
         (startup or running). The candidate is always empty string,
         since IOS does not support candidate configuration.
+
+        extra_arg - may be "full" or "view full" for get config with this options
         """
 
         configs = {"startup": "", "running": "", "candidate": ""}
 
         if retrieve in ("startup", "all"):
-            command = "show startup-config"
+            command = " ".join(["show startup-config", extra_arg])
             output = self._send_command(command)
             configs["startup"] = output
 
         if retrieve in ("running", "all"):
-            command = "show running-config"
+            command = " ".join(["show running-config", extra_arg])
             output = self._send_command(command)
             configs["running"] = output
 

--- a/napalm/ios/ios.py
+++ b/napalm/ios/ios.py
@@ -141,6 +141,7 @@ class IOSDriver(NetworkDriver):
         self.platform = "ios"
         self.profile = [self.platform]
         self.use_canonical_interface = optional_args.get("canonical_int", False)
+        self.force_no_enable = optional_args.get("force_no_enable", False)
 
     def open(self):
         """Open a connection to the device."""


### PR DESCRIPTION
For some cisco models (expample: me3400, me3800) and with user limited rights to get full config
need use "show running-config full" or "show running-config view full" commands.