### PR TITLE
Fix 'Edit in GitHub' button and sync with Read the Docs settings

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -62,7 +62,7 @@ copyright = u"2016, David Barroso"
 # built documents.
 #
 # The short X.Y version.
-version = "0"
+version = "latest"
 # The full version, including alpha/beta/rc tags.
 release = "1"
 
@@ -123,6 +123,14 @@ else:
 # further.  For a list of options available for each theme, see the
 # documentation.
 # html_theme_options = {}
+
+# Configuration for customized parts of the theme
+html_context = {
+  'display_github': True,
+  'github_user': 'napalm-automation',
+  'github_repo': 'napalm',
+  'github_version': 'develop/docs/'
+}
 
 # Add any paths that contain custom themes here, relative to this directory.
 # html_theme_path = []


### PR DESCRIPTION
This changes the "Edit in GitHub" button from editing `master` to `develop`. **Disclaimer:** I've never used Read the Docs so I don't know if adding this setting in **conf.py** will fix the button, break something, or do nothing. It fixes it for local builds though.

This also changes the version in **conf.py** from `0` to `latest` so that the local build matches the live build more closely. Again, I don't know if this will break something on RTD, but it works on local builds.

