### PR TITLE
pin netmiko version to 2.4.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ jinja2
 netaddr
 pyYAML
 pyeapi>=0.8.2
-netmiko>=2.3.0
+netmiko==2.4.2
 pyIOSXR>=0.53
 junos-eznc==2.2.1
 nxapi-plumbing>=0.5.2


### PR DESCRIPTION
per @ktbyers pinning netmiko to 2.4.2 so that netmiko 3.x doesn't accidentally get installed (netmiko 3.x drops python 2 support) breaking python 2 for next 2.5.0 release! 