### PR TITLE
lxml text retrieval (find_txt) shouldn't fail if no text element available

### DIFF
--- a/napalm/base/helpers.py
+++ b/napalm/base/helpers.py
@@ -248,7 +248,7 @@ def textfsm_extractor(cls, template_name, raw_text):
 def find_txt(xml_tree, path, default="", namespaces=None):
     """
     Extracts the text value from an XML tree, using XPath.
-    In case of error, will return a default value.
+    In case of error or text element unavailability, will return a default value.
 
     :param xml_tree:   the XML Tree object. Assumed is <type 'lxml.etree._Element'>.
     :param path:       XPath to be applied, in order to extract the desired data.
@@ -265,7 +265,10 @@ def find_txt(xml_tree, path, default="", namespaces=None):
         if xpath_length and xpath_applied[0] is not None:
             xpath_result = xpath_applied[0]
             if isinstance(xpath_result, type(xml_tree)):
-                value = xpath_result.text.strip()
+                if xpath_result.text:
+                    value = xpath_result.text.strip()
+                else:
+                    value = default
             else:
                 value = xpath_result
         else:


### PR DESCRIPTION
Hi maintainers,
I propose to enhance the `find_txt` function so it won't log an error when it tries to get the text out of the element that has no text element present.

Consider the following example:

```python
import lxml
from napalm.base.helpers import find_txt

s = """
<port>
    <port-id>1/1/c5/1</port-id>
    <oper-state>up</oper-state>
    <system-enabled-capabilities></system-enabled-capabilities>
</port>
"""

e = lxml.etree.fromstring(s)

print(
    "element with text value:", find_txt(e, "oper-state", "default_value",),
)

print(
    "element with no text value:",
    find_txt(e, "system-enabled-capabilities", "default_value",),
)
```

In the XML snippet above, the current `find_txt` behaviour will log an error if one tries to get the text out of the element with not text value (second `print` func):

```bash
# python run_orig_find_txt.py
element with text value: up
'NoneType' object has no attribute 'strip'
element with no text value: default_value
```

The proposed PR adds additional conditional branch to not try to get the text value from a None object. Which will result in a clean execution:

```bash
# python run_new_find_txt.py
element with text value: up
element with no text value: default_value
```