### PR TITLE
adding .vscode and .devcontainer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,8 @@ docs/_static/
 .DS_Store
 .vagrant
 .venv
+.vscode
+.devcontainer
 
 env
 *.swp


### PR DESCRIPTION
For the VSCode IDE its useful to have local IDE setting in gitignore - `.vscode`

and for the users who leverage dev environment in containers - `.devcontainer`