### PR TITLE
IOS driver get_network_instances fix

### DIFF
--- a/napalm/ios/ios.py
+++ b/napalm/ios/ios.py
@@ -3314,7 +3314,11 @@ class IOSDriver(NetworkDriver):
             if "No interfaces" in first_part:
                 interfaces = {}
             else:
-                interfaces = {itf: {} for itf in if_regex.group(1).split()}
+                interfaces = {canonical_interface_name(itf): {} for itf in if_regex.group(1).split()}
+
+            # remove interfaces in the VRF from the default VRF
+            for item in interfaces:
+                del instances['default']['interfaces']['interface'][item]
 
             instances[vrf_name] = {
                 "name": vrf_name,

--- a/napalm/ios/ios.py
+++ b/napalm/ios/ios.py
@@ -84,6 +84,7 @@ RE_VRF_ADVAN = re.compile(r"[ ]{2}(\S+)[ ]+[<> a-z:\d]+[ ]+([a-z\d,]+)")
 RE_BGP_REMOTE_AS = re.compile(r"remote AS (" + ASN_REGEX + r")")
 RE_BGP_AS_PATH = re.compile(r"^[ ]{2}([\d\(]([\d\) ]+)|Local)")
 
+RE_RP_ROUTE = re.compile(r"Routing entry for (" + IP_ADDR_REGEX + r"\/\d+)")
 RE_RP_FROM = re.compile(r"Known via \"([a-z]+)[ \"]")
 RE_RP_VIA = re.compile(r"via (\S+)")
 RE_RP_METRIC = re.compile(r"[ ]+Route metric is (\d+)")
@@ -2870,8 +2871,11 @@ class IOSDriver(NetworkDriver):
             vrfs.append("default")  # global VRF
             ipnet_dest = IPNetwork(destination)
             prefix = str(ipnet_dest.network)
-            netmask = str(ipnet_dest.netmask)
-            routes = {destination: []}
+            netmask = ""
+            routes = {}
+            if '/' in destination:
+                netmask = str(ipnet_dest.netmask)
+                routes = {destination: []}
             commands = []
             for _vrf in vrfs:
                 if _vrf == "default":
@@ -2892,6 +2896,14 @@ class IOSDriver(NetworkDriver):
             for (outitem, _vrf) in zip(output, vrfs):  # for all VRFs
                 route_proto_regex = RE_RP_FROM.search(outitem)
                 if route_proto_regex:
+                    route_match = destination
+                    if netmask == "":
+                        # Get the matching route for a non-exact lookup
+                        route_match_regex = RE_RP_ROUTE.search(outitem)
+                        if route_match_regex:
+                            route_match = route_match_regex.group(1)
+                            if not route_match in routes:
+                                routes[route_match] = []
                     # routing protocol name (bgp, ospf, ...)
                     route_proto = route_proto_regex.group(1)
                     rdb = outitem.split("Routing Descriptor Blocks:")
@@ -2960,7 +2972,7 @@ class IOSDriver(NetworkDriver):
                                 nh_line_found = (
                                     False
                                 )  # for next RT entry processing ...
-                                routes[destination].append(route_entry)
+                                routes[route_match].append(route_entry)
         return routes
 
     def get_snmp_information(self):


### PR DESCRIPTION
Corrects the IOS driver's get_network_instances output. 

Problems addressed:
- on my test devices (IOS and IOS-XE), show vrf detail returns abbreviated interface names
- the function adds all interfaces to the default instance resulting in an interface appearing in default + vrf xyz in Napalm's output