### PR TITLE
Modernize docs for FreeBSD installation

### DIFF
--- a/docs/installation/index.rst
+++ b/docs/installation/index.rst
@@ -14,6 +14,25 @@ You can install napalm with pip:
 That will install all the drivers currently available.
 
 
+OS Package Managers
+-------------------
+
+Some execution environments offer napalm through a system-level package manager. Installing with pip outside of a user profile or virtualenv/venv is inadvisable in these cases.
+
+FreeBSD
+~~~~~~~
+
+.. code-block:: bash
+
+    pkg install net-mgmt/py-napalm
+
+This will install napalm and all drivers and dependencies for the default version(s) of python. To install for a specific version, python X.Y, if supported:
+
+.. code-block:: bash
+
+    pkg install pyXY-napalm
+
+
 Dependencies
 ------------
 

--- a/docs/installation/ios.rst
+++ b/docs/installation/ios.rst
@@ -15,11 +15,3 @@ RedHat and CentOS
 .. code-block:: bash
 
     sudo yum install -y python-pip gcc openssl openssl-devel libffi-devel python-devel
-
-
-FreeBSD
--------
-
-.. code-block:: bash
-
-    sudo pkg_add -r py27-pip

--- a/docs/installation/iosxr.rst
+++ b/docs/installation/iosxr.rst
@@ -15,11 +15,3 @@ RedHat and CentOS
 .. code-block:: bash
 
     sudo yum install -y python-pip gcc openssl openssl-devel libffi-devel python-devel
-
-
-FreeBSD
--------
-
-.. code-block:: bash
-
-    sudo pkg_add -r py27-pip

--- a/docs/installation/junos.rst
+++ b/docs/installation/junos.rst
@@ -15,10 +15,3 @@ RedHat and CentOS
 .. code-block:: bash
 
     sudo yum install -y python-pip python-devel libxml2-devel libxslt-devel gcc openssl openssl-devel libffi-devel
-
-FreeBSD
--------
-
-.. code-block:: bash
-
-    sudo pkg_add -r py27-pip libxml2 libxslt


### PR DESCRIPTION
Replace pip-based installation instructions for FreeBSD with instructions that use the native package management utility, pkg.

Close #934 