### PR TITLE
Better handling of connection closing upon exceptions in __enter__

### DIFF
--- a/napalm/base/base.py
+++ b/napalm/base/base.py
@@ -16,14 +16,16 @@
 from __future__ import print_function
 from __future__ import unicode_literals
 
+import sys
+
+from netmiko import ConnectHandler, NetMikoTimeoutException
+
 # local modules
 import napalm.base.exceptions
-from napalm.base.exceptions import ConnectionException
 import napalm.base.helpers
 from napalm.base import constants as c
 from napalm.base import validate
-
-from netmiko import ConnectHandler, NetMikoTimeoutException
+from napalm.base.exceptions import ConnectionException
 
 
 class NetworkDriver(object):
@@ -44,8 +46,15 @@ class NetworkDriver(object):
         raise NotImplementedError
 
     def __enter__(self):
-        self.open()
-        return self
+        try:
+            self.open()
+            return self
+        except:  # noqa: E722
+            # Swallow exception if __exit__ returns a True value
+            if self.__exit__(*sys.exc_info()):
+                pass
+            else:
+                raise
 
     def __exit__(self, exc_type, exc_value, exc_traceback):
         self.close()
@@ -95,8 +104,9 @@ class NetworkDriver(object):
 
     def _netmiko_close(self):
         """Standardized method of closing a Netmiko connection."""
-        self.device.disconnect()
-        self._netmiko_device = None
+        if getattr(self, "_netmiko_device", None):
+            self._netmiko_device.disconnect()
+            self._netmiko_device = None
         self.device = None
 
     def open(self):


### PR DESCRIPTION
Always try to close netmiko connections.

Closes #991