### PR TITLE
Fix nxos and nxos_ssh hostname change handling

### DIFF
--- a/napalm/nxos/nxos.py
+++ b/napalm/nxos/nxos.py
@@ -218,6 +218,8 @@ class NXOSDriverBase(NetworkDriver):
 
             if self.replace:
                 self._load_cfg_from_checkpoint()
+                # If hostname changes ensure Netmiko state is updated properly
+                self._netmiko_device.set_base_prompt()
             else:
                 self._commit_merge()
 

--- a/napalm/nxos_ssh/nxos_ssh.py
+++ b/napalm/nxos_ssh/nxos_ssh.py
@@ -533,11 +533,9 @@ class NXOSSSHDriver(NXOSDriverBase):
         ]
 
         try:
-            rollback_result = self._send_command_list(commands, expect_string=r"#")
+            rollback_result = self._send_command_list(commands, expect_string=r"[#>]")
         finally:
             self.changed = True
-        # If hostname changes ensure Netmiko state is updated properly
-        self.device.set_base_prompt()
         msg = rollback_result
         if "Rollback failed." in msg:
             raise ReplaceConfigException(msg)

--- a/napalm/nxos_ssh/nxos_ssh.py
+++ b/napalm/nxos_ssh/nxos_ssh.py
@@ -449,12 +449,15 @@ class NXOSSSHDriver(NXOSDriverBase):
         """
         return self.device.send_command(command)
 
-    def _send_command_list(self, commands):
+    def _send_command_list(self, commands, expect_string=None):
         """Wrapper for Netmiko's send_command method (for list of commands."""
         output = ""
         for command in commands:
             output += self.device.send_command(
-                command, strip_prompt=False, strip_command=False
+                command,
+                strip_prompt=False,
+                strip_command=False,
+                expect_string=expect_string,
             )
         return output
 
@@ -528,10 +531,13 @@ class NXOSSSHDriver(NXOSDriverBase):
             "rollback running-config file {}".format(self.candidate_cfg),
             "no terminal dont-ask",
         ]
+
         try:
-            rollback_result = self._send_command_list(commands)
+            rollback_result = self._send_command_list(commands, expect_string=r"#")
         finally:
             self.changed = True
+        # If hostname changes ensure Netmiko state is updated properly
+        self.device.set_base_prompt()
         msg = rollback_result
         if "Rollback failed." in msg:
             raise ReplaceConfigException(msg)


### PR DESCRIPTION
I ran into issues with both nxos driver and nxos_ssh driver with hostname changes. Made fixes here to incorporate. 

I also updated the napalm_custom_test suite to test this for both nxos and nxos_ssh for both merge and replace operations. This generally runs daily against virtual network devices and the develop branch.