### PR TITLE
Raise default max_loops in send_command

### DIFF
--- a/napalm/nxos_ssh/nxos_ssh.py
+++ b/napalm/nxos_ssh/nxos_ssh.py
@@ -444,7 +444,7 @@ class NXOSSSHDriver(NXOSDriverBase):
 
         raw_text argument is not used and is for code sharing with NX-API.
         """
-        return self.device.send_command(command)
+        return self.device.send_command(command, max_loops=1000)
 
     def _send_command_list(self, commands, expect_string=None):
         """Wrapper for Netmiko's send_command method (for list of commands."""


### PR DESCRIPTION
Raise default max_loops from 500 to 1000 on
nxos_ssh send_command.

We own some very heavy loaded Nexus 5696 Chassis
with ~40 Extensions (HP Enclosure C7000 Enclosures).
Listing the interfaces (get_interfaces) takes quite
a while, and uping the max_loops solve the timeout issue.