### PR TITLE
SRX cluster devices stack RPC replies under multi-routing-engine-results

### DIFF
--- a/napalm/junos/utils/junos_views.yml
+++ b/napalm/junos/utils/junos_views.yml
@@ -157,6 +157,14 @@ junos_environment_table:
   key: name
   view: junos_environment_view
 
+junos_environment_table_srx_cluster:
+  rpc: get-environment-information
+  args:
+    node: primary
+  item: multi-routing-engine-item/environment-information/environment-item
+  key: name
+  view: junos_environment_view
+
 junos_environment_view:
   fields:
     class: class
@@ -183,16 +191,33 @@ junos_routing_engine_table:
   key: slot
   view: junos_routing_engine_view
 
+junos_routing_engine_table_srx_cluster:
+  rpc: get-route-engine-information
+  args:
+    node: primary
+  item: multi-routing-engine-item/route-engine-information/route-engine
+  key: ../../re-name
+  view: junos_routing_engine_view
+
 junos_routing_engine_view:
   fields:
     cpu-idle: { cpu-idle: int }
-    memory-dram-size: memory-dram-size
-    memory-buffer-utilization : { memory-buffer-utilization: int }
+    memory-dram-size: memory-dram-size | memory-system-total
+    memory-buffer-utilization: { memory-buffer-utilization: int }
+    memory-system-total-used: { memory-system-total-used: int }
 
 junos_temperature_thresholds:
   rpc: get-temperature-threshold-information
   args:
   item: temperature-threshold
+  key: name
+  view: junos_temperature_thresholds_view
+
+junos_temperature_thresholds_srx_cluster:
+  rpc: get-temperature-threshold-information
+  args:
+    node: primary
+  item: multi-routing-engine-item/temperature-threshold-information/temperature-threshold
   key: name
   view: junos_temperature_thresholds_view
 

--- a/test/junos/conftest.py
+++ b/test/junos/conftest.py
@@ -53,6 +53,7 @@ class FakeJunOSDevice(BaseTestDouble):
         self._conn = FakeConnection(self.rpc)
         self.alternative_facts_file = "facts.yml"
         self.ON_JUNOS = True  # necessary for fake devices
+        self.hostname = "test"
         self.default_facts = {
             "domain": None,
             "hostname": "vsrx",
@@ -132,7 +133,6 @@ class FakeRPCObject:
         filename = "{item}{instance}.xml".format(item=self.item, instance=instance)
         filepathpath = self._device.find_file(filename)
         xml_string = self._device.read_txt_file(filepathpath)
-
         return lxml.etree.fromstring(xml_string)
 
     def get_config(self, get_cmd=None, filter_xml=None, options={}):

--- a/test/junos/mocked_data/test_get_environment/issue1183_srx_multi_node/expected_result.json
+++ b/test/junos/mocked_data/test_get_environment/issue1183_srx_multi_node/expected_result.json
@@ -1,0 +1,49 @@
+{
+  "temperature": {
+    "Routing Engine": {
+      "temperature": 39,
+      "is_alert": false,
+      "is_critical": false
+    },
+    "Routing Engine CPU": {
+      "temperature": 68,
+      "is_alert": true,
+      "is_critical": false
+    }
+  },
+  "fans": {
+    "SRX340 Chassis fan 0": {
+      "status": true
+    },
+    "SRX340 Chassis fan 1": {
+      "status": true
+    },
+    "SRX340 Chassis fan 2": {
+      "status": true
+    },
+    "SRX340 Chassis fan 3": {
+      "status": true
+    }
+  },
+  "power": {
+    "Power Supply 0": {
+      "capacity": -1,
+      "output": -1,
+      "status": true
+    },
+    "Power Supply 1": {
+      "capacity": -1,
+      "output": -1,
+      "status": true
+    }
+  },
+  "cpu": {
+    "node0": {
+      "%usage": 8
+    }
+  },
+  "memory": {
+    "available_ram": 4096,
+    "used_ram": 1311
+  }
+}

--- a/test/junos/mocked_data/test_get_environment/issue1183_srx_multi_node/facts.yml
+++ b/test/junos/mocked_data/test_get_environment/issue1183_srx_multi_node/facts.yml
@@ -1,0 +1,1 @@
+srx_cluster: true

--- a/test/junos/mocked_data/test_get_environment/issue1183_srx_multi_node/get-environment-information.xml
+++ b/test/junos/mocked_data/test_get_environment/issue1183_srx_multi_node/get-environment-information.xml
@@ -1,0 +1,52 @@
+<multi-routing-engine-results>
+    <multi-routing-engine-item>
+        <re-name>node0</re-name>
+        <environment-information>
+            <environment-item>
+                <name>Routing Engine</name>
+                <class>Temp</class>
+                <status>OK</status>
+                <temperature celsius="39">39 degrees C / 102 degrees F</temperature>
+            </environment-item>
+            <environment-item>
+                <name>Routing Engine CPU</name>
+                <status>OK</status>
+                <temperature celsius="68">68 degrees C / 154 degrees F</temperature>
+            </environment-item>
+            <environment-item>
+                <name>SRX340 Chassis fan 0</name>
+                <class>Fans</class>
+                <status>OK</status>
+                <comment>Spinning at normal speed</comment>
+            </environment-item>
+            <environment-item>
+                <name>SRX340 Chassis fan 1</name>
+                <class>Fans</class>
+                <status>OK</status>
+                <comment>Spinning at normal speed</comment>
+            </environment-item>
+            <environment-item>
+                <name>SRX340 Chassis fan 2</name>
+                <class>Fans</class>
+                <status>OK</status>
+                <comment>Spinning at normal speed</comment>
+            </environment-item>
+            <environment-item>
+                <name>SRX340 Chassis fan 3</name>
+                <class>Fans</class>
+                <status>OK</status>
+                <comment>Spinning at normal speed</comment>
+            </environment-item>
+            <environment-item>
+                <name>Power Supply 0</name>
+                <class>Power</class>
+                <status>OK</status>
+            </environment-item>
+            <environment-item>
+                <name>Power Supply 1</name>
+                <class>Power</class>
+                <status>OK</status>
+            </environment-item>
+        </environment-information>
+    </multi-routing-engine-item>
+</multi-routing-engine-results>

--- a/test/junos/mocked_data/test_get_environment/issue1183_srx_multi_node/get-power-usage-information-detail.xml
+++ b/test/junos/mocked_data/test_get_environment/issue1183_srx_multi_node/get-power-usage-information-detail.xml
@@ -1,0 +1,4 @@
+<power-usage-information>
+   <power-usage-item>
+   </power-usage-item>
+</power-usage-information>

--- a/test/junos/mocked_data/test_get_environment/issue1183_srx_multi_node/get-route-engine-information.xml
+++ b/test/junos/mocked_data/test_get_environment/issue1183_srx_multi_node/get-route-engine-information.xml
@@ -1,0 +1,34 @@
+<multi-routing-engine-results>
+    <multi-routing-engine-item>
+        <re-name>node0</re-name>
+        <route-engine-information>
+            <route-engine>
+                <status>OK</status>
+                <temperature celsius="35">35 degrees C / 95 degrees F</temperature>
+                <cpu-temperature celsius="63">63 degrees C / 145 degrees F</cpu-temperature>
+                <memory-system-total>4096</memory-system-total>
+                <memory-system-total-used>1311</memory-system-total-used>
+                <memory-system-total-util>32</memory-system-total-util>
+                <memory-control-plane>2624</memory-control-plane>
+                <memory-control-plane-used>682</memory-control-plane-used>
+                <memory-control-plane-util>26</memory-control-plane-util>
+                <memory-data-plane>1472</memory-data-plane>
+                <memory-data-plane-used>618</memory-data-plane-used>
+                <memory-data-plane-util>42</memory-data-plane-util>
+                <cpu-user>6</cpu-user>
+                <cpu-background>0</cpu-background>
+                <cpu-system>2</cpu-system>
+                <cpu-interrupt>0</cpu-interrupt>
+                <cpu-idle>92</cpu-idle>
+                <model>RE-SRX345-DUAL-AC</model>
+                <serial-number>DS1319AF0037</serial-number>
+                <start-time seconds="1584485864">2020-03-17 22:57:44 UTC</start-time>
+                <up-time seconds="3626317">41 days, 23 hours, 18 minutes, 37 seconds</up-time>
+                <last-reboot-reason>0x1:power cycle/failure </last-reboot-reason>
+                <load-average-one>0.19</load-average-one>
+                <load-average-five>0.09</load-average-five>
+                <load-average-fifteen>0.02</load-average-fifteen>
+            </route-engine>
+        </route-engine-information>
+    </multi-routing-engine-item>
+</multi-routing-engine-results>

--- a/test/junos/mocked_data/test_get_environment/issue1183_srx_multi_node/get-temperature-threshold-information.xml
+++ b/test/junos/mocked_data/test_get_environment/issue1183_srx_multi_node/get-temperature-threshold-information.xml
@@ -1,0 +1,27 @@
+<multi-routing-engine-results>
+    <multi-routing-engine-item>
+        <re-name>node0</re-name>
+        <temperature-threshold-information>
+            <temperature-threshold>
+                <name>Chassis default</name>
+                <fan-normal-speed>35</fan-normal-speed>
+                <fan-high-speed>56</fan-high-speed>
+                <bad-fan-yellow-alarm>40</bad-fan-yellow-alarm>
+                <bad-fan-red-alarm>65</bad-fan-red-alarm>
+                <yellow-alarm>60</yellow-alarm>
+                <red-alarm>75</red-alarm>
+                <fire-shutdown>100</fire-shutdown>
+            </temperature-threshold>
+            <temperature-threshold>
+                <name>Routing Engine</name>
+                <fan-normal-speed>35</fan-normal-speed>
+                <fan-high-speed>56</fan-high-speed>
+                <bad-fan-yellow-alarm>40</bad-fan-yellow-alarm>
+                <bad-fan-red-alarm>65</bad-fan-red-alarm>
+                <yellow-alarm>60</yellow-alarm>
+                <red-alarm>75</red-alarm>
+                <fire-shutdown>100</fire-shutdown>
+            </temperature-threshold>
+        </temperature-threshold-information>
+    </multi-routing-engine-item>
+</multi-routing-engine-results>


### PR DESCRIPTION
The usual replies look like:

```
mircea@switch> show chassis environment | display xml
<rpc-reply xmlns:junos="http://xml.juniper.net/junos/15.1X49/junos">
    <environment-information xmlns="http://xml.juniper.net/junos/15.1X49/junos-chassis">
    ...
    </environment-information>
</rpc-reply>
```

On SRX multi-node devices, the reply is encapsulated under the
``<multi-routing-engine-results><multi-routing-engine-item>`` tags,
e.g.,

```
mircea@srx> show chassis environment | display xml
<rpc-reply xmlns:junos="http://xml.juniper.net/junos/15.1X49/junos">
    <multi-routing-engine-results>
        <multi-routing-engine-item>
            <re-name>node0</re-name>
            <environment-information xmlns="http://xml.juniper.net/junos/15.1X49/junos-chassis">
            ...
            </environment-information>
        </multi-routing-engine-item>
    </multi-routing-engine-results>
</rpc-reply>
```

The same goes for other RPC calls such as
``get-route-engine-information`` or
``get-temperature-threshold-information``.

Fixes #1183. Partially, at least, as the ``get_environment`` structure
doesn't currently permit a multi-node structure, so on SRX clusters it
will only return the details for the primary node.