### PR TITLE
FIX: traceroute output parsing in ios

### DIFF
--- a/napalm/ios/ios.py
+++ b/napalm/ios/ios.py
@@ -3223,7 +3223,11 @@ class IOSDriver(NetworkDriver):
                 # Now you have the start and stop index for each hop
                 # and you can parse the probes
             # Set the hop_variable, and remove spaces between msec and [AS 12345] garbage for easier matching
-            hop_string = re.sub(' \[AS [0-9.]+\]', '', output[start_index:stop_index].replace(" msec", "msec"))
+            hop_string = re.sub(
+                r" \[AS [0-9.]+\]",
+                "",
+                output[start_index:stop_index].replace(" msec", "msec"),
+            )
             hop_list = hop_string.split()
             current_hop = int(hop_list.pop(0))
             # Prepare dictionary for each hop (assuming there are 3 probes in each hop)

--- a/napalm/ios/ios.py
+++ b/napalm/ios/ios.py
@@ -3223,7 +3223,7 @@ class IOSDriver(NetworkDriver):
                 # Now you have the start and stop index for each hop
                 # and you can parse the probes
             # Set the hop_variable, and remove spaces between msec and [AS 12345] garbage for easier matching
-            hop_string = re.sub(' \[AS [0-9]+\]', '', output[start_index:stop_index].replace(" msec", "msec"))
+            hop_string = re.sub(' \[AS [0-9.]+\]', '', output[start_index:stop_index].replace(" msec", "msec"))
             hop_list = hop_string.split()
             current_hop = int(hop_list.pop(0))
             # Prepare dictionary for each hop (assuming there are 3 probes in each hop)

--- a/napalm/ios/ios.py
+++ b/napalm/ios/ios.py
@@ -3222,8 +3222,8 @@ class IOSDriver(NetworkDriver):
                 stop_index = next_hop_match.start()
                 # Now you have the start and stop index for each hop
                 # and you can parse the probes
-            # Set the hop_variable, and remove spaces between msec for easier matching
-            hop_string = output[start_index:stop_index].replace(" msec", "msec")
+            # Set the hop_variable, and remove spaces between msec and [AS 12345] garbage for easier matching
+            hop_string = re.sub(' \[AS [0-9]+\]', '', output[start_index:stop_index].replace(" msec", "msec"))
             hop_list = hop_string.split()
             current_hop = int(hop_list.pop(0))
             # Prepare dictionary for each hop (assuming there are 3 probes in each hop)

--- a/napalm/ios/ios.py
+++ b/napalm/ios/ios.py
@@ -3222,7 +3222,7 @@ class IOSDriver(NetworkDriver):
                 stop_index = next_hop_match.start()
                 # Now you have the start and stop index for each hop
                 # and you can parse the probes
-            # Set the hop_variable, and remove spaces between msec and [AS 12345] garbage for easier matching
+            # Set the hop_variable, and remove spaces between msec and [AS 1234] for easier matching
             hop_string = re.sub(
                 r" \[AS [0-9.]+\]",
                 "",


### PR DESCRIPTION
traceroute output with AS number parsed wrongly.
This small fix cleans up this:
Example hop parsed wrongly:
`  1 1.1.1.1 [AS 65200] 40 msec 40 msec 40 msec`
string after clean:
`1 1.1.1.1 40 msec 40 msec 40 msec`