### PR TITLE
Fix unittests with junos-eznc 2.3.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ pyYAML
 pyeapi>=0.8.2
 netmiko==2.4.2
 pyIOSXR>=0.53
-junos-eznc==2.2.1
+junos-eznc>=2.2.1
 nxapi-plumbing>=0.5.2
 ciscoconfparse
 scp

--- a/test/junos/conftest.py
+++ b/test/junos/conftest.py
@@ -77,6 +77,10 @@ class FakeJunOSDevice(BaseTestDouble):
         }
         self._uptime = 4380
 
+        # Since junos-eznc 2.3.0 the new SAX parser is used as default. Thus
+        # disable it to use the DOM parser which was used prior.
+        self._use_filter = False
+
     @property
     def facts(self):
         # we want to reinitialize it every time to avoid side effects


### PR DESCRIPTION
Since junos-eznc 2.3.0 the SAX parser is used as default. This is
enabled with "use_filter=True" at several locations. Thus disable it to
use the DOM parser that was used prior to pass the unittests.

This should fix #1060.