### PR TITLE
address single and multiple v6 address on n9k

### DIFF
--- a/napalm/nxos/nxos.py
+++ b/napalm/nxos/nxos.py
@@ -1106,7 +1106,9 @@ class NXOSDriver(NXOSDriverBase):
             if "addr" not in interface.keys():
                 # Handle nexus 9000 ipv6 interface output
                 if isinstance(interface["TABLE_addr"]["ROW_addr"], list):
-                    addrs = [addr["addr"] for addr in interface["TABLE_addr"]["ROW_addr"]]
+                    addrs = [
+                        addr["addr"] for addr in interface["TABLE_addr"]["ROW_addr"]
+                    ]
                 elif isinstance(interface["TABLE_addr"]["ROW_addr"], dict):
                     addrs = interface["TABLE_addr"]["ROW_addr"]["addr"]
                 interface["addr"] = addrs

--- a/napalm/nxos/nxos.py
+++ b/napalm/nxos/nxos.py
@@ -1105,7 +1105,10 @@ class NXOSDriver(NXOSDriverBase):
                 interfaces_ip[interface_name]["ipv6"] = {}
             if "addr" not in interface.keys():
                 # Handle nexus 9000 ipv6 interface output
-                addrs = [addr["addr"] for addr in interface["TABLE_addr"]["ROW_addr"]]
+                if isinstance(interface["TABLE_addr"]["ROW_addr"], list):
+                    addrs = [addr["addr"] for addr in interface["TABLE_addr"]["ROW_addr"]]
+                elif isinstance(interface["TABLE_addr"]["ROW_addr"], dict):
+                    addrs = interface["TABLE_addr"]["ROW_addr"]["addr"]
                 interface["addr"] = addrs
 
             if type(interface.get("addr", "")) is list:

--- a/test/nxos/mocked_data/test_get_interfaces_ip/ipv6_n9k/expected_result.json
+++ b/test/nxos/mocked_data/test_get_interfaces_ip/ipv6_n9k/expected_result.json
@@ -4,13 +4,18 @@
             "172.16.100.1": {
                 "prefix_length": 24
             }
-        }
-    },
-    "Ethernet1/128": {
+        },
         "ipv6": {
-            "2001:dead:beef::1": {
+            "200::2": {
                 "prefix_length": 128
             },
+            "dead:beef::1": {
+                "prefix_length": 64
+            }
+        }
+    },
+    "Ethernet1/2": {
+        "ipv6": {
             "2001:c0ff:ee::1": {
                 "prefix_length": 128
             }

--- a/test/nxos/mocked_data/test_get_interfaces_ip/ipv6_n9k/show_ipv6_interface.json
+++ b/test/nxos/mocked_data/test_get_interfaces_ip/ipv6_n9k/show_ipv6_interface.json
@@ -1,64 +1,115 @@
 {
     "TABLE_intf": {
-        "ROW_intf": {
-            "vrf-name-out": "default",
-            "intf-name": "Ethernet1/128",
-            "proto-state": "down",
-            "link-state": "down",
-            "admin-state": "up",
-            "prefix": "2001:dead:beef::1/128",
-            "linklocal-addr": "fe80::5054:ff:fe12:345d",
-            "linklocal-configured": "FALSE",
-            "mrouting-enabled": "disabled",
-            "mgroup-locally-joined": "TRUE",
-            "mtu": 1500,
-            "urpf-mode": "none",
-            "ipv6-lstype": "none",
-            "stats-last-reset": "never",
-            "upkt-fwd": 0,
-            "upkt-orig": 0,
-            "upkt-consumed": 0,
-            "ubyte-fwd": 0,
-            "ubyte-orig": 0,
-            "ubyte-consumed": 0,
-            "mpkt-fwd": 0,
-            "mpkt-orig": 0,
-            "mpkt-consumed": 0,
-            "mbyte-fwd": 0,
-            "mbyte-orig": 0,
-            "mbyte-consumed": 0,
-            "TABLE_addr": {
-                "ROW_addr": [
-                    {
-                        "addr": "2001:dead:beef::1/128"
-                    },
-                    {
+        "ROW_intf": [
+            {
+                "vrf-name-out": "default",
+                "intf-name": "Ethernet1/1",
+                "proto-state": "up",
+                "link-state": "up",
+                "admin-state": "up",
+                "prefix": "dead:beef::/64",
+                "linklocal-addr": "fe80::a00:27ff:fe6c:ee14",
+                "linklocal-configured": "FALSE",
+                "mrouting-enabled": "disabled",
+                "mgroup-locally-joined": "TRUE",
+                "mtu": 1500,
+                "urpf-mode": "none",
+                "ipv6-lstype": "none",
+                "stats-last-reset": "never",
+                "upkt-fwd": 0,
+                "upkt-orig": 0,
+                "upkt-consumed": 0,
+                "ubyte-fwd": 0,
+                "ubyte-orig": 0,
+                "ubyte-consumed": 0,
+                "mpkt-fwd": 0,
+                "mpkt-orig": 9,
+                "mpkt-consumed": 0,
+                "mbyte-fwd": 0,
+                "mbyte-orig": 786,
+                "mbyte-consumed": 0,
+                "TABLE_addr": {
+                    "ROW_addr": [
+                        {
+                            "addr": "dead:beef::1/64"
+                        },
+                        {
+                            "addr": "200::2/128"
+                        }
+                    ]
+                },
+                "TABLE_maddr": {
+                    "ROW_maddr": [
+                        {
+                            "m-addr": "ff02::1:ff00:1"
+                        },
+                        {
+                            "m-addr": "ff02::2"
+                        },
+                        {
+                            "m-addr": "ff02::1"
+                        },
+                        {
+                            "m-addr": "ff02::1:ff00:1"
+                        },
+                        {
+                            "m-addr": "ff02::1:ff6c:ee14"
+                        }
+                    ]
+                }
+            },
+            {
+                "vrf-name-out": "default",
+                "intf-name": "Ethernet1/2",
+                "proto-state": "up",
+                "link-state": "up",
+                "admin-state": "up",
+                "prefix": "2001:c0ff:ee::/128",
+                "linklocal-addr": "fe80::a00:27ff:fe6c:ee14",
+                "linklocal-configured": "FALSE",
+                "mrouting-enabled": "disabled",
+                "mgroup-locally-joined": "TRUE",
+                "mtu": 1500,
+                "urpf-mode": "none",
+                "ipv6-lstype": "none",
+                "stats-last-reset": "never",
+                "upkt-fwd": 0,
+                "upkt-orig": 0,
+                "upkt-consumed": 0,
+                "ubyte-fwd": 0,
+                "ubyte-orig": 0,
+                "ubyte-consumed": 0,
+                "mpkt-fwd": 0,
+                "mpkt-orig": 7,
+                "mpkt-consumed": 0,
+                "mbyte-fwd": 0,
+                "mbyte-orig": 614,
+                "mbyte-consumed": 0,
+                "TABLE_addr": {
+                    "ROW_addr": {
                         "addr": "2001:c0ff:ee::1/128"
                     }
-                ]
-            },
-            "TABLE_maddr": {
-                "ROW_maddr": [
-                    {
-                        "m-addr": "ff02::1:ff00:1"
-                    },
-                    {
-                        "m-addr": "ff02::2"
-                    },
-                    {
-                        "m-addr": "ff02::1"
-                    },
-                    {
-                        "m-addr": "ff02::1:ff00:1"
-                    },
-                    {
-                        "m-addr": "ff02::1:ff12:345d"
-                    },
-                    {
-                        "m-addr": "ff02::1:ff00:1"
-                    }
-                ]
+                },
+                "TABLE_maddr": {
+                    "ROW_maddr": [
+                        {
+                            "m-addr": "ff02::2"
+                        },
+                        {
+                            "m-addr": "ff02::1"
+                        },
+                        {
+                            "m-addr": "ff02::1:ff00:2"
+                        },
+                        {
+                            "m-addr": "ff02::1:ff6c:ee14"
+                        },
+                        {
+                            "m-addr": "ff02::1:ff00:2"
+                        }
+                    ]
+                }
             }
-        }
+        ]
     }
 }


### PR DESCRIPTION
previous fix for n9k ipv6 interfaces only handled interfaces w/ multiple v6 addresses -- thinking that link local would show up. link local shows up in its own field so this broke interfaces w/ only one address -- fixed here.