### PR TITLE
Use Kickstart version to determine NXOS version

### DIFF
--- a/napalm/nxos/nxos.py
+++ b/napalm/nxos/nxos.py
@@ -804,7 +804,7 @@ class NXOSDriver(NXOSDriverBase):
         facts["model"] = show_version.get("chassis_id", "")
         facts["hostname"] = show_version.get("host_name", "")
         facts["os_version"] = show_version.get(
-            "sys_ver_str", show_version.get("rr_sys_ver", "")
+            "sys_ver_str", show_version.get("kickstart_ver_str", "")
         )
 
         uptime_days = show_version.get("kern_uptm_days", 0)


### PR DESCRIPTION
`rr_sys_ver` reports the system version from before a reboot, not the current version. As the NXAPI seems to lack a straightforward `sys_ver_str` (This is why we’re in this mess in the first place), we’ll need to use the `kickstart_ver_str` instead.

This is also shown to be an issue in the official documentation: https://developer.cisco.com/docs/nx-api-cli-reference-for-the-cisco-nexus-9000-series-platform/#!version-commands/show-version

This fixes #1171