### PR TITLE
Add get_environment support for NXOS driver

### DIFF
--- a/test/nxos/mocked_data/test_get_environment/normal/expected_result.json
+++ b/test/nxos/mocked_data/test_get_environment/normal/expected_result.json
@@ -1,0 +1,59 @@
+{
+    "cpu": {
+        "0": {
+            "%usage": 0.75 
+        }
+    },
+    "fans": {
+        "Fan1(sys_fan1)": {
+            "status": true
+        },
+        "Fan2(sys_fan2)": {
+            "status": true
+        },
+        "Fan3(sys_fan3)": {
+            "status": true
+        },
+        "Fan4(sys_fan4)": {
+            "status": true
+        }
+    },
+    "memory": {
+        "available_ram": 417000,
+        "used_ram": 45000
+    },
+    "power": {
+        "1": {
+            "capacity": 400.0,
+            "output": 396.0,
+            "status": true
+        },
+        "2": {
+            "capacity": 400.0,
+            "output": 396.0,
+            "status": true
+        }
+    },
+    "temperature": {
+        "1-1 ASIC": {
+            "is_alert": false,
+            "is_critical": false,
+            "temperature": 56.0
+        },
+        "1-2 INTAKE": {
+            "is_alert": false,
+            "is_critical": false,
+            "temperature": 23.0
+        },
+        "1-3 ASIC": {
+            "is_alert": false,
+            "is_critical": false,
+            "temperature": 56.0
+        },
+        "1-4 INTAKE": {
+            "is_alert": false,
+            "is_critical": false,
+            "temperature": 23.0
+        }
+    }
+}

--- a/test/nxos/mocked_data/test_get_environment/normal/show_environment.json
+++ b/test/nxos/mocked_data/test_get_environment/normal/show_environment.json
@@ -1,0 +1,147 @@
+{
+    "TABLE_tempinfo": {
+        "ROW_tempinfo": [
+            {
+                "alarmstatus": "Ok",
+                "curtemp": "56",
+                "majthres": "92  ",
+                "minthres": "85  ",
+                "sensor": "ASIC",
+                "tempmod": "1        "
+            },
+            {
+                "alarmstatus": "Ok",
+                "curtemp": "23",
+                "majthres": "45  ",
+                "minthres": "31  ",
+                "sensor": "INTAKE",
+                "tempmod": "1        "
+            },
+            {
+                "alarmstatus": "Ok",
+                "curtemp": "56",
+                "majthres": "110 ",
+                "minthres": "90  ",
+                "sensor": "ASIC",
+                "tempmod": "1        "
+            },
+            {
+                "alarmstatus": "Ok",
+                "curtemp": "23",
+                "majthres": "70  ",
+                "minthres": "40  ",
+                "sensor": "INTAKE",
+                "tempmod": "1        "
+            }
+        ]
+    },
+    "fandetails_3k": {
+        "TABLE_fan_zone_speed": {
+            "ROW_fan_zone_speed": {
+                "speed": 0,
+                "zone": "1"
+            }
+        },
+        "TABLE_faninfo": {
+            "ROW_faninfo": [
+                {
+                    "fandir": "front-to-back",
+                    "fanhwver": "0.0",
+                    "fanmodel": "NXA-FAN-30CFM-F",
+                    "fanname": "Fan1(sys_fan1)",
+                    "fanstatus": "Ok"
+                },
+                {
+                    "fandir": "front-to-back",
+                    "fanhwver": "0.0",
+                    "fanmodel": "NXA-FAN-30CFM-F",
+                    "fanname": "Fan2(sys_fan2)",
+                    "fanstatus": "Ok"
+                },
+                {
+                    "fandir": "front-to-back",
+                    "fanhwver": "0.0",
+                    "fanmodel": "NXA-FAN-30CFM-F",
+                    "fanname": "Fan3(sys_fan3)",
+                    "fanstatus": "Ok"
+                },
+                {
+                    "fandir": "front-to-back",
+                    "fanhwver": "0.0",
+                    "fanmodel": "NXA-FAN-30CFM-F",
+                    "fanname": "Fan4(sys_fan4)",
+                    "fanstatus": "Ok"
+                },
+                {
+                    "fandir": "front-to-back",
+                    "fanhwver": "--",
+                    "fanmodel": "N2200-PAC-400W",
+                    "fanname": "Fan_in_PS1",
+                    "fanstatus": "Ok"
+                },
+                {
+                    "fandir": "front-to-back",
+                    "fanhwver": "--",
+                    "fanmodel": "N2200-PAC-400W",
+                    "fanname": "Fan_in_PS2",
+                    "fanstatus": "Ok"
+                }
+            ]
+        },
+        "fan_filter_status": "NotSupported"
+    },
+    "powersup": {
+        "TABLE_mod_pow_info": [
+            {
+                "ROW_mod_pow_info": {
+                    "modnum": "1 "
+                }
+            },
+            {
+                "ROW_mod_pow_info": {
+                    "modnum": "2 "
+                }
+            },
+            {
+                "ROW_mod_pow_info": {
+                    "amps_alloced": "29.00  ",
+                    "amps_requested": "29.00  ",
+                    "mod_model": "N3K-C3548P-10G     ",
+                    "modnum": "1   ",
+                    "modstatus_3k": "powered-up",
+                    "watts_alloced": "348.00 ",
+                    "watts_requested": "348.00 "
+                }
+            }
+        ],
+        "TABLE_psinfo": [
+            {
+                "ROW_psinfo": {
+                    "amps": "  33.00",
+                    "input_type": "AC",
+                    "ps_status_3k": "ok",
+                    "psmodel": "N2200-PAC-400W",
+                    "watts": " 396.00"
+                }
+            },
+            {
+                "ROW_psinfo": {
+                    "amps": "  33.00",
+                    "input_type": "AC",
+                    "ps_status_3k": "ok",
+                    "psmodel": "N2200-PAC-400W",
+                    "watts": " 396.00"
+                }
+            }
+        ],
+        "power_summary": {
+            "available_pow": "  444.00 W",
+            "pow_used_by_mods": "    0.00 W",
+            "ps_redun_mode_3k": "Redundant",
+            "ps_redun_op_mode": "Redundant",
+            "reserve_sup": "  348.00 W",
+            "tot_pow_capacity": "  792.00 W"
+        },
+        "voltage_level": 12
+    }
+}

--- a/test/nxos/mocked_data/test_get_environment/normal/show_processes_cpu.json
+++ b/test/nxos/mocked_data/test_get_environment/normal/show_processes_cpu.json
@@ -1,0 +1,2137 @@
+{
+    "TABLE_process_cpu": {
+        "ROW_process_cpu": [
+            {
+                "invoked": 117856,
+                "onesec": "0.00",
+                "pid": 1,
+                "process": "init",
+                "runtime": 6442,
+                "usecs": 54
+            },
+            {
+                "invoked": 2802,
+                "onesec": "0.00",
+                "pid": 2,
+                "process": "kthreadd",
+                "runtime": 49,
+                "usecs": 17
+            },
+            {
+                "invoked": 365359,
+                "onesec": "0.00",
+                "pid": 3,
+                "process": "ksoftirqd/0",
+                "runtime": 2716,
+                "usecs": 7
+            },
+            {
+                "invoked": 43581,
+                "onesec": "0.00",
+                "pid": 6,
+                "process": "migration/0",
+                "runtime": 855,
+                "usecs": 19
+            },
+            {
+                "invoked": 146490,
+                "onesec": "0.00",
+                "pid": 7,
+                "process": "watchdog/0",
+                "runtime": 481,
+                "usecs": 3
+            },
+            {
+                "invoked": 53370,
+                "onesec": "0.00",
+                "pid": 8,
+                "process": "migration/1",
+                "runtime": 1003,
+                "usecs": 18
+            },
+            {
+                "invoked": 45119,
+                "onesec": "0.00",
+                "pid": 10,
+                "process": "ksoftirqd/1",
+                "runtime": 1035,
+                "usecs": 22
+            },
+            {
+                "invoked": 34590969,
+                "onesec": "0.00",
+                "pid": 11,
+                "process": "kworker/0:1",
+                "runtime": 31451,
+                "usecs": 0
+            },
+            {
+                "invoked": 146490,
+                "onesec": "0.00",
+                "pid": 12,
+                "process": "watchdog/1",
+                "runtime": 410,
+                "usecs": 2
+            },
+            {
+                "invoked": 158817,
+                "onesec": "0.00",
+                "pid": 13,
+                "process": "migration/2",
+                "runtime": 2041,
+                "usecs": 12
+            },
+            {
+                "invoked": 8744,
+                "onesec": "0.00",
+                "pid": 15,
+                "process": "ksoftirqd/2",
+                "runtime": 304,
+                "usecs": 34
+            },
+            {
+                "invoked": 146490,
+                "onesec": "0.00",
+                "pid": 16,
+                "process": "watchdog/2",
+                "runtime": 346,
+                "usecs": 2
+            },
+            {
+                "invoked": 185988,
+                "onesec": "0.00",
+                "pid": 17,
+                "process": "migration/3",
+                "runtime": 2067,
+                "usecs": 11
+            },
+            {
+                "invoked": 6668,
+                "onesec": "0.00",
+                "pid": 19,
+                "process": "ksoftirqd/3",
+                "runtime": 289,
+                "usecs": 43
+            },
+            {
+                "invoked": 146490,
+                "onesec": "0.00",
+                "pid": 20,
+                "process": "watchdog/3",
+                "runtime": 359,
+                "usecs": 2
+            },
+            {
+                "invoked": 2,
+                "onesec": "0.00",
+                "pid": 21,
+                "process": "cpuset",
+                "runtime": 0,
+                "usecs": 4
+            },
+            {
+                "invoked": 2,
+                "onesec": "0.00",
+                "pid": 22,
+                "process": "khelper",
+                "runtime": 0,
+                "usecs": 3
+            },
+            {
+                "invoked": 169,
+                "onesec": "0.00",
+                "pid": 23,
+                "process": "kdevtmpfs",
+                "runtime": 2,
+                "usecs": 12
+            },
+            {
+                "invoked": 2,
+                "onesec": "0.00",
+                "pid": 24,
+                "process": "netns",
+                "runtime": 0,
+                "usecs": 3
+            },
+            {
+                "invoked": 97663,
+                "onesec": "0.00",
+                "pid": 25,
+                "process": "sync_supers",
+                "runtime": 429,
+                "usecs": 4
+            },
+            {
+                "invoked": 9652,
+                "onesec": "0.00",
+                "pid": 26,
+                "process": "bdi-default",
+                "runtime": 91,
+                "usecs": 9
+            },
+            {
+                "invoked": 2,
+                "onesec": "0.00",
+                "pid": 27,
+                "process": "kblockd",
+                "runtime": 0,
+                "usecs": 3
+            },
+            {
+                "invoked": 2,
+                "onesec": "0.00",
+                "pid": 28,
+                "process": "ata_sff",
+                "runtime": 0,
+                "usecs": 4
+            },
+            {
+                "invoked": 95,
+                "onesec": "0.00",
+                "pid": 29,
+                "process": "khubd",
+                "runtime": 1,
+                "usecs": 13
+            },
+            {
+                "invoked": 2,
+                "onesec": "0.00",
+                "pid": 30,
+                "process": "rpciod",
+                "runtime": 0,
+                "usecs": 5
+            },
+            {
+                "invoked": 32859791,
+                "onesec": "0.00",
+                "pid": 31,
+                "process": "kworker/1:1",
+                "runtime": 31037,
+                "usecs": 0
+            },
+            {
+                "invoked": 4884,
+                "onesec": "0.00",
+                "pid": 50,
+                "process": "khungtaskd",
+                "runtime": 202,
+                "usecs": 41
+            },
+            {
+                "invoked": 21,
+                "onesec": "0.00",
+                "pid": 51,
+                "process": "kswapd0",
+                "runtime": 45,
+                "usecs": 2148
+            },
+            {
+                "invoked": 28794101,
+                "onesec": "2.50",
+                "pid": 52,
+                "process": "ksmd",
+                "runtime": 41792799,
+                "usecs": 1451
+            },
+            {
+                "invoked": 5,
+                "onesec": "0.00",
+                "pid": 53,
+                "process": "fsnotify_mark",
+                "runtime": 0,
+                "usecs": 1
+            },
+            {
+                "invoked": 2,
+                "onesec": "0.00",
+                "pid": 54,
+                "process": "unionfs_siod",
+                "runtime": 0,
+                "usecs": 3
+            },
+            {
+                "invoked": 2,
+                "onesec": "0.00",
+                "pid": 55,
+                "process": "nfsiod",
+                "runtime": 0,
+                "usecs": 3
+            },
+            {
+                "invoked": 2,
+                "onesec": "0.00",
+                "pid": 56,
+                "process": "crypto",
+                "runtime": 0,
+                "usecs": 3
+            },
+            {
+                "invoked": 214,
+                "onesec": "0.00",
+                "pid": 71,
+                "process": "kworker/2:1",
+                "runtime": 1,
+                "usecs": 8
+            },
+            {
+                "invoked": 12875464,
+                "onesec": "0.00",
+                "pid": 72,
+                "process": "kworker/3:1",
+                "runtime": 14022,
+                "usecs": 1
+            },
+            {
+                "invoked": 9,
+                "onesec": "0.00",
+                "pid": 73,
+                "process": "scsi_eh_0",
+                "runtime": 0,
+                "usecs": 8
+            },
+            {
+                "invoked": 9,
+                "onesec": "0.00",
+                "pid": 74,
+                "process": "scsi_eh_1",
+                "runtime": 0,
+                "usecs": 11
+            },
+            {
+                "invoked": 9,
+                "onesec": "0.00",
+                "pid": 75,
+                "process": "scsi_eh_2",
+                "runtime": 0,
+                "usecs": 19
+            },
+            {
+                "invoked": 9,
+                "onesec": "0.00",
+                "pid": 76,
+                "process": "scsi_eh_3",
+                "runtime": 0,
+                "usecs": 15
+            },
+            {
+                "invoked": 5,
+                "onesec": "0.00",
+                "pid": 77,
+                "process": "kworker/u:2",
+                "runtime": 0,
+                "usecs": 6
+            },
+            {
+                "invoked": 160,
+                "onesec": "0.00",
+                "pid": 78,
+                "process": "kworker/u:3",
+                "runtime": 36,
+                "usecs": 230
+            },
+            {
+                "invoked": 2,
+                "onesec": "0.00",
+                "pid": 80,
+                "process": "cnic_wq",
+                "runtime": 0,
+                "usecs": 3
+            },
+            {
+                "invoked": 2,
+                "onesec": "0.00",
+                "pid": 81,
+                "process": "bnx2x",
+                "runtime": 0,
+                "usecs": 2
+            },
+            {
+                "invoked": 2,
+                "onesec": "0.00",
+                "pid": 82,
+                "process": "edac-poller",
+                "runtime": 0,
+                "usecs": 3
+            },
+            {
+                "invoked": 2,
+                "onesec": "0.00",
+                "pid": 83,
+                "process": "deferwq",
+                "runtime": 0,
+                "usecs": 3
+            },
+            {
+                "invoked": 13,
+                "onesec": "0.00",
+                "pid": 85,
+                "process": "kworker/0:2",
+                "runtime": 0,
+                "usecs": 1
+            },
+            {
+                "invoked": 2,
+                "onesec": "0.00",
+                "pid": 86,
+                "process": "scsi_eh_4",
+                "runtime": 0,
+                "usecs": 3
+            },
+            {
+                "invoked": 103207,
+                "onesec": "0.00",
+                "pid": 87,
+                "process": "usb-storage",
+                "runtime": 495,
+                "usecs": 4
+            },
+            {
+                "invoked": 772,
+                "onesec": "0.00",
+                "pid": 211,
+                "process": "loop0",
+                "runtime": 49,
+                "usecs": 64
+            },
+            {
+                "invoked": 1725,
+                "onesec": "0.00",
+                "pid": 2175,
+                "process": "loop1",
+                "runtime": 147,
+                "usecs": 85
+            },
+            {
+                "invoked": 946,
+                "onesec": "0.00",
+                "pid": 2178,
+                "process": "loop2",
+                "runtime": 163,
+                "usecs": 172
+            },
+            {
+                "invoked": 918,
+                "onesec": "0.00",
+                "pid": 2181,
+                "process": "loop3",
+                "runtime": 99,
+                "usecs": 107
+            },
+            {
+                "invoked": 310,
+                "onesec": "0.00",
+                "pid": 2184,
+                "process": "loop4",
+                "runtime": 85,
+                "usecs": 274
+            },
+            {
+                "invoked": 3,
+                "onesec": "0.00",
+                "pid": 2190,
+                "process": "loop5",
+                "runtime": 0,
+                "usecs": 8
+            },
+            {
+                "invoked": 3,
+                "onesec": "0.00",
+                "pid": 2192,
+                "process": "loop6",
+                "runtime": 0,
+                "usecs": 7
+            },
+            {
+                "invoked": 2,
+                "onesec": "0.00",
+                "pid": 3737,
+                "process": "trigger",
+                "runtime": 0,
+                "usecs": 3
+            },
+            {
+                "invoked": 14036829,
+                "onesec": "0.00",
+                "pid": 5691,
+                "process": "kworker/2:2",
+                "runtime": 9041,
+                "usecs": 0
+            },
+            {
+                "invoked": 4,
+                "onesec": "0.00",
+                "pid": 5713,
+                "process": "kworker/1:2",
+                "runtime": 0,
+                "usecs": 6
+            },
+            {
+                "invoked": 16,
+                "onesec": "0.00",
+                "pid": 6290,
+                "process": "jbd2/sda5-8",
+                "runtime": 0,
+                "usecs": 38
+            },
+            {
+                "invoked": 2,
+                "onesec": "0.00",
+                "pid": 6291,
+                "process": "ext4-dio-unwrit",
+                "runtime": 0,
+                "usecs": 5
+            },
+            {
+                "invoked": 15,
+                "onesec": "0.00",
+                "pid": 6297,
+                "process": "jbd2/sda6-8",
+                "runtime": 0,
+                "usecs": 38
+            },
+            {
+                "invoked": 2,
+                "onesec": "0.00",
+                "pid": 6298,
+                "process": "ext4-dio-unwrit",
+                "runtime": 0,
+                "usecs": 4
+            },
+            {
+                "invoked": 49,
+                "onesec": "0.00",
+                "pid": 9503,
+                "process": "flush-8:0",
+                "runtime": 0,
+                "usecs": 6
+            },
+            {
+                "invoked": 13,
+                "onesec": "0.00",
+                "pid": 9504,
+                "process": "flush-mtd-unmap",
+                "runtime": 0,
+                "usecs": 6
+            },
+            {
+                "invoked": 13,
+                "onesec": "0.00",
+                "pid": 9505,
+                "process": "flush-7:10",
+                "runtime": 0,
+                "usecs": 5
+            },
+            {
+                "invoked": 3,
+                "onesec": "0.00",
+                "pid": 9619,
+                "process": "vsh.bin",
+                "runtime": 6,
+                "usecs": 2130
+            },
+            {
+                "invoked": 9,
+                "onesec": "0.00",
+                "pid": 9620,
+                "process": "ps",
+                "runtime": 25,
+                "usecs": 2885
+            },
+            {
+                "invoked": 1,
+                "onesec": "0.00",
+                "pid": 11550,
+                "process": "sshd",
+                "runtime": 0,
+                "usecs": 856
+            },
+            {
+                "invoked": 1823,
+                "onesec": "0.00",
+                "pid": 12019,
+                "process": "loop7",
+                "runtime": 73,
+                "usecs": 40
+            },
+            {
+                "invoked": 14,
+                "onesec": "0.00",
+                "pid": 12022,
+                "process": "loop8",
+                "runtime": 0,
+                "usecs": 16
+            },
+            {
+                "invoked": 42,
+                "onesec": "0.00",
+                "pid": 12025,
+                "process": "loop9",
+                "runtime": 1,
+                "usecs": 24
+            },
+            {
+                "invoked": 401,
+                "onesec": "0.00",
+                "pid": 12190,
+                "process": "jbd2/sda4-8",
+                "runtime": 27,
+                "usecs": 67
+            },
+            {
+                "invoked": 2,
+                "onesec": "0.00",
+                "pid": 12191,
+                "process": "ext4-dio-unwrit",
+                "runtime": 0,
+                "usecs": 5
+            },
+            {
+                "invoked": 37,
+                "onesec": "0.00",
+                "pid": 12351,
+                "process": "portmap",
+                "runtime": 2,
+                "usecs": 69
+            },
+            {
+                "invoked": 2,
+                "onesec": "0.00",
+                "pid": 12494,
+                "process": "lockd",
+                "runtime": 0,
+                "usecs": 8
+            },
+            {
+                "invoked": 164,
+                "onesec": "0.00",
+                "pid": 12495,
+                "process": "nfsd",
+                "runtime": 0,
+                "usecs": 2
+            },
+            {
+                "invoked": 1,
+                "onesec": "0.00",
+                "pid": 12497,
+                "process": "rpc.mountd",
+                "runtime": 0,
+                "usecs": 352
+            },
+            {
+                "invoked": 6,
+                "onesec": "0.00",
+                "pid": 12499,
+                "process": "rpc.statd",
+                "runtime": 2,
+                "usecs": 400
+            },
+            {
+                "invoked": 6,
+                "onesec": "0.00",
+                "pid": 14900,
+                "process": "nginx_1",
+                "runtime": 1,
+                "usecs": 229
+            },
+            {
+                "invoked": 3988,
+                "onesec": "0.00",
+                "pid": 14913,
+                "process": "nginx_1",
+                "runtime": 5008,
+                "usecs": 1255
+            },
+            {
+                "invoked": 2,
+                "onesec": "0.00",
+                "pid": 15420,
+                "process": "mcelog",
+                "runtime": 0,
+                "usecs": 159
+            },
+            {
+                "invoked": 77582,
+                "onesec": "0.00",
+                "pid": 15555,
+                "process": "vsh.bin",
+                "runtime": 2339,
+                "usecs": 30
+            },
+            {
+                "invoked": 7,
+                "onesec": "0.00",
+                "pid": 16873,
+                "process": "libvirtd_mon.sh",
+                "runtime": 12,
+                "usecs": 1824
+            },
+            {
+                "invoked": 8,
+                "onesec": "0.00",
+                "pid": 16874,
+                "process": "sh",
+                "runtime": 12,
+                "usecs": 1619
+            },
+            {
+                "invoked": 1219520,
+                "onesec": "0.00",
+                "pid": 16875,
+                "process": "sysmgr",
+                "runtime": 73323,
+                "usecs": 60
+            },
+            {
+                "invoked": 1183741,
+                "onesec": "0.00",
+                "pid": 16876,
+                "process": "sysmgr",
+                "runtime": 43229,
+                "usecs": 36
+            },
+            {
+                "invoked": 5,
+                "onesec": "0.00",
+                "pid": 16885,
+                "process": "inotifywait",
+                "runtime": 28,
+                "usecs": 5788
+            },
+            {
+                "invoked": 53,
+                "onesec": "0.00",
+                "pid": 16886,
+                "process": "libvirtd",
+                "runtime": 186,
+                "usecs": 3518
+            },
+            {
+                "invoked": 1,
+                "onesec": "0.00",
+                "pid": 21291,
+                "process": "mping-thread",
+                "runtime": 0,
+                "usecs": 19
+            },
+            {
+                "invoked": 1,
+                "onesec": "0.00",
+                "pid": 21292,
+                "process": "mping-thread",
+                "runtime": 0,
+                "usecs": 14
+            },
+            {
+                "invoked": 1,
+                "onesec": "0.00",
+                "pid": 21552,
+                "process": "cctrl_kthread",
+                "runtime": 0,
+                "usecs": 7
+            },
+            {
+                "invoked": 2,
+                "onesec": "0.00",
+                "pid": 22138,
+                "process": "redun_kthread",
+                "runtime": 0,
+                "usecs": 19
+            },
+            {
+                "invoked": 333,
+                "onesec": "0.00",
+                "pid": 22408,
+                "process": "usd_mts_kthread",
+                "runtime": 5,
+                "usecs": 17
+            },
+            {
+                "invoked": 292944,
+                "onesec": "0.00",
+                "pid": 22931,
+                "process": "ls-notify-mts-t",
+                "runtime": 637,
+                "usecs": 2
+            },
+            {
+                "invoked": 65211,
+                "onesec": "0.00",
+                "pid": 25604,
+                "process": "vsh.bin",
+                "runtime": 1752,
+                "usecs": 26
+            },
+            {
+                "invoked": 54,
+                "onesec": "0.00",
+                "pid": 25974,
+                "process": "bootflash_sync.",
+                "runtime": 29,
+                "usecs": 549
+            },
+            {
+                "invoked": 43,
+                "onesec": "0.00",
+                "pid": 25995,
+                "process": "inotifywait",
+                "runtime": 8,
+                "usecs": 192
+            },
+            {
+                "invoked": 81,
+                "onesec": "0.00",
+                "pid": 26269,
+                "process": "sdwrapd",
+                "runtime": 299,
+                "usecs": 3691
+            },
+            {
+                "invoked": 37046015,
+                "onesec": "0.00",
+                "pid": 26271,
+                "process": "pfmclnt",
+                "runtime": 1502610,
+                "usecs": 40
+            },
+            {
+                "invoked": 13,
+                "onesec": "0.00",
+                "pid": 26449,
+                "process": "xinetd",
+                "runtime": 11,
+                "usecs": 922
+            },
+            {
+                "invoked": 6,
+                "onesec": "0.00",
+                "pid": 26450,
+                "process": "tftpd",
+                "runtime": 8,
+                "usecs": 1336
+            },
+            {
+                "invoked": 585990,
+                "onesec": "0.00",
+                "pid": 26451,
+                "process": "syslogd",
+                "runtime": 24369,
+                "usecs": 41
+            },
+            {
+                "invoked": 50,
+                "onesec": "0.00",
+                "pid": 26452,
+                "process": "sdwrapd",
+                "runtime": 142,
+                "usecs": 2842
+            },
+            {
+                "invoked": 977601,
+                "onesec": "0.00",
+                "pid": 26454,
+                "process": "platform",
+                "runtime": 287009,
+                "usecs": 293
+            },
+            {
+                "invoked": 98,
+                "onesec": "0.00",
+                "pid": 26461,
+                "process": "klogd",
+                "runtime": 36,
+                "usecs": 371
+            },
+            {
+                "invoked": 150557,
+                "onesec": "0.00",
+                "pid": 26462,
+                "process": "vshd",
+                "runtime": 4995,
+                "usecs": 33
+            },
+            {
+                "invoked": 9973,
+                "onesec": "0.00",
+                "pid": 26463,
+                "process": "template_manager",
+                "runtime": 807,
+                "usecs": 80
+            },
+            {
+                "invoked": 9998,
+                "onesec": "0.00",
+                "pid": 26464,
+                "process": "tamnw",
+                "runtime": 527,
+                "usecs": 52
+            },
+            {
+                "invoked": 59,
+                "onesec": "0.00",
+                "pid": 26465,
+                "process": "smm",
+                "runtime": 89,
+                "usecs": 1510
+            },
+            {
+                "invoked": 585610,
+                "onesec": "0.00",
+                "pid": 26466,
+                "process": "psshelper",
+                "runtime": 10690,
+                "usecs": 18
+            },
+            {
+                "invoked": 117658,
+                "onesec": "0.00",
+                "pid": 26467,
+                "process": "pixm_vl",
+                "runtime": 4800,
+                "usecs": 40
+            },
+            {
+                "invoked": 117313,
+                "onesec": "0.00",
+                "pid": 26468,
+                "process": "pixm_gl",
+                "runtime": 3439,
+                "usecs": 29
+            },
+            {
+                "invoked": 21,
+                "onesec": "0.00",
+                "pid": 26469,
+                "process": "nxapi",
+                "runtime": 94,
+                "usecs": 4497
+            },
+            {
+                "invoked": 9878,
+                "onesec": "0.00",
+                "pid": 26470,
+                "process": "mmode",
+                "runtime": 644,
+                "usecs": 65
+            },
+            {
+                "invoked": 9826,
+                "onesec": "0.00",
+                "pid": 26471,
+                "process": "lmgrd",
+                "runtime": 869,
+                "usecs": 88
+            },
+            {
+                "invoked": 36094,
+                "onesec": "0.00",
+                "pid": 26472,
+                "process": "fs-daemon",
+                "runtime": 11074,
+                "usecs": 306
+            },
+            {
+                "invoked": 50179,
+                "onesec": "0.00",
+                "pid": 26473,
+                "process": "feature-mgr",
+                "runtime": 2297,
+                "usecs": 45
+            },
+            {
+                "invoked": 2418,
+                "onesec": "0.00",
+                "pid": 26474,
+                "process": "confcheck",
+                "runtime": 391,
+                "usecs": 162
+            },
+            {
+                "invoked": 58645,
+                "onesec": "0.00",
+                "pid": 26475,
+                "process": "capability",
+                "runtime": 1542,
+                "usecs": 26
+            },
+            {
+                "invoked": 58723,
+                "onesec": "0.00",
+                "pid": 26476,
+                "process": "bloggerd",
+                "runtime": 1565,
+                "usecs": 26
+            },
+            {
+                "invoked": 585506,
+                "onesec": "0.00",
+                "pid": 26477,
+                "process": "psshelper_gsvc",
+                "runtime": 10814,
+                "usecs": 18
+            },
+            {
+                "invoked": 42679,
+                "onesec": "0.00",
+                "pid": 26487,
+                "process": "clis",
+                "runtime": 29441,
+                "usecs": 689
+            },
+            {
+                "invoked": 117367,
+                "onesec": "0.00",
+                "pid": 26488,
+                "process": "licmgr",
+                "runtime": 2588,
+                "usecs": 22
+            },
+            {
+                "invoked": 390658,
+                "onesec": "0.00",
+                "pid": 26491,
+                "process": "tams_proc",
+                "runtime": 28790,
+                "usecs": 73
+            },
+            {
+                "invoked": 9781,
+                "onesec": "0.00",
+                "pid": 26497,
+                "process": "cisco",
+                "runtime": 1301,
+                "usecs": 133
+            },
+            {
+                "invoked": 147443,
+                "onesec": "0.00",
+                "pid": 26501,
+                "process": "nginx",
+                "runtime": 3473,
+                "usecs": 23
+            },
+            {
+                "invoked": 364147,
+                "onesec": "0.00",
+                "pid": 26505,
+                "process": "tamd_proc",
+                "runtime": 39488,
+                "usecs": 108
+            },
+            {
+                "invoked": 1026592,
+                "onesec": "0.00",
+                "pid": 26507,
+                "process": "nginx",
+                "runtime": 21667,
+                "usecs": 21
+            },
+            {
+                "invoked": 195250,
+                "onesec": "0.00",
+                "pid": 26509,
+                "process": "xmlma",
+                "runtime": 4907,
+                "usecs": 25
+            },
+            {
+                "invoked": 117263,
+                "onesec": "0.00",
+                "pid": 26510,
+                "process": "vmm",
+                "runtime": 2916,
+                "usecs": 24
+            },
+            {
+                "invoked": 24621,
+                "onesec": "0.00",
+                "pid": 26511,
+                "process": "vman",
+                "runtime": 1646,
+                "usecs": 66
+            },
+            {
+                "invoked": 117447,
+                "onesec": "0.00",
+                "pid": 26512,
+                "process": "vdc_mgr",
+                "runtime": 3482,
+                "usecs": 29
+            },
+            {
+                "invoked": 117326,
+                "onesec": "0.00",
+                "pid": 26513,
+                "process": "usbhsd",
+                "runtime": 13222,
+                "usecs": 112
+            },
+            {
+                "invoked": 292805,
+                "onesec": "0.00",
+                "pid": 26514,
+                "process": "ttyd",
+                "runtime": 7062,
+                "usecs": 24
+            },
+            {
+                "invoked": 75197,
+                "onesec": "0.00",
+                "pid": 26515,
+                "process": "sysinfo",
+                "runtime": 3834,
+                "usecs": 50
+            },
+            {
+                "invoked": 58674,
+                "onesec": "0.00",
+                "pid": 26516,
+                "process": "snmpmib_proc",
+                "runtime": 1602,
+                "usecs": 27
+            },
+            {
+                "invoked": 117,
+                "onesec": "0.00",
+                "pid": 26517,
+                "process": "sksd",
+                "runtime": 200,
+                "usecs": 1715
+            },
+            {
+                "invoked": 11370,
+                "onesec": "0.00",
+                "pid": 26519,
+                "process": "res_mgr",
+                "runtime": 612,
+                "usecs": 53
+            },
+            {
+                "invoked": 585961,
+                "onesec": "0.00",
+                "pid": 26520,
+                "process": "plugin",
+                "runtime": 9055,
+                "usecs": 15
+            },
+            {
+                "invoked": 117485,
+                "onesec": "0.00",
+                "pid": 26521,
+                "process": "plog_sup",
+                "runtime": 3650,
+                "usecs": 31
+            },
+            {
+                "invoked": 585921,
+                "onesec": "0.00",
+                "pid": 26522,
+                "process": "patch-installer",
+                "runtime": 7238,
+                "usecs": 12
+            },
+            {
+                "invoked": 73,
+                "onesec": "0.00",
+                "pid": 26523,
+                "process": "nbproxy",
+                "runtime": 164,
+                "usecs": 2258
+            },
+            {
+                "invoked": 39099,
+                "onesec": "0.00",
+                "pid": 26524,
+                "process": "mvsh",
+                "runtime": 1104,
+                "usecs": 28
+            },
+            {
+                "invoked": 25,
+                "onesec": "0.00",
+                "pid": 26525,
+                "process": "mping_server",
+                "runtime": 42,
+                "usecs": 1704
+            },
+            {
+                "invoked": 175350,
+                "onesec": "0.00",
+                "pid": 26526,
+                "process": "module",
+                "runtime": 37533,
+                "usecs": 214
+            },
+            {
+                "invoked": 96,
+                "onesec": "0.00",
+                "pid": 26527,
+                "process": "kim",
+                "runtime": 270,
+                "usecs": 2817
+            },
+            {
+                "invoked": 39189,
+                "onesec": "0.00",
+                "pid": 26528,
+                "process": "evms",
+                "runtime": 1115,
+                "usecs": 28
+            },
+            {
+                "invoked": 117,
+                "onesec": "0.00",
+                "pid": 26530,
+                "process": "epld_upgrade_stdby",
+                "runtime": 182,
+                "usecs": 1563
+            },
+            {
+                "invoked": 122728,
+                "onesec": "0.00",
+                "pid": 26531,
+                "process": "diagclient",
+                "runtime": 247333,
+                "usecs": 2015
+            },
+            {
+                "invoked": 197418,
+                "onesec": "0.00",
+                "pid": 26532,
+                "process": "dhclient",
+                "runtime": 21793,
+                "usecs": 110
+            },
+            {
+                "invoked": 73015,
+                "onesec": "0.00",
+                "pid": 26533,
+                "process": "crdcfg_server",
+                "runtime": 14870,
+                "usecs": 203
+            },
+            {
+                "invoked": 98,
+                "onesec": "0.00",
+                "pid": 26534,
+                "process": "core-dmon",
+                "runtime": 191,
+                "usecs": 1954
+            },
+            {
+                "invoked": 624580,
+                "onesec": "0.00",
+                "pid": 26535,
+                "process": "clk_mgr",
+                "runtime": 40397,
+                "usecs": 64
+            },
+            {
+                "invoked": 118544,
+                "onesec": "0.00",
+                "pid": 26536,
+                "process": "bios_daemon",
+                "runtime": 35319,
+                "usecs": 297
+            },
+            {
+                "invoked": 73443,
+                "onesec": "0.00",
+                "pid": 26537,
+                "process": "ascii-cfg",
+                "runtime": 2539,
+                "usecs": 34
+            },
+            {
+                "invoked": 586483,
+                "onesec": "0.00",
+                "pid": 26538,
+                "process": "securityd",
+                "runtime": 8431,
+                "usecs": 14
+            },
+            {
+                "invoked": 585537,
+                "onesec": "0.00",
+                "pid": 26539,
+                "process": "cert_enroll",
+                "runtime": 9397,
+                "usecs": 16
+            },
+            {
+                "invoked": 587434,
+                "onesec": "0.00",
+                "pid": 26540,
+                "process": "aaa",
+                "runtime": 12878,
+                "usecs": 21
+            },
+            {
+                "invoked": 73338,
+                "onesec": "0.00",
+                "pid": 26541,
+                "process": "obfl",
+                "runtime": 3100,
+                "usecs": 42
+            },
+            {
+                "invoked": 118,
+                "onesec": "0.00",
+                "pid": 26546,
+                "process": "urib",
+                "runtime": 286,
+                "usecs": 2430
+            },
+            {
+                "invoked": 97042,
+                "onesec": "0.00",
+                "pid": 26547,
+                "process": "aclmgr",
+                "runtime": 33701,
+                "usecs": 347
+            },
+            {
+                "invoked": 29590,
+                "onesec": "0.00",
+                "pid": 26549,
+                "process": "evmc",
+                "runtime": 864,
+                "usecs": 29
+            },
+            {
+                "invoked": 45329,
+                "onesec": "0.00",
+                "pid": 26554,
+                "process": "xbar",
+                "runtime": 1343,
+                "usecs": 29
+            },
+            {
+                "invoked": 649687,
+                "onesec": "0.00",
+                "pid": 26572,
+                "process": "device_test",
+                "runtime": 35928,
+                "usecs": 55
+            },
+            {
+                "invoked": 91,
+                "onesec": "0.00",
+                "pid": 26576,
+                "process": "ExceptionLog",
+                "runtime": 152,
+                "usecs": 1674
+            },
+            {
+                "invoked": 299397,
+                "onesec": "0.00",
+                "pid": 26577,
+                "process": "bootvar",
+                "runtime": 17994,
+                "usecs": 60
+            },
+            {
+                "invoked": 117250,
+                "onesec": "0.00",
+                "pid": 26578,
+                "process": "cardclient",
+                "runtime": 5152,
+                "usecs": 43
+            },
+            {
+                "invoked": 275899,
+                "onesec": "0.00",
+                "pid": 26579,
+                "process": "diagmgr",
+                "runtime": 258012,
+                "usecs": 935
+            },
+            {
+                "invoked": 58986,
+                "onesec": "0.00",
+                "pid": 26581,
+                "process": "ifmgr",
+                "runtime": 2130,
+                "usecs": 36
+            },
+            {
+                "invoked": 142836,
+                "onesec": "0.00",
+                "pid": 26593,
+                "process": "sensor",
+                "runtime": 20610,
+                "usecs": 144
+            },
+            {
+                "invoked": 106635,
+                "onesec": "0.00",
+                "pid": 26594,
+                "process": "statsclient",
+                "runtime": 172224,
+                "usecs": 1615
+            },
+            {
+                "invoked": 571,
+                "onesec": "0.00",
+                "pid": 26608,
+                "process": "l3vm",
+                "runtime": 479,
+                "usecs": 840
+            },
+            {
+                "invoked": 52,
+                "onesec": "0.00",
+                "pid": 26778,
+                "process": "npacl",
+                "runtime": 216,
+                "usecs": 4172
+            },
+            {
+                "invoked": 1086,
+                "onesec": "0.00",
+                "pid": 26788,
+                "process": "incrond",
+                "runtime": 278,
+                "usecs": 256
+            },
+            {
+                "invoked": 77,
+                "onesec": "0.50",
+                "pid": 26791,
+                "process": "adjmgr",
+                "runtime": 138,
+                "usecs": 1799
+            },
+            {
+                "invoked": 236,
+                "onesec": "0.00",
+                "pid": 26792,
+                "process": "u6rib",
+                "runtime": 185,
+                "usecs": 785
+            },
+            {
+                "invoked": 106,
+                "onesec": "0.00",
+                "pid": 26813,
+                "process": "arp",
+                "runtime": 241,
+                "usecs": 2278
+            },
+            {
+                "invoked": 196,
+                "onesec": "0.00",
+                "pid": 26814,
+                "process": "icmpv6",
+                "runtime": 169,
+                "usecs": 864
+            },
+            {
+                "invoked": 87,
+                "onesec": "0.00",
+                "pid": 26818,
+                "process": "pktmgr",
+                "runtime": 210,
+                "usecs": 2423
+            },
+            {
+                "invoked": 91,
+                "onesec": "0.00",
+                "pid": 26840,
+                "process": "netstack",
+                "runtime": 400,
+                "usecs": 4396
+            },
+            {
+                "invoked": 585823,
+                "onesec": "0.00",
+                "pid": 26862,
+                "process": "radius",
+                "runtime": 18485,
+                "usecs": 31
+            },
+            {
+                "invoked": 157382,
+                "onesec": "0.00",
+                "pid": 26864,
+                "process": "cdp",
+                "runtime": 13238,
+                "usecs": 84
+            },
+            {
+                "invoked": 136834,
+                "onesec": "0.00",
+                "pid": 26865,
+                "process": "cfs",
+                "runtime": 5053,
+                "usecs": 36
+            },
+            {
+                "invoked": 27,
+                "onesec": "0.00",
+                "pid": 26867,
+                "process": "ip_dummy",
+                "runtime": 45,
+                "usecs": 1689
+            },
+            {
+                "invoked": 27,
+                "onesec": "0.00",
+                "pid": 26869,
+                "process": "ipv6_dummy",
+                "runtime": 31,
+                "usecs": 1175
+            },
+            {
+                "invoked": 117681,
+                "onesec": "0.00",
+                "pid": 26870,
+                "process": "otm",
+                "runtime": 3379,
+                "usecs": 28
+            },
+            {
+                "invoked": 309633,
+                "onesec": "0.00",
+                "pid": 26871,
+                "process": "snmpd",
+                "runtime": 79010,
+                "usecs": 255
+            },
+            {
+                "invoked": 33,
+                "onesec": "0.00",
+                "pid": 26872,
+                "process": "tcpudp_dummy",
+                "runtime": 33,
+                "usecs": 1018
+            },
+            {
+                "invoked": 148,
+                "onesec": "0.00",
+                "pid": 26875,
+                "process": "dcos-xinetd",
+                "runtime": 84,
+                "usecs": 573
+            },
+            {
+                "invoked": 586013,
+                "onesec": "0.00",
+                "pid": 26918,
+                "process": "callhome",
+                "runtime": 8929,
+                "usecs": 15
+            },
+            {
+                "invoked": 119383,
+                "onesec": "0.00",
+                "pid": 27808,
+                "process": "port-profile",
+                "runtime": 6953,
+                "usecs": 58
+            },
+            {
+                "invoked": 90171,
+                "onesec": "0.00",
+                "pid": 27817,
+                "process": "spm",
+                "runtime": 15184,
+                "usecs": 168
+            },
+            {
+                "invoked": 100,
+                "onesec": "0.00",
+                "pid": 27818,
+                "process": "rpm",
+                "runtime": 296,
+                "usecs": 2964
+            },
+            {
+                "invoked": 62969,
+                "onesec": "0.00",
+                "pid": 27819,
+                "process": "pltfm_config",
+                "runtime": 2867,
+                "usecs": 45
+            },
+            {
+                "invoked": 89921,
+                "onesec": "0.00",
+                "pid": 27820,
+                "process": "plcmgr",
+                "runtime": 15095,
+                "usecs": 167
+            },
+            {
+                "invoked": 152021,
+                "onesec": "0.00",
+                "pid": 27821,
+                "process": "pfstat",
+                "runtime": 27381,
+                "usecs": 180
+            },
+            {
+                "invoked": 39452,
+                "onesec": "0.00",
+                "pid": 27823,
+                "process": "ntp",
+                "runtime": 3838,
+                "usecs": 97
+            },
+            {
+                "invoked": 117387,
+                "onesec": "0.00",
+                "pid": 27824,
+                "process": "monitor",
+                "runtime": 3579,
+                "usecs": 30
+            },
+            {
+                "invoked": 117370,
+                "onesec": "0.00",
+                "pid": 27825,
+                "process": "lim",
+                "runtime": 3392,
+                "usecs": 28
+            },
+            {
+                "invoked": 572146,
+                "onesec": "0.00",
+                "pid": 27826,
+                "process": "l2rib",
+                "runtime": 32340,
+                "usecs": 56
+            },
+            {
+                "invoked": 39369,
+                "onesec": "0.00",
+                "pid": 27827,
+                "process": "ipfib",
+                "runtime": 2511,
+                "usecs": 63
+            },
+            {
+                "invoked": 411,
+                "onesec": "0.00",
+                "pid": 27829,
+                "process": "igmp",
+                "runtime": 734,
+                "usecs": 1786
+            },
+            {
+                "invoked": 62755,
+                "onesec": "0.00",
+                "pid": 27830,
+                "process": "eth_port_channel",
+                "runtime": 2314,
+                "usecs": 36
+            },
+            {
+                "invoked": 58795,
+                "onesec": "0.00",
+                "pid": 27831,
+                "process": "eltm",
+                "runtime": 1883,
+                "usecs": 32
+            },
+            {
+                "invoked": 72,
+                "onesec": "0.00",
+                "pid": 27832,
+                "process": "ecp",
+                "runtime": 152,
+                "usecs": 2114
+            },
+            {
+                "invoked": 19612,
+                "onesec": "0.00",
+                "pid": 27833,
+                "process": "adbm",
+                "runtime": 716,
+                "usecs": 36
+            },
+            {
+                "invoked": 42679,
+                "onesec": "0.00",
+                "pid": 27835,
+                "process": "acllog",
+                "runtime": 2115,
+                "usecs": 49
+            },
+            {
+                "invoked": 13897,
+                "onesec": "0.00",
+                "pid": 27853,
+                "process": "eth_dstats",
+                "runtime": 643,
+                "usecs": 46
+            },
+            {
+                "invoked": 1165855,
+                "onesec": "0.00",
+                "pid": 27854,
+                "process": "ipqosmgr",
+                "runtime": 1534299,
+                "usecs": 1316
+            },
+            {
+                "invoked": 586020,
+                "onesec": "0.00",
+                "pid": 27858,
+                "process": "ntpd",
+                "runtime": 21126,
+                "usecs": 36
+            },
+            {
+                "invoked": 59025,
+                "onesec": "0.00",
+                "pid": 27863,
+                "process": "vlan_mgr",
+                "runtime": 3649,
+                "usecs": 61
+            },
+            {
+                "invoked": 14280,
+                "onesec": "0.00",
+                "pid": 27869,
+                "process": "diag_port_lb",
+                "runtime": 2758,
+                "usecs": 193
+            },
+            {
+                "invoked": 11103,
+                "onesec": "0.00",
+                "pid": 27870,
+                "process": "ethpm",
+                "runtime": 1530,
+                "usecs": 137
+            },
+            {
+                "invoked": 59678,
+                "onesec": "0.00",
+                "pid": 27871,
+                "process": "l2fm",
+                "runtime": 2682,
+                "usecs": 44
+            },
+            {
+                "invoked": 3040279,
+                "onesec": "0.00",
+                "pid": 27873,
+                "process": "stp",
+                "runtime": 122483,
+                "usecs": 40
+            },
+            {
+                "invoked": 117178,
+                "onesec": "0.00",
+                "pid": 27874,
+                "process": "stripcl",
+                "runtime": 3105,
+                "usecs": 26
+            },
+            {
+                "invoked": 99351,
+                "onesec": "0.00",
+                "pid": 27884,
+                "process": "copp",
+                "runtime": 46469,
+                "usecs": 467
+            },
+            {
+                "invoked": 122185,
+                "onesec": "0.00",
+                "pid": 27887,
+                "process": "ufdm",
+                "runtime": 5128,
+                "usecs": 41
+            },
+            {
+                "invoked": 58570,
+                "onesec": "0.00",
+                "pid": 27888,
+                "process": "u2",
+                "runtime": 1504,
+                "usecs": 25
+            },
+            {
+                "invoked": 117169,
+                "onesec": "0.00",
+                "pid": 27889,
+                "process": "sal",
+                "runtime": 3002,
+                "usecs": 25
+            },
+            {
+                "invoked": 208,
+                "onesec": "0.00",
+                "pid": 27890,
+                "process": "mrib",
+                "runtime": 524,
+                "usecs": 2521
+            },
+            {
+                "invoked": 80205,
+                "onesec": "0.00",
+                "pid": 27891,
+                "process": "mfdm",
+                "runtime": 9240,
+                "usecs": 115
+            },
+            {
+                "invoked": 117189,
+                "onesec": "0.00",
+                "pid": 27892,
+                "process": "mcm",
+                "runtime": 3253,
+                "usecs": 27
+            },
+            {
+                "invoked": 73,
+                "onesec": "0.00",
+                "pid": 27893,
+                "process": "m6rib",
+                "runtime": 213,
+                "usecs": 2925
+            },
+            {
+                "invoked": 586718,
+                "onesec": "0.00",
+                "pid": 27894,
+                "process": "l2pt",
+                "runtime": 148562,
+                "usecs": 253
+            },
+            {
+                "invoked": 29309,
+                "onesec": "0.00",
+                "pid": 27920,
+                "process": "m2rib",
+                "runtime": 1070,
+                "usecs": 36
+            },
+            {
+                "invoked": 41,
+                "onesec": "0.00",
+                "pid": 27926,
+                "process": "mcastfwd",
+                "runtime": 147,
+                "usecs": 3607
+            },
+            {
+                "invoked": 17,
+                "onesec": "0.00",
+                "pid": 27941,
+                "process": "obfl_sup",
+                "runtime": 17,
+                "usecs": 1003
+            },
+            {
+                "invoked": 585829,
+                "onesec": "0.00",
+                "pid": 27963,
+                "process": "wdpunch_thread",
+                "runtime": 3702,
+                "usecs": 6
+            },
+            {
+                "invoked": 5,
+                "onesec": "0.00",
+                "pid": 29887,
+                "process": "kworker/3:0",
+                "runtime": 0,
+                "usecs": 6
+            },
+            {
+                "invoked": 1779,
+                "onesec": "0.00",
+                "pid": 29890,
+                "process": "jbd2/sda3-8",
+                "runtime": 79,
+                "usecs": 44
+            },
+            {
+                "invoked": 2,
+                "onesec": "0.00",
+                "pid": 29891,
+                "process": "ext4-dio-unwrit",
+                "runtime": 0,
+                "usecs": 5
+            },
+            {
+                "invoked": 2,
+                "onesec": "0.00",
+                "pid": 29929,
+                "process": "bkncmd",
+                "runtime": 0,
+                "usecs": 7
+            },
+            {
+                "invoked": 2,
+                "onesec": "0.00",
+                "pid": 29930,
+                "process": "bknevt",
+                "runtime": 0,
+                "usecs": 5
+            },
+            {
+                "invoked": 58585,
+                "onesec": "0.00",
+                "pid": 29948,
+                "process": "bloggerd",
+                "runtime": 1042,
+                "usecs": 17
+            },
+            {
+                "invoked": 585459,
+                "onesec": "0.00",
+                "pid": 29949,
+                "process": "psshelper",
+                "runtime": 10921,
+                "usecs": 18
+            },
+            {
+                "invoked": 585450,
+                "onesec": "0.00",
+                "pid": 29950,
+                "process": "psshelper",
+                "runtime": 11045,
+                "usecs": 18
+            },
+            {
+                "invoked": 118336,
+                "onesec": "0.00",
+                "pid": 29951,
+                "process": "plog_lc",
+                "runtime": 5004,
+                "usecs": 42
+            },
+            {
+                "invoked": 585856,
+                "onesec": "0.00",
+                "pid": 29952,
+                "process": "patch_installer",
+                "runtime": 7902,
+                "usecs": 13
+            },
+            {
+                "invoked": 73281,
+                "onesec": "0.00",
+                "pid": 29953,
+                "process": "obfl_lc",
+                "runtime": 2938,
+                "usecs": 40
+            },
+            {
+                "invoked": 39080,
+                "onesec": "0.00",
+                "pid": 29954,
+                "process": "mvsh",
+                "runtime": 792,
+                "usecs": 20
+            },
+            {
+                "invoked": 29365,
+                "onesec": "0.00",
+                "pid": 29957,
+                "process": "evmc",
+                "runtime": 601,
+                "usecs": 20
+            },
+            {
+                "invoked": 585889,
+                "onesec": "0.00",
+                "pid": 29958,
+                "process": "dt_helper",
+                "runtime": 13648,
+                "usecs": 23
+            },
+            {
+                "invoked": 19566,
+                "onesec": "0.00",
+                "pid": 29959,
+                "process": "diagclient",
+                "runtime": 448,
+                "usecs": 22
+            },
+            {
+                "invoked": 3105035,
+                "onesec": "0.00",
+                "pid": 29960,
+                "process": "crdcfg_server",
+                "runtime": 396460,
+                "usecs": 127
+            },
+            {
+                "invoked": 58631,
+                "onesec": "0.00",
+                "pid": 29961,
+                "process": "capability",
+                "runtime": 1745,
+                "usecs": 29
+            },
+            {
+                "invoked": 585834,
+                "onesec": "0.00",
+                "pid": 29962,
+                "process": "device_test",
+                "runtime": 12442,
+                "usecs": 21
+            },
+            {
+                "invoked": 1567280,
+                "onesec": "0.00",
+                "pid": 29963,
+                "process": "crdclient",
+                "runtime": 4789841,
+                "usecs": 3056
+            },
+            {
+                "invoked": 11,
+                "onesec": "0.00",
+                "pid": 29968,
+                "process": "obfl_lc",
+                "runtime": 18,
+                "usecs": 1666
+            },
+            {
+                "invoked": 4569017,
+                "onesec": "0.50",
+                "pid": 29971,
+                "process": "mtc_usd",
+                "runtime": 7208672,
+                "usecs": 1577
+            },
+            {
+                "invoked": 150818,
+                "onesec": "0.00",
+                "pid": 29972,
+                "process": "neutron_usd_uc",
+                "runtime": 5150,
+                "usecs": 34
+            },
+            {
+                "invoked": 439478,
+                "onesec": "0.00",
+                "pid": 30001,
+                "process": "bfdc",
+                "runtime": 15645,
+                "usecs": 35
+            },
+            {
+                "invoked": 172003,
+                "onesec": "0.00",
+                "pid": 30002,
+                "process": "iftmc",
+                "runtime": 14498,
+                "usecs": 84
+            },
+            {
+                "invoked": 117233,
+                "onesec": "0.00",
+                "pid": 30003,
+                "process": "pixc",
+                "runtime": 2367,
+                "usecs": 20
+            },
+            {
+                "invoked": 84890,
+                "onesec": "0.00",
+                "pid": 30004,
+                "process": "port_client",
+                "runtime": 7771,
+                "usecs": 91
+            },
+            {
+                "invoked": 6852391,
+                "onesec": "0.00",
+                "pid": 30005,
+                "process": "stats_client",
+                "runtime": 3879275,
+                "usecs": 566
+            },
+            {
+                "invoked": 16023,
+                "onesec": "0.00",
+                "pid": 30009,
+                "process": "mtm",
+                "runtime": 1114,
+                "usecs": 69
+            },
+            {
+                "invoked": 60814,
+                "onesec": "0.00",
+                "pid": 30010,
+                "process": "ipfib",
+                "runtime": 20314,
+                "usecs": 334
+            },
+            {
+                "invoked": 914755,
+                "onesec": "0.00",
+                "pid": 30012,
+                "process": "aclqos",
+                "runtime": 468869,
+                "usecs": 512
+            },
+            {
+                "invoked": 34496,
+                "onesec": "0.00",
+                "pid": 30013,
+                "process": "ptplc",
+                "runtime": 1929,
+                "usecs": 55
+            },
+            {
+                "invoked": 29308,
+                "onesec": "0.00",
+                "pid": 30019,
+                "process": "monc",
+                "runtime": 819,
+                "usecs": 27
+            },
+            {
+                "invoked": 63,
+                "onesec": "0.00",
+                "pid": 30074,
+                "process": "loop10",
+                "runtime": 1,
+                "usecs": 21
+            },
+            {
+                "invoked": 2,
+                "onesec": "0.00",
+                "pid": 30075,
+                "process": "ext4-dio-unwrit",
+                "runtime": 0,
+                "usecs": 6
+            },
+            {
+                "invoked": 64368,
+                "onesec": "0.00",
+                "pid": 30350,
+                "process": "lldp",
+                "runtime": 37765,
+                "usecs": 586
+            },
+            {
+                "invoked": 2,
+                "onesec": "0.00",
+                "pid": 30559,
+                "process": "jffs2_gcd_mtd2",
+                "runtime": 0,
+                "usecs": 9
+            },
+            {
+                "invoked": 175,
+                "onesec": "0.00",
+                "pid": 32748,
+                "process": "getty",
+                "runtime": 103,
+                "usecs": 592
+            }
+        ]
+    },
+    "idle_percent": "99.25",
+    "kernel_percent": "0.74",
+    "user_percent": "0.00"
+}

--- a/test/nxos/mocked_data/test_get_environment/normal/show_processes_memory_shared.json
+++ b/test/nxos/mocked_data/test_get_environment/normal/show_processes_memory_shared.json
@@ -1,0 +1,393 @@
+{
+    "TABLE_process_tag": {
+        "ROW_process_tag": {
+            "TABLE_SHOWPROC": {
+                "ROW_SHOWPROC": [
+                    {
+                        "TABLE_ONEITEM": {
+                            "ROW_ONEITEM": {
+                                "process-memory-share-proc-smr-name": "smm",
+                                "process-memory-share-smr-addr": "50000000",
+                                "process-memory-share-smr-avail": 1024,
+                                "process-memory-share-smr-empty-char": "",
+                                "process-memory-share-smr-ref-count": 49,
+                                "process-memory-share-smr-size": 1028,
+                                "process-memory-share-smr-star-char": {},
+                                "process-memory-share-smr-used": 4
+                            }
+                        },
+                        "process-memory-share-table-showproc-key": "/rsw/shm/smm"
+                    },
+                    {
+                        "TABLE_ONEITEM": {
+                            "ROW_ONEITEM": {
+                                "process-memory-share-proc-smr-name": "cli",
+                                "process-memory-share-smr-addr": "50101000",
+                                "process-memory-share-smr-avail": 31635,
+                                "process-memory-share-smr-empty-char": "",
+                                "process-memory-share-smr-ref-count": 19,
+                                "process-memory-share-smr-size": 71684,
+                                "process-memory-share-smr-star-char": "*",
+                                "process-memory-share-smr-used": 40049
+                            }
+                        },
+                        "process-memory-share-table-showproc-key": "/rsw/shm/cli"
+                    },
+                    {
+                        "TABLE_ONEITEM": {
+                            "ROW_ONEITEM": {
+                                "process-memory-share-dynamic-smr-name": "urib"
+                            }
+                        },
+                        "TABLE_ONEITEMDYNAMIC": {
+                            "ROW_ONEITEMDYNAMIC": {
+                                "process-memory-share-dynamic-plus-char": "+",
+                                "process-memory-share-dynamic-smr-addr": "54702000",
+                                "process-memory-share-dynamic-smr-avail": 1050,
+                                "process-memory-share-dynamic-smr-ref-count": "21",
+                                "process-memory-share-dynamic-smr-size": 2048,
+                                "process-memory-share-dynamic-smr-used": 998,
+                                "process-memory-share-max-mem-size-str": "(131076)"
+                            }
+                        },
+                        "process-memory-share-table-showproc-key": "/rsw/shm/urib"
+                    },
+                    {
+                        "TABLE_ONEITEM": {
+                            "ROW_ONEITEM": {
+                                "process-memory-share-proc-smr-name": "urib-pib",
+                                "process-memory-share-smr-addr": "5C703000",
+                                "process-memory-share-smr-avail": 771,
+                                "process-memory-share-smr-empty-char": "",
+                                "process-memory-share-smr-ref-count": 21,
+                                "process-memory-share-smr-size": 1028,
+                                "process-memory-share-smr-star-char": "*",
+                                "process-memory-share-smr-used": 257
+                            }
+                        },
+                        "process-memory-share-table-showproc-key": "/rsw/shm/urib-pib"
+                    },
+                    {
+                        "TABLE_ONEITEM": {
+                            "ROW_ONEITEM": {
+                                "process-memory-share-proc-smr-name": "urib-redist",
+                                "process-memory-share-smr-addr": "5C804000",
+                                "process-memory-share-smr-avail": 4324,
+                                "process-memory-share-smr-empty-char": "",
+                                "process-memory-share-smr-ref-count": 21,
+                                "process-memory-share-smr-size": 5124,
+                                "process-memory-share-smr-star-char": "*",
+                                "process-memory-share-smr-used": 800
+                            }
+                        },
+                        "process-memory-share-table-showproc-key": "/rsw/shm/urib-redist"
+                    },
+                    {
+                        "TABLE_ONEITEM": {
+                            "ROW_ONEITEM": {
+                                "process-memory-share-proc-smr-name": "urib-ufdm",
+                                "process-memory-share-smr-addr": "5CD05000",
+                                "process-memory-share-smr-avail": 8078,
+                                "process-memory-share-smr-empty-char": "",
+                                "process-memory-share-smr-ref-count": 1,
+                                "process-memory-share-smr-size": 8196,
+                                "process-memory-share-smr-star-char": "*",
+                                "process-memory-share-smr-used": 118
+                            }
+                        },
+                        "process-memory-share-table-showproc-key": "/rsw/shm/urib-ufdm"
+                    },
+                    {
+                        "TABLE_ONEITEM": {
+                            "ROW_ONEITEM": {
+                                "process-memory-share-proc-smr-name": "npacl",
+                                "process-memory-share-smr-addr": "5D506000",
+                                "process-memory-share-smr-avail": 4098,
+                                "process-memory-share-smr-empty-char": "",
+                                "process-memory-share-smr-ref-count": 2,
+                                "process-memory-share-smr-size": 4100,
+                                "process-memory-share-smr-star-char": "*",
+                                "process-memory-share-smr-used": 2
+                            }
+                        },
+                        "process-memory-share-table-showproc-key": "/rsw/shm/npacl"
+                    },
+                    {
+                        "TABLE_ONEITEM": {
+                            "ROW_ONEITEM": {
+                                "process-memory-share-proc-smr-name": "am",
+                                "process-memory-share-smr-addr": "5D907000",
+                                "process-memory-share-smr-avail": 827,
+                                "process-memory-share-smr-empty-char": "",
+                                "process-memory-share-smr-ref-count": 9,
+                                "process-memory-share-smr-size": 1028,
+                                "process-memory-share-smr-star-char": "*",
+                                "process-memory-share-smr-used": 201
+                            }
+                        },
+                        "process-memory-share-table-showproc-key": "/rsw/shm/am"
+                    },
+                    {
+                        "TABLE_ONEITEM": {
+                            "ROW_ONEITEM": {
+                                "process-memory-share-proc-smr-name": "am_lim",
+                                "process-memory-share-smr-addr": "5DA08000",
+                                "process-memory-share-smr-avail": 67,
+                                "process-memory-share-smr-empty-char": "",
+                                "process-memory-share-smr-ref-count": 9,
+                                "process-memory-share-smr-size": 68,
+                                "process-memory-share-smr-star-char": "*",
+                                "process-memory-share-smr-used": 1
+                            }
+                        },
+                        "process-memory-share-table-showproc-key": "/rsw/shm/am_lim"
+                    },
+                    {
+                        "TABLE_ONEITEM": {
+                            "ROW_ONEITEM": {
+                                "process-memory-share-dynamic-smr-name": "u6rib"
+                            }
+                        },
+                        "TABLE_ONEITEMDYNAMIC": {
+                            "ROW_ONEITEMDYNAMIC": {
+                                "process-memory-share-dynamic-plus-char": "+",
+                                "process-memory-share-dynamic-smr-addr": "5DA19000",
+                                "process-memory-share-dynamic-smr-avail": 598,
+                                "process-memory-share-dynamic-smr-ref-count": "12",
+                                "process-memory-share-dynamic-smr-size": 1024,
+                                "process-memory-share-dynamic-smr-used": 426,
+                                "process-memory-share-max-mem-size-str": "(98308)"
+                            }
+                        },
+                        "process-memory-share-table-showproc-key": "/rsw/shm/u6rib"
+                    },
+                    {
+                        "TABLE_ONEITEM": {
+                            "ROW_ONEITEM": {
+                                "process-memory-share-proc-smr-name": "u6rib-pib",
+                                "process-memory-share-smr-addr": "63A1A000",
+                                "process-memory-share-smr-avail": 752,
+                                "process-memory-share-smr-empty-char": "",
+                                "process-memory-share-smr-ref-count": 12,
+                                "process-memory-share-smr-size": 1028,
+                                "process-memory-share-smr-star-char": "*",
+                                "process-memory-share-smr-used": 276
+                            }
+                        },
+                        "process-memory-share-table-showproc-key": "/rsw/shm/u6rib-pib"
+                    },
+                    {
+                        "TABLE_ONEITEM": {
+                            "ROW_ONEITEM": {
+                                "process-memory-share-proc-smr-name": "u6rib-notify",
+                                "process-memory-share-smr-addr": "63B1B000",
+                                "process-memory-share-smr-avail": 3305,
+                                "process-memory-share-smr-empty-char": "",
+                                "process-memory-share-smr-ref-count": 12,
+                                "process-memory-share-smr-size": 4100,
+                                "process-memory-share-smr-star-char": "*",
+                                "process-memory-share-smr-used": 795
+                            }
+                        },
+                        "process-memory-share-table-showproc-key": "/rsw/shm/u6rib-notify"
+                    },
+                    {
+                        "TABLE_ONEITEM": {
+                            "ROW_ONEITEM": {
+                                "process-memory-share-proc-smr-name": "icmpv6",
+                                "process-memory-share-smr-addr": "63F1C000",
+                                "process-memory-share-smr-avail": 5659,
+                                "process-memory-share-smr-empty-char": "",
+                                "process-memory-share-smr-ref-count": 10,
+                                "process-memory-share-smr-size": 6148,
+                                "process-memory-share-smr-star-char": {},
+                                "process-memory-share-smr-used": 489
+                            }
+                        },
+                        "process-memory-share-table-showproc-key": "/rsw/shm/icmpv6"
+                    },
+                    {
+                        "TABLE_ONEITEM": {
+                            "ROW_ONEITEM": {
+                                "process-memory-share-proc-smr-name": "arp",
+                                "process-memory-share-smr-addr": "6451D000",
+                                "process-memory-share-smr-avail": 4099,
+                                "process-memory-share-smr-empty-char": "",
+                                "process-memory-share-smr-ref-count": 7,
+                                "process-memory-share-smr-size": 4100,
+                                "process-memory-share-smr-star-char": "*",
+                                "process-memory-share-smr-used": 1
+                            }
+                        },
+                        "process-memory-share-table-showproc-key": "/rsw/shm/arp"
+                    },
+                    {
+                        "TABLE_ONEITEM": {
+                            "ROW_ONEITEM": {
+                                "process-memory-share-proc-smr-name": "arplib",
+                                "process-memory-share-smr-addr": "6491E000",
+                                "process-memory-share-smr-avail": 12164,
+                                "process-memory-share-smr-empty-char": "",
+                                "process-memory-share-smr-ref-count": 1,
+                                "process-memory-share-smr-size": 12292,
+                                "process-memory-share-smr-star-char": "*",
+                                "process-memory-share-smr-used": 128
+                            }
+                        },
+                        "process-memory-share-table-showproc-key": "/rsw/shm/arplib"
+                    },
+                    {
+                        "TABLE_ONEITEM": {
+                            "ROW_ONEITEM": {
+                                "process-memory-share-proc-smr-name": "ip",
+                                "process-memory-share-smr-addr": "6551F000",
+                                "process-memory-share-smr-avail": 10025,
+                                "process-memory-share-smr-empty-char": "",
+                                "process-memory-share-smr-ref-count": 23,
+                                "process-memory-share-smr-size": 10244,
+                                "process-memory-share-smr-star-char": {},
+                                "process-memory-share-smr-used": 219
+                            }
+                        },
+                        "process-memory-share-table-showproc-key": "/rsw/shm/ip"
+                    },
+                    {
+                        "TABLE_ONEITEM": {
+                            "ROW_ONEITEM": {
+                                "process-memory-share-proc-smr-name": "ipv6",
+                                "process-memory-share-smr-addr": "65F20000",
+                                "process-memory-share-smr-avail": 11777,
+                                "process-memory-share-smr-empty-char": "",
+                                "process-memory-share-smr-ref-count": 11,
+                                "process-memory-share-smr-size": 12292,
+                                "process-memory-share-smr-star-char": {},
+                                "process-memory-share-smr-used": 515
+                            }
+                        },
+                        "process-memory-share-table-showproc-key": "/rsw/shm/ipv6"
+                    },
+                    {
+                        "TABLE_ONEITEM": {
+                            "ROW_ONEITEM": {
+                                "process-memory-share-dynamic-smr-name": "rpm"
+                            }
+                        },
+                        "TABLE_ONEITEMDYNAMIC": {
+                            "ROW_ONEITEMDYNAMIC": {
+                                "process-memory-share-dynamic-plus-char": "+",
+                                "process-memory-share-dynamic-smr-addr": "66B21000",
+                                "process-memory-share-dynamic-smr-avail": 2047,
+                                "process-memory-share-dynamic-smr-ref-count": "7",
+                                "process-memory-share-dynamic-smr-size": 2048,
+                                "process-memory-share-dynamic-smr-used": 1,
+                                "process-memory-share-max-mem-size-str": "(5124)"
+                            }
+                        },
+                        "process-memory-share-table-showproc-key": "/rsw/shm/rpm"
+                    },
+                    {
+                        "TABLE_ONEITEM": {
+                            "ROW_ONEITEM": {
+                                "process-memory-share-proc-smr-name": "igmp",
+                                "process-memory-share-smr-addr": "67022000",
+                                "process-memory-share-smr-avail": 3076,
+                                "process-memory-share-smr-empty-char": "",
+                                "process-memory-share-smr-ref-count": 2,
+                                "process-memory-share-smr-size": 3076,
+                                "process-memory-share-smr-star-char": {},
+                                "process-memory-share-smr-used": 0
+                            }
+                        },
+                        "process-memory-share-table-showproc-key": "/rsw/shm/igmp"
+                    },
+                    {
+                        "TABLE_ONEITEM": {
+                            "ROW_ONEITEM": {
+                                "process-memory-share-dynamic-smr-name": "m6rib"
+                            }
+                        },
+                        "TABLE_ONEITEMDYNAMIC": {
+                            "ROW_ONEITEMDYNAMIC": {
+                                "process-memory-share-dynamic-plus-char": "+",
+                                "process-memory-share-dynamic-smr-addr": "67323000",
+                                "process-memory-share-dynamic-smr-avail": 3060,
+                                "process-memory-share-dynamic-smr-ref-count": "3",
+                                "process-memory-share-dynamic-smr-size": 3072,
+                                "process-memory-share-dynamic-smr-used": 12,
+                                "process-memory-share-max-mem-size-str": "(8196)"
+                            }
+                        },
+                        "process-memory-share-table-showproc-key": "/rsw/shm/m6rib"
+                    },
+                    {
+                        "TABLE_ONEITEM": {
+                            "ROW_ONEITEM": {
+                                "process-memory-share-proc-smr-name": "m6rib-mfdm",
+                                "process-memory-share-smr-addr": "67B24000",
+                                "process-memory-share-smr-avail": 5124,
+                                "process-memory-share-smr-empty-char": "",
+                                "process-memory-share-smr-ref-count": 2,
+                                "process-memory-share-smr-size": 5124,
+                                "process-memory-share-smr-star-char": {},
+                                "process-memory-share-smr-used": 0
+                            }
+                        },
+                        "process-memory-share-table-showproc-key": "/rsw/shm/m6rib-mfdm"
+                    },
+                    {
+                        "TABLE_ONEITEM": {
+                            "ROW_ONEITEM": {
+                                "process-memory-share-dynamic-smr-name": "mrib"
+                            }
+                        },
+                        "TABLE_ONEITEMDYNAMIC": {
+                            "ROW_ONEITEMDYNAMIC": {
+                                "process-memory-share-dynamic-plus-char": "+",
+                                "process-memory-share-dynamic-smr-addr": "68025000",
+                                "process-memory-share-dynamic-smr-avail": 3069,
+                                "process-memory-share-dynamic-smr-ref-count": "3",
+                                "process-memory-share-dynamic-smr-size": 3072,
+                                "process-memory-share-dynamic-smr-used": 3,
+                                "process-memory-share-max-mem-size-str": "(59396)"
+                            }
+                        },
+                        "process-memory-share-table-showproc-key": "/rsw/shm/mrib"
+                    },
+                    {
+                        "TABLE_ONEITEM": {
+                            "ROW_ONEITEM": {
+                                "process-memory-share-proc-smr-name": "mrib-mfdm",
+                                "process-memory-share-smr-addr": "6BA26000",
+                                "process-memory-share-smr-avail": 4100,
+                                "process-memory-share-smr-empty-char": "",
+                                "process-memory-share-smr-ref-count": 1,
+                                "process-memory-share-smr-size": 4100,
+                                "process-memory-share-smr-star-char": "*",
+                                "process-memory-share-smr-used": 0
+                            }
+                        },
+                        "process-memory-share-table-showproc-key": "/rsw/shm/mrib-mfdm"
+                    },
+                    {
+                        "TABLE_ONEITEM": {
+                            "ROW_ONEITEM": {
+                                "process-memory-share-proc-smr-name": "mcastfwd",
+                                "process-memory-share-smr-addr": "6BE27000",
+                                "process-memory-share-smr-avail": 15350,
+                                "process-memory-share-smr-empty-char": "",
+                                "process-memory-share-smr-ref-count": 2,
+                                "process-memory-share-smr-size": 15364,
+                                "process-memory-share-smr-star-char": {},
+                                "process-memory-share-smr-used": 14
+                            }
+                        },
+                        "process-memory-share-table-showproc-key": "/rsw/shm/mcastfwd"
+                    }
+                ]
+            },
+            "process-memory-share-total-shm-avail": 417,
+            "process-memory-share-total-shm-size": 462,
+            "process-memory-share-total-shm-used": 45
+        }
+    }
+}

--- a/test/nxos/mocked_data/test_get_environment/pre_7.0/expected_result.json
+++ b/test/nxos/mocked_data/test_get_environment/pre_7.0/expected_result.json
@@ -1,0 +1,59 @@
+{
+    "cpu": {
+        "0": {
+            "%usage": 0.01
+        }
+    },
+    "fans": {
+        "Fan-1": {
+            "status": false
+        },
+        "Fan-2": {
+            "status": false
+        },
+        "Fan-3": {
+            "status": false
+        },
+        "Fan-4": {
+            "status": false
+        }
+    },
+    "memory": {
+        "available_ram": 268000,
+        "used_ram": 24000
+    },
+    "power": {
+        "1": {
+            "capacity": 400.0,
+            "output": 396.0,
+            "status": true
+        },
+        "2": {
+            "capacity": 400.0,
+            "output": 396.0,
+            "status": true
+        }
+    },
+    "temperature": {
+        "1-1 ASIC": {
+            "is_alert": true,
+            "is_critical": false,
+            "temperature": 37.0
+        },
+        "1-2 INTAKE": {
+            "is_alert": true,
+            "is_critical": false,
+            "temperature": 20.0
+        },
+        "1-3 ASIC": {
+            "is_alert": true,
+            "is_critical": false,
+            "temperature": 37.0
+        },
+        "1-4 INTAKE": {
+            "is_alert": true,
+            "is_critical": false,
+            "temperature": 20.0
+        }
+    }
+}

--- a/test/nxos/mocked_data/test_get_environment/pre_7.0/show_environment.json
+++ b/test/nxos/mocked_data/test_get_environment/pre_7.0/show_environment.json
@@ -1,0 +1,121 @@
+{
+    "TABLE_tempinfo": {
+        "ROW_tempinfo": [
+            {
+                "alarmstatus": "ok             ",
+                "curtemp": "37         ",
+                "majthres": "92           ",
+                "minthres": "85          ",
+                "sensor": "ASIC      ",
+                "tempmod": "1       "
+            },
+            {
+                "alarmstatus": "ok             ",
+                "curtemp": "20         ",
+                "majthres": "45           ",
+                "minthres": "31          ",
+                "sensor": "INTAKE    ",
+                "tempmod": "1       "
+            },
+            {
+                "alarmstatus": "ok             ",
+                "curtemp": "37         ",
+                "majthres": "110          ",
+                "minthres": "90          ",
+                "sensor": "ASIC      ",
+                "tempmod": "1       "
+            },
+            {
+                "alarmstatus": "ok             ",
+                "curtemp": "20         ",
+                "majthres": "70           ",
+                "minthres": "40          ",
+                "sensor": "INTAKE    ",
+                "tempmod": "1       "
+            }
+        ]
+    },
+    "fandetails": {
+        "TABLE_faninfo": {
+            "ROW_faninfo": [
+                {
+                    "fanhwver": "--",
+                    "fanmodel": "NXA-FAN-30CFM-F",
+                    "fanname": "Fan-1",
+                    "fanstatus": "ok"
+                },
+                {
+                    "fanhwver": "--",
+                    "fanmodel": "NXA-FAN-30CFM-F",
+                    "fanname": "Fan-2",
+                    "fanstatus": "ok"
+                },
+                {
+                    "fanhwver": "--",
+                    "fanmodel": "NXA-FAN-30CFM-F",
+                    "fanname": "Fan-3",
+                    "fanstatus": "ok"
+                },
+                {
+                    "fanhwver": "--",
+                    "fanmodel": "NXA-FAN-30CFM-F",
+                    "fanname": "Fan-4",
+                    "fanstatus": "ok"
+                },
+                {
+                    "fanhwver": "--",
+                    "fanmodel": "N2200-PAC-400W",
+                    "fanname": "PS-1",
+                    "fanstatus": "ok"
+                },
+                {
+                    "fanhwver": "--",
+                    "fanmodel": "N2200-PAC-400W",
+                    "fanname": "PS-2",
+                    "fanstatus": "ok"
+                }
+            ]
+        },
+        "fan_filter_status": "NotSupported"
+    },
+    "powersup": {
+        "TABLE_mod_pow_info": {
+            "ROW_mod_pow_info": {
+                "amps_alloced": "29.10  ",
+                "amps_requested": "29.10  ",
+                "mod_model": "N3K-C3548P-10GX-SUP",
+                "modnum": "1   ",
+                "modstatus": "powered-up          ",
+                "watts_alloced": "349.20 ",
+                "watts_requested": "349.20 "
+            }
+        },
+        "TABLE_psinfo": {
+            "ROW_psinfo": [
+                {
+                    "amps": "  33.00",
+                    "ps_status": "ok",
+                    "psmodel": "N2200-PAC-400W",
+                    "psnum": 1,
+                    "watts": " 396.00"
+                },
+                {
+                    "amps": "  33.00",
+                    "ps_status": "ok",
+                    "psmodel": "N2200-PAC-400W",
+                    "psnum": 2,
+                    "watts": " 396.00"
+                }
+            ]
+        },
+        "power_summary": {
+            "available_pow": "  442.80",
+            "pow_used_by_mods": "    0.00",
+            "ps_redun_mode": "redundant",
+            "ps_redun_op_mode": "Non-redundant",
+            "reserve_sup": "  349.20",
+            "tot_pow_capacity": "  792.00"
+        },
+        "voltage_level": 12
+    }
+}

--- a/test/nxos/mocked_data/test_get_environment/pre_7.0/show_processes_cpu.json
+++ b/test/nxos/mocked_data/test_get_environment/pre_7.0/show_processes_cpu.json
@@ -1,0 +1,1517 @@
+{
+    "TABLE_cpu_util": {
+        "ROW_cpu_util": {
+            "idle_percent": "99.99",
+            "kernel_percent": "0.00",
+            "user_percent": "0.00"
+        }
+    },
+    "TABLE_process_cpu": {
+        "ROW_process_cpu": [
+            {
+                "invoked": 4900233,
+                "onesec_percent": "0.00",
+                "pid": 1,
+                "process": "init",
+                "runtime": 292793,
+                "usecs": 59
+            },
+            {
+                "invoked": 500,
+                "onesec_percent": "0.00",
+                "pid": 2,
+                "process": "kthreadd",
+                "runtime": 5,
+                "usecs": 10
+            },
+            {
+                "invoked": 1117039,
+                "onesec_percent": "0.00",
+                "pid": 3,
+                "process": "migration/0",
+                "runtime": 4542,
+                "usecs": 4
+            },
+            {
+                "invoked": 12520316,
+                "onesec_percent": "0.00",
+                "pid": 4,
+                "process": "ksoftirqd/0",
+                "runtime": 611265,
+                "usecs": 48
+            },
+            {
+                "invoked": 3725933,
+                "onesec_percent": "0.00",
+                "pid": 5,
+                "process": "watchdog/0",
+                "runtime": 166082,
+                "usecs": 44
+            },
+            {
+                "invoked": 1315453,
+                "onesec_percent": "0.00",
+                "pid": 6,
+                "process": "migration/1",
+                "runtime": 5322,
+                "usecs": 4
+            },
+            {
+                "invoked": 6081495,
+                "onesec_percent": "0.00",
+                "pid": 7,
+                "process": "ksoftirqd/1",
+                "runtime": 356898,
+                "usecs": 58
+            },
+            {
+                "invoked": 3725933,
+                "onesec_percent": "0.00",
+                "pid": 8,
+                "process": "watchdog/1",
+                "runtime": 22745,
+                "usecs": 6
+            },
+            {
+                "invoked": 3563208,
+                "onesec_percent": "0.00",
+                "pid": 9,
+                "process": "migration/2",
+                "runtime": 12909,
+                "usecs": 3
+            },
+            {
+                "invoked": 6932949,
+                "onesec_percent": "0.00",
+                "pid": 10,
+                "process": "ksoftirqd/2",
+                "runtime": 350672,
+                "usecs": 50
+            },
+            {
+                "invoked": 3725933,
+                "onesec_percent": "0.00",
+                "pid": 11,
+                "process": "watchdog/2",
+                "runtime": 21857,
+                "usecs": 5
+            },
+            {
+                "invoked": 3489486,
+                "onesec_percent": "0.00",
+                "pid": 12,
+                "process": "migration/3",
+                "runtime": 12713,
+                "usecs": 3
+            },
+            {
+                "invoked": 7324957,
+                "onesec_percent": "0.00",
+                "pid": 13,
+                "process": "ksoftirqd/3",
+                "runtime": 389958,
+                "usecs": 53
+            },
+            {
+                "invoked": 3725933,
+                "onesec_percent": "0.00",
+                "pid": 14,
+                "process": "watchdog/3",
+                "runtime": 20910,
+                "usecs": 5
+            },
+            {
+                "invoked": 36475007,
+                "onesec_percent": "0.00",
+                "pid": 15,
+                "process": "events/0",
+                "runtime": 1406882,
+                "usecs": 38
+            },
+            {
+                "invoked": 23997480,
+                "onesec_percent": "0.00",
+                "pid": 16,
+                "process": "events/1",
+                "runtime": 156414,
+                "usecs": 6
+            },
+            {
+                "invoked": 24000617,
+                "onesec_percent": "0.00",
+                "pid": 17,
+                "process": "events/2",
+                "runtime": 155912,
+                "usecs": 6
+            },
+            {
+                "invoked": 24922183,
+                "onesec_percent": "0.00",
+                "pid": 18,
+                "process": "events/3",
+                "runtime": 157807,
+                "usecs": 6
+            },
+            {
+                "invoked": 57,
+                "onesec_percent": "0.00",
+                "pid": 19,
+                "process": "khelper",
+                "runtime": 1,
+                "usecs": 26
+            },
+            {
+                "invoked": 10,
+                "onesec_percent": "0.00",
+                "pid": 20,
+                "process": "netns",
+                "runtime": 30,
+                "usecs": 3090
+            },
+            {
+                "invoked": 54362,
+                "onesec_percent": "0.00",
+                "pid": 21,
+                "process": "kblockd/0",
+                "runtime": 567,
+                "usecs": 10
+            },
+            {
+                "invoked": 22113,
+                "onesec_percent": "0.00",
+                "pid": 22,
+                "process": "kblockd/1",
+                "runtime": 411,
+                "usecs": 18
+            },
+            {
+                "invoked": 24400,
+                "onesec_percent": "0.00",
+                "pid": 23,
+                "process": "kblockd/2",
+                "runtime": 302,
+                "usecs": 12
+            },
+            {
+                "invoked": 23548,
+                "onesec_percent": "0.00",
+                "pid": 24,
+                "process": "kblockd/3",
+                "runtime": 423,
+                "usecs": 17
+            },
+            {
+                "invoked": 2,
+                "onesec_percent": "0.00",
+                "pid": 25,
+                "process": "kacpid",
+                "runtime": 0,
+                "usecs": 0
+            },
+            {
+                "invoked": 2,
+                "onesec_percent": "0.00",
+                "pid": 26,
+                "process": "kacpi_notify",
+                "runtime": 0,
+                "usecs": 0
+            },
+            {
+                "invoked": 2,
+                "onesec_percent": "0.00",
+                "pid": 27,
+                "process": "ksuspend_usbd",
+                "runtime": 0,
+                "usecs": 0
+            },
+            {
+                "invoked": 61,
+                "onesec_percent": "0.00",
+                "pid": 28,
+                "process": "khubd",
+                "runtime": 2,
+                "usecs": 33
+            },
+            {
+                "invoked": 2565073,
+                "onesec_percent": "0.00",
+                "pid": 29,
+                "process": "pdflush",
+                "runtime": 76008,
+                "usecs": 29
+            },
+            {
+                "invoked": 2659589,
+                "onesec_percent": "0.00",
+                "pid": 30,
+                "process": "pdflush",
+                "runtime": 77346,
+                "usecs": 29
+            },
+            {
+                "invoked": 2,
+                "onesec_percent": "0.00",
+                "pid": 31,
+                "process": "kswapd0",
+                "runtime": 0,
+                "usecs": 1
+            },
+            {
+                "invoked": 2,
+                "onesec_percent": "0.00",
+                "pid": 32,
+                "process": "aio/0",
+                "runtime": 0,
+                "usecs": 2
+            },
+            {
+                "invoked": 2,
+                "onesec_percent": "0.00",
+                "pid": 33,
+                "process": "aio/1",
+                "runtime": 0,
+                "usecs": 2
+            },
+            {
+                "invoked": 2,
+                "onesec_percent": "0.00",
+                "pid": 34,
+                "process": "aio/2",
+                "runtime": 0,
+                "usecs": 1
+            },
+            {
+                "invoked": 2,
+                "onesec_percent": "0.00",
+                "pid": 35,
+                "process": "aio/3",
+                "runtime": 0,
+                "usecs": 1
+            },
+            {
+                "invoked": 2,
+                "onesec_percent": "0.00",
+                "pid": 36,
+                "process": "nfsiod",
+                "runtime": 0,
+                "usecs": 1
+            },
+            {
+                "invoked": 2,
+                "onesec_percent": "0.00",
+                "pid": 37,
+                "process": "kide/0",
+                "runtime": 0,
+                "usecs": 1
+            },
+            {
+                "invoked": 2,
+                "onesec_percent": "0.00",
+                "pid": 38,
+                "process": "kide/1",
+                "runtime": 0,
+                "usecs": 2
+            },
+            {
+                "invoked": 2,
+                "onesec_percent": "0.00",
+                "pid": 39,
+                "process": "kide/2",
+                "runtime": 0,
+                "usecs": 1
+            },
+            {
+                "invoked": 2,
+                "onesec_percent": "0.00",
+                "pid": 40,
+                "process": "kide/3",
+                "runtime": 0,
+                "usecs": 1
+            },
+            {
+                "invoked": 2,
+                "onesec_percent": "0.00",
+                "pid": 43,
+                "process": "rpciod/0",
+                "runtime": 0,
+                "usecs": 1
+            },
+            {
+                "invoked": 17,
+                "onesec_percent": "0.00",
+                "pid": 44,
+                "process": "rpciod/1",
+                "runtime": 0,
+                "usecs": 11
+            },
+            {
+                "invoked": 2,
+                "onesec_percent": "0.00",
+                "pid": 45,
+                "process": "rpciod/2",
+                "runtime": 0,
+                "usecs": 1
+            },
+            {
+                "invoked": 2,
+                "onesec_percent": "0.00",
+                "pid": 46,
+                "process": "rpciod/3",
+                "runtime": 0,
+                "usecs": 1
+            },
+            {
+                "invoked": 2,
+                "onesec_percent": "0.00",
+                "pid": 47,
+                "process": "scsi_eh_0",
+                "runtime": 0,
+                "usecs": 1
+            },
+            {
+                "invoked": 13191303,
+                "onesec_percent": "0.00",
+                "pid": 48,
+                "process": "usb-storage",
+                "runtime": 98629,
+                "usecs": 7
+            },
+            {
+                "invoked": 877530,
+                "onesec_percent": "0.00",
+                "pid": 520,
+                "process": "kjournald",
+                "runtime": 22631,
+                "usecs": 25
+            },
+            {
+                "invoked": 842239,
+                "onesec_percent": "0.00",
+                "pid": 525,
+                "process": "kjournald",
+                "runtime": 16594,
+                "usecs": 19
+            },
+            {
+                "invoked": 5111,
+                "onesec_percent": "0.00",
+                "pid": 741,
+                "process": "vsh",
+                "runtime": 636,
+                "usecs": 124
+            },
+            {
+                "invoked": 976719,
+                "onesec_percent": "0.00",
+                "pid": 1394,
+                "process": "kjournald",
+                "runtime": 20641,
+                "usecs": 21
+            },
+            {
+                "invoked": 7,
+                "onesec_percent": "0.00",
+                "pid": 1403,
+                "process": "jffs2_gcd_mtd2",
+                "runtime": 10,
+                "usecs": 1556
+            },
+            {
+                "invoked": 956633,
+                "onesec_percent": "0.00",
+                "pid": 1406,
+                "process": "kjournald",
+                "runtime": 23869,
+                "usecs": 24
+            },
+            {
+                "invoked": 30,
+                "onesec_percent": "0.00",
+                "pid": 1977,
+                "process": "portmap",
+                "runtime": 1,
+                "usecs": 38
+            },
+            {
+                "invoked": 6,
+                "onesec_percent": "0.00",
+                "pid": 1986,
+                "process": "rpc.statd",
+                "runtime": 4,
+                "usecs": 684
+            },
+            {
+                "invoked": 2,
+                "onesec_percent": "0.00",
+                "pid": 2001,
+                "process": "lockd",
+                "runtime": 0,
+                "usecs": 2
+            },
+            {
+                "invoked": 6670,
+                "onesec_percent": "0.00",
+                "pid": 2002,
+                "process": "nfsd",
+                "runtime": 49,
+                "usecs": 7
+            },
+            {
+                "invoked": 6670,
+                "onesec_percent": "0.00",
+                "pid": 2003,
+                "process": "nfsd",
+                "runtime": 58,
+                "usecs": 8
+            },
+            {
+                "invoked": 6670,
+                "onesec_percent": "0.00",
+                "pid": 2004,
+                "process": "nfsd",
+                "runtime": 38,
+                "usecs": 5
+            },
+            {
+                "invoked": 6671,
+                "onesec_percent": "0.00",
+                "pid": 2005,
+                "process": "nfsd",
+                "runtime": 45,
+                "usecs": 6
+            },
+            {
+                "invoked": 6670,
+                "onesec_percent": "0.00",
+                "pid": 2006,
+                "process": "nfsd",
+                "runtime": 33,
+                "usecs": 5
+            },
+            {
+                "invoked": 6673,
+                "onesec_percent": "0.00",
+                "pid": 2007,
+                "process": "nfsd",
+                "runtime": 47,
+                "usecs": 7
+            },
+            {
+                "invoked": 6671,
+                "onesec_percent": "0.00",
+                "pid": 2008,
+                "process": "nfsd",
+                "runtime": 32,
+                "usecs": 4
+            },
+            {
+                "invoked": 6669,
+                "onesec_percent": "0.00",
+                "pid": 2009,
+                "process": "nfsd",
+                "runtime": 53,
+                "usecs": 7
+            },
+            {
+                "invoked": 1,
+                "onesec_percent": "0.00",
+                "pid": 2014,
+                "process": "rpc.mountd",
+                "runtime": 0,
+                "usecs": 135
+            },
+            {
+                "invoked": 10,
+                "onesec_percent": "0.00",
+                "pid": 2037,
+                "process": "sh",
+                "runtime": 5,
+                "usecs": 552
+            },
+            {
+                "invoked": 53500223,
+                "onesec_percent": "0.00",
+                "pid": 2038,
+                "process": "sysmgr",
+                "runtime": 2517694,
+                "usecs": 47
+            },
+            {
+                "invoked": 23,
+                "onesec_percent": "0.00",
+                "pid": 2047,
+                "process": "libvirtd",
+                "runtime": 26,
+                "usecs": 1130
+            },
+            {
+                "invoked": 1,
+                "onesec_percent": "0.00",
+                "pid": 2799,
+                "process": "mping-thread",
+                "runtime": 0,
+                "usecs": 30
+            },
+            {
+                "invoked": 2,
+                "onesec_percent": "0.00",
+                "pid": 3222,
+                "process": "bond0",
+                "runtime": 0,
+                "usecs": 1
+            },
+            {
+                "invoked": 2,
+                "onesec_percent": "0.00",
+                "pid": 3537,
+                "process": "xinetd",
+                "runtime": 9,
+                "usecs": 4905
+            },
+            {
+                "invoked": 3,
+                "onesec_percent": "0.00",
+                "pid": 3538,
+                "process": "tftpd",
+                "runtime": 4,
+                "usecs": 1405
+            },
+            {
+                "invoked": 27059623,
+                "onesec_percent": "0.00",
+                "pid": 3539,
+                "process": "syslogd",
+                "runtime": 11619108,
+                "usecs": 429
+            },
+            {
+                "invoked": 752,
+                "onesec_percent": "0.00",
+                "pid": 3540,
+                "process": "sdwrapd",
+                "runtime": 264,
+                "usecs": 352
+            },
+            {
+                "invoked": 76729213,
+                "onesec_percent": "0.00",
+                "pid": 3541,
+                "process": "pfma",
+                "runtime": 63686187,
+                "usecs": 830
+            },
+            {
+                "invoked": 12000948,
+                "onesec_percent": "0.00",
+                "pid": 3551,
+                "process": "ls-notify-mts-t",
+                "runtime": 112983,
+                "usecs": 9
+            },
+            {
+                "invoked": 752561,
+                "onesec_percent": "0.00",
+                "pid": 3559,
+                "process": "usd_mts_kthread",
+                "runtime": 17393,
+                "usecs": 23
+            },
+            {
+                "invoked": 30832206,
+                "onesec_percent": "0.00",
+                "pid": 3573,
+                "process": "vshd",
+                "runtime": 1415340,
+                "usecs": 45
+            },
+            {
+                "invoked": 28,
+                "onesec_percent": "0.00",
+                "pid": 3574,
+                "process": "smm",
+                "runtime": 471,
+                "usecs": 16822
+            },
+            {
+                "invoked": 24007145,
+                "onesec_percent": "0.00",
+                "pid": 3575,
+                "process": "psshelper",
+                "runtime": 453014,
+                "usecs": 18
+            },
+            {
+                "invoked": 400303,
+                "onesec_percent": "0.00",
+                "pid": 3576,
+                "process": "lmgrd",
+                "runtime": 22903,
+                "usecs": 57
+            },
+            {
+                "invoked": 5618711,
+                "onesec_percent": "0.00",
+                "pid": 3577,
+                "process": "licmgr",
+                "runtime": 166849,
+                "usecs": 29
+            },
+            {
+                "invoked": 1784763,
+                "onesec_percent": "0.00",
+                "pid": 3578,
+                "process": "fs-daemon",
+                "runtime": 443983,
+                "usecs": 248
+            },
+            {
+                "invoked": 7583002,
+                "onesec_percent": "0.00",
+                "pid": 3579,
+                "process": "feature-mgr",
+                "runtime": 256070,
+                "usecs": 33
+            },
+            {
+                "invoked": 4802243,
+                "onesec_percent": "0.00",
+                "pid": 3580,
+                "process": "fcfwd",
+                "runtime": 109844,
+                "usecs": 22
+            },
+            {
+                "invoked": 21729,
+                "onesec_percent": "0.00",
+                "pid": 3581,
+                "process": "confcheck",
+                "runtime": 2908,
+                "usecs": 133
+            },
+            {
+                "invoked": 2444449,
+                "onesec_percent": "0.00",
+                "pid": 3582,
+                "process": "capability",
+                "runtime": 77766,
+                "usecs": 31
+            },
+            {
+                "invoked": 24007031,
+                "onesec_percent": "0.00",
+                "pid": 3583,
+                "process": "psshelper_gsvc",
+                "runtime": 445983,
+                "usecs": 18
+            },
+            {
+                "invoked": 801346,
+                "onesec_percent": "0.00",
+                "pid": 3590,
+                "process": "cisco",
+                "runtime": 134874,
+                "usecs": 168
+            },
+            {
+                "invoked": 2456483,
+                "onesec_percent": "0.00",
+                "pid": 3594,
+                "process": "clis",
+                "runtime": 246464,
+                "usecs": 100
+            },
+            {
+                "invoked": 6269273,
+                "onesec_percent": "0.00",
+                "pid": 3597,
+                "process": "port-profile",
+                "runtime": 441316,
+                "usecs": 70
+            },
+            {
+                "invoked": 2493481,
+                "onesec_percent": "0.00",
+                "pid": 3600,
+                "process": "provision",
+                "runtime": 89866,
+                "usecs": 36
+            },
+            {
+                "invoked": 8012157,
+                "onesec_percent": "0.00",
+                "pid": 3603,
+                "process": "xmlma",
+                "runtime": 184008,
+                "usecs": 22
+            },
+            {
+                "invoked": 4893983,
+                "onesec_percent": "0.00",
+                "pid": 3604,
+                "process": "vmm",
+                "runtime": 159553,
+                "usecs": 32
+            },
+            {
+                "invoked": 3010325,
+                "onesec_percent": "0.00",
+                "pid": 3605,
+                "process": "vman",
+                "runtime": 134960,
+                "usecs": 44
+            },
+            {
+                "invoked": 8927377,
+                "onesec_percent": "0.00",
+                "pid": 3606,
+                "process": "vdc_mgr",
+                "runtime": 1328765,
+                "usecs": 148
+            },
+            {
+                "invoked": 4899143,
+                "onesec_percent": "0.00",
+                "pid": 3607,
+                "process": "ufdm",
+                "runtime": 212978,
+                "usecs": 43
+            },
+            {
+                "invoked": 12011638,
+                "onesec_percent": "0.00",
+                "pid": 3608,
+                "process": "ttyd",
+                "runtime": 295740,
+                "usecs": 24
+            },
+            {
+                "invoked": 9089249,
+                "onesec_percent": "0.00",
+                "pid": 3609,
+                "process": "sysinfo",
+                "runtime": 630993,
+                "usecs": 69
+            },
+            {
+                "invoked": 721180662,
+                "onesec_percent": "0.00",
+                "pid": 3610,
+                "process": "statsclient",
+                "runtime": 18446744071771162624,
+                "usecs": 3267
+            },
+            {
+                "invoked": 18864,
+                "onesec_percent": "0.00",
+                "pid": 3611,
+                "process": "sksd",
+                "runtime": 6750,
+                "usecs": 357
+            },
+            {
+                "invoked": 4009999,
+                "onesec_percent": "0.00",
+                "pid": 3612,
+                "process": "sensor",
+                "runtime": 1962204,
+                "usecs": 489
+            },
+            {
+                "invoked": 2206757,
+                "onesec_percent": "0.00",
+                "pid": 3613,
+                "process": "scheduler",
+                "runtime": 91333,
+                "usecs": 41
+            },
+            {
+                "invoked": 480283,
+                "onesec_percent": "0.00",
+                "pid": 3614,
+                "process": "res_mgr",
+                "runtime": 15367,
+                "usecs": 31
+            },
+            {
+                "invoked": 4912377,
+                "onesec_percent": "0.00",
+                "pid": 3615,
+                "process": "pseudo_msrc",
+                "runtime": 157938,
+                "usecs": 32
+            },
+            {
+                "invoked": 24023175,
+                "onesec_percent": "0.00",
+                "pid": 3616,
+                "process": "plugin",
+                "runtime": 533415,
+                "usecs": 22
+            },
+            {
+                "invoked": 6524570,
+                "onesec_percent": "0.00",
+                "pid": 3617,
+                "process": "pltfm_config",
+                "runtime": 444831,
+                "usecs": 68
+            },
+            {
+                "invoked": 4818977,
+                "onesec_percent": "0.00",
+                "pid": 3618,
+                "process": "plog_sup",
+                "runtime": 151544,
+                "usecs": 31
+            },
+            {
+                "invoked": 91078844,
+                "onesec_percent": "0.00",
+                "pid": 3619,
+                "process": "pfstat",
+                "runtime": 8437739,
+                "usecs": 92
+            },
+            {
+                "invoked": 847612,
+                "onesec_percent": "0.00",
+                "pid": 3620,
+                "process": "patch-installer",
+                "runtime": 20073,
+                "usecs": 23
+            },
+            {
+                "invoked": 3031119,
+                "onesec_percent": "0.00",
+                "pid": 3621,
+                "process": "obfl",
+                "runtime": 99704,
+                "usecs": 32
+            },
+            {
+                "invoked": 5113,
+                "onesec_percent": "0.00",
+                "pid": 3622,
+                "process": "npacl",
+                "runtime": 598,
+                "usecs": 117
+            },
+            {
+                "invoked": 2454195,
+                "onesec_percent": "0.00",
+                "pid": 3623,
+                "process": "nohms",
+                "runtime": 80938,
+                "usecs": 32
+            },
+            {
+                "invoked": 284477067,
+                "onesec_percent": "0.00",
+                "pid": 3624,
+                "process": "neutron_usd_uc",
+                "runtime": 31147508,
+                "usecs": 109
+            },
+            {
+                "invoked": 1631998,
+                "onesec_percent": "0.00",
+                "pid": 3625,
+                "process": "mvsh",
+                "runtime": 53481,
+                "usecs": 32
+            },
+            {
+                "invoked": 416827175,
+                "onesec_percent": "0.00",
+                "pid": 3626,
+                "process": "mtc_usd",
+                "runtime": 18446744071839766528,
+                "usecs": 5818
+            },
+            {
+                "invoked": 5888573,
+                "onesec_percent": "0.00",
+                "pid": 3627,
+                "process": "mfdm",
+                "runtime": 305229,
+                "usecs": 51
+            },
+            {
+                "invoked": 4906693,
+                "onesec_percent": "0.00",
+                "pid": 3628,
+                "process": "mcm",
+                "runtime": 180602,
+                "usecs": 36
+            },
+            {
+                "invoked": 24011093,
+                "onesec_percent": "0.00",
+                "pid": 3629,
+                "process": "ledmgr",
+                "runtime": 529800,
+                "usecs": 22
+            },
+            {
+                "invoked": 6692508,
+                "onesec_percent": "0.00",
+                "pid": 3630,
+                "process": "ifmgr",
+                "runtime": 608244,
+                "usecs": 90
+            },
+            {
+                "invoked": 4809462,
+                "onesec_percent": "0.00",
+                "pid": 3631,
+                "process": "idehsd",
+                "runtime": 467359,
+                "usecs": 97
+            },
+            {
+                "invoked": 1630300,
+                "onesec_percent": "0.00",
+                "pid": 3632,
+                "process": "evms",
+                "runtime": 53337,
+                "usecs": 32
+            },
+            {
+                "invoked": 1227432,
+                "onesec_percent": "0.00",
+                "pid": 3634,
+                "process": "evmc",
+                "runtime": 42357,
+                "usecs": 34
+            },
+            {
+                "invoked": 1215005,
+                "onesec_percent": "0.00",
+                "pid": 3635,
+                "process": "ethpc",
+                "runtime": 6996004,
+                "usecs": 5758
+            },
+            {
+                "invoked": 2423070,
+                "onesec_percent": "0.00",
+                "pid": 3636,
+                "process": "eth_dstats",
+                "runtime": 154530,
+                "usecs": 63
+            },
+            {
+                "invoked": 748,
+                "onesec_percent": "0.00",
+                "pid": 3637,
+                "process": "core-dmon",
+                "runtime": 2230,
+                "usecs": 2982
+            },
+            {
+                "invoked": 24033460,
+                "onesec_percent": "0.00",
+                "pid": 3638,
+                "process": "callhome",
+                "runtime": 439365,
+                "usecs": 18
+            },
+            {
+                "invoked": 12025237,
+                "onesec_percent": "0.00",
+                "pid": 3639,
+                "process": "bootvar",
+                "runtime": 216507,
+                "usecs": 18
+            },
+            {
+                "invoked": 4818375,
+                "onesec_percent": "0.00",
+                "pid": 3640,
+                "process": "bios_daemon",
+                "runtime": 104370,
+                "usecs": 21
+            },
+            {
+                "invoked": 15512602,
+                "onesec_percent": "0.00",
+                "pid": 3641,
+                "process": "bfdc",
+                "runtime": 378068,
+                "usecs": 24
+            },
+            {
+                "invoked": 3033425,
+                "onesec_percent": "0.00",
+                "pid": 3642,
+                "process": "ascii-cfg",
+                "runtime": 71874,
+                "usecs": 23
+            },
+            {
+                "invoked": 24148343,
+                "onesec_percent": "0.00",
+                "pid": 3643,
+                "process": "securityd",
+                "runtime": 559767,
+                "usecs": 23
+            },
+            {
+                "invoked": 24014621,
+                "onesec_percent": "0.00",
+                "pid": 3644,
+                "process": "cert_enroll",
+                "runtime": 420085,
+                "usecs": 17
+            },
+            {
+                "invoked": 79336706,
+                "onesec_percent": "0.00",
+                "pid": 3645,
+                "process": "aaa",
+                "runtime": 175669735,
+                "usecs": 2214
+            },
+            {
+                "invoked": 546,
+                "onesec_percent": "0.00",
+                "pid": 3648,
+                "process": "l3vm",
+                "runtime": 509,
+                "usecs": 932
+            },
+            {
+                "invoked": 561,
+                "onesec_percent": "0.00",
+                "pid": 3651,
+                "process": "urib",
+                "runtime": 515,
+                "usecs": 919
+            },
+            {
+                "invoked": 314,
+                "onesec_percent": "0.00",
+                "pid": 3677,
+                "process": "adjmgr",
+                "runtime": 477,
+                "usecs": 1521
+            },
+            {
+                "invoked": 330,
+                "onesec_percent": "0.00",
+                "pid": 3679,
+                "process": "mrib",
+                "runtime": 513,
+                "usecs": 1556
+            },
+            {
+                "invoked": 88,
+                "onesec_percent": "0.00",
+                "pid": 3680,
+                "process": "u6rib",
+                "runtime": 498,
+                "usecs": 5660
+            },
+            {
+                "invoked": 812186,
+                "onesec_percent": "0.00",
+                "pid": 3685,
+                "process": "aclmgr",
+                "runtime": 279276,
+                "usecs": 343
+            },
+            {
+                "invoked": 26790203,
+                "onesec_percent": "0.00",
+                "pid": 3691,
+                "process": "snmpd",
+                "runtime": 3072740,
+                "usecs": 114
+            },
+            {
+                "invoked": 17,
+                "onesec_percent": "0.00",
+                "pid": 3694,
+                "process": "core-client",
+                "runtime": 12,
+                "usecs": 738
+            },
+            {
+                "invoked": 420790,
+                "onesec_percent": "0.00",
+                "pid": 3752,
+                "process": "spm",
+                "runtime": 19098,
+                "usecs": 45
+            },
+            {
+                "invoked": 881,
+                "onesec_percent": "0.00",
+                "pid": 3770,
+                "process": "arp",
+                "runtime": 583,
+                "usecs": 662
+            },
+            {
+                "invoked": 77,
+                "onesec_percent": "0.00",
+                "pid": 3771,
+                "process": "icmpv6",
+                "runtime": 568,
+                "usecs": 7382
+            },
+            {
+                "invoked": 994,
+                "onesec_percent": "0.00",
+                "pid": 3774,
+                "process": "m6rib",
+                "runtime": 2691,
+                "usecs": 2707
+            },
+            {
+                "invoked": 4930244,
+                "onesec_percent": "0.00",
+                "pid": 3777,
+                "process": "sal",
+                "runtime": 3182502,
+                "usecs": 645
+            },
+            {
+                "invoked": 97174226,
+                "onesec_percent": "0.00",
+                "pid": 3787,
+                "process": "fwm",
+                "runtime": 21489146,
+                "usecs": 221
+            },
+            {
+                "invoked": 11920,
+                "onesec_percent": "0.00",
+                "pid": 3788,
+                "process": "ptplc",
+                "runtime": 2462,
+                "usecs": 206
+            },
+            {
+                "invoked": 2983459,
+                "onesec_percent": "0.00",
+                "pid": 3789,
+                "process": "qd",
+                "runtime": 68333,
+                "usecs": 22
+            },
+            {
+                "invoked": 53371155,
+                "onesec_percent": "0.00",
+                "pid": 3916,
+                "process": "afm",
+                "runtime": 979231,
+                "usecs": 18
+            },
+            {
+                "invoked": 38591749,
+                "onesec_percent": "0.00",
+                "pid": 3917,
+                "process": "ipfib",
+                "runtime": 1859939,
+                "usecs": 48
+            },
+            {
+                "invoked": 1240143,
+                "onesec_percent": "0.00",
+                "pid": 3918,
+                "process": "m2rib",
+                "runtime": 52008,
+                "usecs": 41
+            },
+            {
+                "invoked": 4914472,
+                "onesec_percent": "0.00",
+                "pid": 3919,
+                "process": "monitor",
+                "runtime": 211030,
+                "usecs": 42
+            },
+            {
+                "invoked": 244,
+                "onesec_percent": "0.00",
+                "pid": 3920,
+                "process": "netstack",
+                "runtime": 698,
+                "usecs": 2862
+            },
+            {
+                "invoked": 12139451,
+                "onesec_percent": "0.00",
+                "pid": 3955,
+                "process": "eth_port_channel",
+                "runtime": 611187,
+                "usecs": 50
+            },
+            {
+                "invoked": 2437859,
+                "onesec_percent": "0.00",
+                "pid": 3956,
+                "process": "vlan_mgr",
+                "runtime": 173379,
+                "usecs": 71
+            },
+            {
+                "invoked": 24018264,
+                "onesec_percent": "0.00",
+                "pid": 3976,
+                "process": "radius",
+                "runtime": 669722,
+                "usecs": 27
+            },
+            {
+                "invoked": 1212108,
+                "onesec_percent": "0.00",
+                "pid": 3979,
+                "process": "acllog",
+                "runtime": 61512,
+                "usecs": 50
+            },
+            {
+                "invoked": 241891633,
+                "onesec_percent": "0.00",
+                "pid": 3980,
+                "process": "cfs",
+                "runtime": 16069019,
+                "usecs": 66
+            },
+            {
+                "invoked": 3920,
+                "onesec_percent": "0.00",
+                "pid": 3981,
+                "process": "igmp",
+                "runtime": 563,
+                "usecs": 143
+            },
+            {
+                "invoked": 145,
+                "onesec_percent": "0.00",
+                "pid": 3982,
+                "process": "ip_dummy",
+                "runtime": 17,
+                "usecs": 122
+            },
+            {
+                "invoked": 145,
+                "onesec_percent": "0.00",
+                "pid": 3983,
+                "process": "ipv6_dummy",
+                "runtime": 18,
+                "usecs": 126
+            },
+            {
+                "invoked": 1434571,
+                "onesec_percent": "0.00",
+                "pid": 3984,
+                "process": "ntp",
+                "runtime": 91890,
+                "usecs": 64
+            },
+            {
+                "invoked": 4916008,
+                "onesec_percent": "0.00",
+                "pid": 3985,
+                "process": "otm",
+                "runtime": 159998,
+                "usecs": 32
+            },
+            {
+                "invoked": 151,
+                "onesec_percent": "0.00",
+                "pid": 3986,
+                "process": "pktmgr_dummy",
+                "runtime": 18,
+                "usecs": 121
+            },
+            {
+                "invoked": 2758,
+                "onesec_percent": "0.00",
+                "pid": 3987,
+                "process": "rpm",
+                "runtime": 517,
+                "usecs": 187
+            },
+            {
+                "invoked": 273,
+                "onesec_percent": "0.00",
+                "pid": 3988,
+                "process": "tcpudp_dummy",
+                "runtime": 19,
+                "usecs": 71
+            },
+            {
+                "invoked": 432750,
+                "onesec_percent": "0.00",
+                "pid": 3994,
+                "process": "copp",
+                "runtime": 179783,
+                "usecs": 415
+            },
+            {
+                "invoked": 393,
+                "onesec_percent": "0.00",
+                "pid": 3996,
+                "process": "dcos-xinetd",
+                "runtime": 508,
+                "usecs": 1292
+            },
+            {
+                "invoked": 5816420,
+                "onesec_percent": "0.00",
+                "pid": 3997,
+                "process": "cdp",
+                "runtime": 199409,
+                "usecs": 34
+            },
+            {
+                "invoked": 13880707,
+                "onesec_percent": "0.00",
+                "pid": 3998,
+                "process": "lldp",
+                "runtime": 3019661,
+                "usecs": 217
+            },
+            {
+                "invoked": 6205278,
+                "onesec_percent": "0.00",
+                "pid": 4002,
+                "process": "ipqosmgr",
+                "runtime": 2625660,
+                "usecs": 423
+            },
+            {
+                "invoked": 13860663,
+                "onesec_percent": "0.00",
+                "pid": 4003,
+                "process": "lacp",
+                "runtime": 791243,
+                "usecs": 57
+            },
+            {
+                "invoked": 237161866,
+                "onesec_percent": "0.00",
+                "pid": 4021,
+                "process": "ethpm",
+                "runtime": 35900302,
+                "usecs": 151
+            },
+            {
+                "invoked": 35877032,
+                "onesec_percent": "0.00",
+                "pid": 4035,
+                "process": "ntpd",
+                "runtime": 1311731,
+                "usecs": 36
+            },
+            {
+                "invoked": 80,
+                "onesec_percent": "0.00",
+                "pid": 4041,
+                "process": "mcastfwd",
+                "runtime": 492,
+                "usecs": 6152
+            },
+            {
+                "invoked": 124690448,
+                "onesec_percent": "0.00",
+                "pid": 4049,
+                "process": "stp",
+                "runtime": 6129821,
+                "usecs": 49
+            },
+            {
+                "invoked": 4800787,
+                "onesec_percent": "0.00",
+                "pid": 4130,
+                "process": "wdpunch_thread",
+                "runtime": 78783,
+                "usecs": 16
+            },
+            {
+                "invoked": 2,
+                "onesec_percent": "0.00",
+                "pid": 4282,
+                "process": "kauditd",
+                "runtime": 0,
+                "usecs": 2
+            },
+            {
+                "invoked": 679737,
+                "onesec_percent": "0.00",
+                "pid": 4325,
+                "process": "klogd",
+                "runtime": 15260,
+                "usecs": 22
+            },
+            {
+                "invoked": 40,
+                "onesec_percent": "0.00",
+                "pid": 4378,
+                "process": "getty",
+                "runtime": 9,
+                "usecs": 239
+            },
+            {
+                "invoked": 6,
+                "onesec_percent": "0.00",
+                "pid": 22513,
+                "process": "nginx_1",
+                "runtime": 1,
+                "usecs": 323
+            },
+            {
+                "invoked": 2,
+                "onesec_percent": "0.00",
+                "pid": 22520,
+                "process": "nginx_1",
+                "runtime": 1,
+                "usecs": 766
+            },
+            {
+                "invoked": 61982282,
+                "onesec_percent": "0.00",
+                "pid": 22521,
+                "process": "nginx_1",
+                "runtime": 18267446,
+                "usecs": 294
+            },
+            {
+                "invoked": 114318380,
+                "onesec_percent": "0.00",
+                "pid": 22522,
+                "process": "nginx_1",
+                "runtime": 30878415,
+                "usecs": 270
+            },
+            {
+                "invoked": 37433914,
+                "onesec_percent": "0.00",
+                "pid": 22523,
+                "process": "vsh",
+                "runtime": 24397904,
+                "usecs": 651
+            },
+            {
+                "invoked": 3,
+                "onesec_percent": "0.00",
+                "pid": 28769,
+                "process": "vsh",
+                "runtime": 1,
+                "usecs": 575
+            },
+            {
+                "invoked": 52,
+                "onesec_percent": "0.00",
+                "pid": 28770,
+                "process": "ps",
+                "runtime": 31,
+                "usecs": 607
+            }
+        ]
+    }
+}

--- a/test/nxos/mocked_data/test_get_environment/pre_7.0/show_processes_memory_shared.json
+++ b/test/nxos/mocked_data/test_get_environment/pre_7.0/show_processes_memory_shared.json
@@ -1,0 +1,281 @@
+{
+    "TABLE_process_tag": {
+        "ROW_process_tag": {
+            "TABLE_SHOWPROC": {
+                "ROW_SHOWPROC": {
+                    "TABLE_ONEITEM": [
+                        {
+                            "ROW_ONEITEM": [
+                                {
+                                    "process-memory-share-proc-smr-name": "smm",
+                                    "process-memory-share-smr-addr": "50000000",
+                                    "process-memory-share-smr-avail": 1085,
+                                    "process-memory-share-smr-empty-char": "",
+                                    "process-memory-share-smr-ref-count": 44,
+                                    "process-memory-share-smr-size": 1088,
+                                    "process-memory-share-smr-star-char": {},
+                                    "process-memory-share-smr-used": 3
+                                },
+                                {
+                                    "process-memory-share-proc-smr-name": "cli",
+                                    "process-memory-share-smr-addr": "50110000",
+                                    "process-memory-share-smr-avail": 29270,
+                                    "process-memory-share-smr-empty-char": "",
+                                    "process-memory-share-smr-ref-count": 20,
+                                    "process-memory-share-smr-size": 49216,
+                                    "process-memory-share-smr-star-char": "*",
+                                    "process-memory-share-smr-used": 19946
+                                },
+                                {
+                                    "process-memory-share-proc-smr-name": "npacl",
+                                    "process-memory-share-smr-addr": "53120000",
+                                    "process-memory-share-smr-avail": 4158,
+                                    "process-memory-share-smr-empty-char": "",
+                                    "process-memory-share-smr-ref-count": 2,
+                                    "process-memory-share-smr-size": 4160,
+                                    "process-memory-share-smr-star-char": {},
+                                    "process-memory-share-smr-used": 2
+                                },
+                                {
+                                    "process-memory-share-dynamic-smr-name": "urib"
+                                }
+                            ]
+                        },
+                        {
+                            "ROW_ONEITEM": [
+                                {
+                                    "process-memory-share-proc-smr-name": "urib-pib",
+                                    "process-memory-share-smr-addr": "57540000",
+                                    "process-memory-share-smr-avail": 842,
+                                    "process-memory-share-smr-empty-char": "",
+                                    "process-memory-share-smr-ref-count": 20,
+                                    "process-memory-share-smr-size": 1088,
+                                    "process-memory-share-smr-star-char": "*",
+                                    "process-memory-share-smr-used": 247
+                                },
+                                {
+                                    "process-memory-share-proc-smr-name": "urib-redist",
+                                    "process-memory-share-smr-addr": "57650000",
+                                    "process-memory-share-smr-avail": 4244,
+                                    "process-memory-share-smr-empty-char": "",
+                                    "process-memory-share-smr-ref-count": 20,
+                                    "process-memory-share-smr-size": 5184,
+                                    "process-memory-share-smr-star-char": "*",
+                                    "process-memory-share-smr-used": 940
+                                },
+                                {
+                                    "process-memory-share-proc-smr-name": "urib-ufdm",
+                                    "process-memory-share-smr-addr": "57B60000",
+                                    "process-memory-share-smr-avail": 8138,
+                                    "process-memory-share-smr-empty-char": "",
+                                    "process-memory-share-smr-ref-count": 1,
+                                    "process-memory-share-smr-size": 8256,
+                                    "process-memory-share-smr-star-char": "*",
+                                    "process-memory-share-smr-used": 118
+                                },
+                                {
+                                    "process-memory-share-dynamic-smr-name": "mrib"
+                                }
+                            ]
+                        },
+                        {
+                            "ROW_ONEITEM": [
+                                {
+                                    "process-memory-share-proc-smr-name": "mrib-mfdm",
+                                    "process-memory-share-smr-addr": "5BD80000",
+                                    "process-memory-share-smr-avail": 4160,
+                                    "process-memory-share-smr-empty-char": "",
+                                    "process-memory-share-smr-ref-count": 1,
+                                    "process-memory-share-smr-size": 4160,
+                                    "process-memory-share-smr-star-char": "*",
+                                    "process-memory-share-smr-used": 0
+                                },
+                                {
+                                    "process-memory-share-proc-smr-name": "am",
+                                    "process-memory-share-smr-addr": "5C190000",
+                                    "process-memory-share-smr-avail": 1044,
+                                    "process-memory-share-smr-empty-char": "",
+                                    "process-memory-share-smr-ref-count": 8,
+                                    "process-memory-share-smr-size": 1088,
+                                    "process-memory-share-smr-star-char": "*",
+                                    "process-memory-share-smr-used": 44
+                                },
+                                {
+                                    "process-memory-share-proc-smr-name": "am_limit",
+                                    "process-memory-share-smr-addr": "5C2A0000",
+                                    "process-memory-share-smr-avail": 127,
+                                    "process-memory-share-smr-empty-char": "",
+                                    "process-memory-share-smr-ref-count": 8,
+                                    "process-memory-share-smr-size": 128,
+                                    "process-memory-share-smr-star-char": "*",
+                                    "process-memory-share-smr-used": 1
+                                },
+                                {
+                                    "process-memory-share-dynamic-smr-name": "u6rib"
+                                }
+                            ]
+                        },
+                        {
+                            "ROW_ONEITEM": [
+                                {
+                                    "process-memory-share-proc-smr-name": "u6rib-pib",
+                                    "process-memory-share-smr-addr": "5DAD0000",
+                                    "process-memory-share-smr-avail": 816,
+                                    "process-memory-share-smr-empty-char": "",
+                                    "process-memory-share-smr-ref-count": 12,
+                                    "process-memory-share-smr-size": 1088,
+                                    "process-memory-share-smr-star-char": "*",
+                                    "process-memory-share-smr-used": 272
+                                },
+                                {
+                                    "process-memory-share-proc-smr-name": "u6rib-notify",
+                                    "process-memory-share-smr-addr": "5DBE0000",
+                                    "process-memory-share-smr-avail": 2341,
+                                    "process-memory-share-smr-empty-char": "",
+                                    "process-memory-share-smr-ref-count": 12,
+                                    "process-memory-share-smr-size": 3136,
+                                    "process-memory-share-smr-star-char": "*",
+                                    "process-memory-share-smr-used": 795
+                                },
+                                {
+                                    "process-memory-share-proc-smr-name": "icmpv6",
+                                    "process-memory-share-smr-addr": "5DEF0000",
+                                    "process-memory-share-smr-avail": 4160,
+                                    "process-memory-share-smr-empty-char": "",
+                                    "process-memory-share-smr-ref-count": 10,
+                                    "process-memory-share-smr-size": 4160,
+                                    "process-memory-share-smr-star-char": {},
+                                    "process-memory-share-smr-used": 0
+                                },
+                                {
+                                    "process-memory-share-dynamic-smr-name": "m6rib"
+                                }
+                            ]
+                        },
+                        {
+                            "ROW_ONEITEM": [
+                                {
+                                    "process-memory-share-proc-smr-name": "m6rib-mfdm",
+                                    "process-memory-share-smr-addr": "5EB10000",
+                                    "process-memory-share-smr-avail": 5184,
+                                    "process-memory-share-smr-empty-char": "",
+                                    "process-memory-share-smr-ref-count": 2,
+                                    "process-memory-share-smr-size": 5184,
+                                    "process-memory-share-smr-star-char": {},
+                                    "process-memory-share-smr-used": 0
+                                },
+                                {
+                                    "process-memory-share-proc-smr-name": "ip",
+                                    "process-memory-share-smr-addr": "5F020000",
+                                    "process-memory-share-smr-avail": 10239,
+                                    "process-memory-share-smr-empty-char": "",
+                                    "process-memory-share-smr-ref-count": 15,
+                                    "process-memory-share-smr-size": 10304,
+                                    "process-memory-share-smr-star-char": {},
+                                    "process-memory-share-smr-used": 65
+                                },
+                                {
+                                    "process-memory-share-proc-smr-name": "ipv6",
+                                    "process-memory-share-smr-addr": "5FA30000",
+                                    "process-memory-share-smr-avail": 8255,
+                                    "process-memory-share-smr-empty-char": "",
+                                    "process-memory-share-smr-ref-count": 10,
+                                    "process-memory-share-smr-size": 8256,
+                                    "process-memory-share-smr-star-char": {},
+                                    "process-memory-share-smr-used": 1
+                                },
+                                {
+                                    "process-memory-share-dynamic-smr-name": "rpm"
+                                }
+                            ]
+                        },
+                        {
+                            "ROW_ONEITEM": [
+                                {
+                                    "process-memory-share-proc-smr-name": "igmp",
+                                    "process-memory-share-smr-addr": "61250000",
+                                    "process-memory-share-smr-avail": 4160,
+                                    "process-memory-share-smr-empty-char": "",
+                                    "process-memory-share-smr-ref-count": 2,
+                                    "process-memory-share-smr-size": 4160,
+                                    "process-memory-share-smr-star-char": "*",
+                                    "process-memory-share-smr-used": 0
+                                },
+                                {
+                                    "process-memory-share-proc-smr-name": "mcastfwd",
+                                    "process-memory-share-smr-addr": "61660000",
+                                    "process-memory-share-smr-avail": 12338,
+                                    "process-memory-share-smr-empty-char": "",
+                                    "process-memory-share-smr-ref-count": 2,
+                                    "process-memory-share-smr-size": 12352,
+                                    "process-memory-share-smr-star-char": {},
+                                    "process-memory-share-smr-used": 14
+                                }
+                            ]
+                        }
+                    ],
+                    "TABLE_ONEITEMDYNAMIC": [
+                        {
+                            "ROW_ONEITEMDYNAMIC": {
+                                "process-memory-share-dynamic-plus-char": "+",
+                                "process-memory-share-dynamic-smr-addr": "53530000",
+                                "process-memory-share-dynamic-smr-avail": 136,
+                                "process-memory-share-dynamic-smr-ref-count": "20",
+                                "process-memory-share-dynamic-smr-size": 1024,
+                                "process-memory-share-dynamic-smr-used": 888,
+                                "process-memory-share-max-mem-size-str": "(65600)"
+                            }
+                        },
+                        {
+                            "ROW_ONEITEMDYNAMIC": {
+                                "process-memory-share-dynamic-plus-char": "+",
+                                "process-memory-share-dynamic-smr-addr": "58370000",
+                                "process-memory-share-dynamic-smr-avail": 3069,
+                                "process-memory-share-dynamic-smr-ref-count": "3",
+                                "process-memory-share-dynamic-smr-size": 3072,
+                                "process-memory-share-dynamic-smr-used": 3,
+                                "process-memory-share-max-mem-size-str": "(59456)"
+                            }
+                        },
+                        {
+                            "ROW_ONEITEMDYNAMIC": {
+                                "process-memory-share-dynamic-plus-char": "+",
+                                "process-memory-share-dynamic-smr-addr": "5C2C0000",
+                                "process-memory-share-dynamic-smr-avail": 708,
+                                "process-memory-share-dynamic-smr-ref-count": "12",
+                                "process-memory-share-dynamic-smr-size": 1024,
+                                "process-memory-share-dynamic-smr-used": 316,
+                                "process-memory-share-max-mem-size-str": "(24640)"
+                            }
+                        },
+                        {
+                            "ROW_ONEITEMDYNAMIC": {
+                                "process-memory-share-dynamic-plus-char": "+",
+                                "process-memory-share-dynamic-smr-addr": "5E300000",
+                                "process-memory-share-dynamic-smr-avail": 3060,
+                                "process-memory-share-dynamic-smr-ref-count": "1",
+                                "process-memory-share-dynamic-smr-size": 3072,
+                                "process-memory-share-dynamic-smr-used": 12,
+                                "process-memory-share-max-mem-size-str": "(8256)"
+                            }
+                        },
+                        {
+                            "ROW_ONEITEMDYNAMIC": {
+                                "process-memory-share-dynamic-plus-char": "+",
+                                "process-memory-share-dynamic-smr-addr": "60240000",
+                                "process-memory-share-dynamic-smr-avail": 2047,
+                                "process-memory-share-dynamic-smr-ref-count": "5",
+                                "process-memory-share-dynamic-smr-size": 2048,
+                                "process-memory-share-dynamic-smr-used": 1,
+                                "process-memory-share-max-mem-size-str": "(16448)"
+                            }
+                        }
+                    ]
+                }
+            },
+            "process-memory-share-total-shm-avail": 268,
+            "process-memory-share-total-shm-size": 291,
+            "process-memory-share-total-shm-used": 24
+        }
+    }
+}


### PR DESCRIPTION
This was tested on NXOS devices running 6.0(2)A8(11) and 7.0(3)I7(6), there were some API response changes between the two versions that are handled in the code.