### PR TITLE
Fixed pyIOSXR XML mode timeout due to Netmiko cmd_verify

### DIFF
--- a/napalm/pyIOSXR/iosxr.py
+++ b/napalm/pyIOSXR/iosxr.py
@@ -186,6 +186,7 @@ class IOSXR(object):
                 port=self.port,
                 username=self.username,
                 password=self.password,
+                global_cmd_verify=False,
                 **self.netmiko_kwargs
             )
             self.device.timeout = self.timeout

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ jinja2
 netaddr
 pyYAML
 pyeapi>=0.8.2
-netmiko>=3.0.0
+netmiko>=3.1.0
 junos-eznc>=2.2.1
 ciscoconfparse
 scp


### PR DESCRIPTION
Disabled Netmiko cmd_verify globally in pyIOSXR and now require at least netmiko 3.1.0.

Netmiko now defaults to cmd_verify=True in send_command.  This verifies that the sent text is echoed from the remote.  Devices in XML mode do not echo; therefore it timed out waiting.

Users can still enable global_cmd_verify by passing the option to the constructor or open method.