### PR TITLE
Junos: close configuration in case configure_private is set to avoid …

### DIFF
--- a/napalm/junos/junos.py
+++ b/napalm/junos/junos.py
@@ -283,12 +283,16 @@ class JunOSDriver(NetworkDriver):
         self.device.cu.commit(ignore_warning=self.ignore_warning, **commit_args)
         if not self.lock_disable and not self.session_config_lock:
             self._unlock()
+        if self.config_private:
+            self.device.rpc.close_configuration()
 
     def discard_config(self):
         """Discard changes (rollback 0)."""
         self.device.cu.rollback(rb_id=0)
         if not self.lock_disable and not self.session_config_lock:
             self._unlock()
+        if self.config_private:
+            self.device.rpc.close_configuration()
 
     def rollback(self):
         """Rollback to previous commit."""


### PR DESCRIPTION
Using this: https://www.juniper.net/documentation/en_US/junos/topics/task/configuration/junos-xml-protocol-configuration-locking-unlocking.html as reference. 
Configuration must be closed after has been open private.
If not, a "configure" session stays open unless you disconnect. 
