### PR TITLE
When asPathType is Internal (IBGP), as_path is empty and the remote-as is the local_as

### DIFF
--- a/napalm/eos/eos.py
+++ b/napalm/eos/eos.py
@@ -1245,7 +1245,13 @@ class EOSDriver(NetworkDriver):
                         as_path = bgp_route_details.get("asPathEntry", {}).get(
                             "asPath", ""
                         )
-                        remote_as = int(as_path.strip("()").split()[-1])
+                        as_path_type = bgp_route_details.get("asPathEntry", {}).get(
+                            "asPathType", ""
+                        )
+                        if as_path_type in ["Internal", "Local"]:
+                            remote_as = local_as
+                        else:
+                            remote_as = int(as_path.strip("()").split()[-1])
                         remote_address = napalm.base.helpers.ip(
                             bgp_route_details.get("routeDetail", {})
                             .get("peerEntry", {})


### PR DESCRIPTION
Cherry-picked and adapted @cuong-nguyenduy's commit from https://github.com/napalm-automation/napalm/pull/794.