### PR TITLE
Add CLI support to configuration methods 

### DIFF
--- a/napalm/iosxr_netconf/constants.py
+++ b/napalm/iosxr_netconf/constants.py
@@ -404,3 +404,6 @@ ENV_SYS_MON_RPC_REQ_FILTER = """
 <system-monitoring xmlns="http://cisco.com/ns/yang/Cisco-IOS-XR-wdsysmon-fd-oper">
  <cpu-utilization/>
 </system-monitoring>"""
+
+# possible encoding values for optional argument "config_encoding"
+CONFIG_ENCODINGS = ["cli", "xml"]

--- a/napalm/iosxr_netconf/constants.py
+++ b/napalm/iosxr_netconf/constants.py
@@ -405,5 +405,9 @@ ENV_SYS_MON_RPC_REQ_FILTER = """
  <cpu-utilization/>
 </system-monitoring>"""
 
+# subtree filter to get CLI configuration using GET-CONFIG RPC
+CLI_CONFIG_RPC_REQ_FILTER = """
+<cli xmlns="http://cisco.com/ns/yang/Cisco-IOS-XR-cli-cfg"/>"""
+
 # possible encoding values for optional argument "config_encoding"
 CONFIG_ENCODINGS = ["cli", "xml"]

--- a/napalm/iosxr_netconf/constants.py
+++ b/napalm/iosxr_netconf/constants.py
@@ -409,5 +409,9 @@ ENV_SYS_MON_RPC_REQ_FILTER = """
 CLI_CONFIG_RPC_REQ_FILTER = """
 <cli xmlns="http://cisco.com/ns/yang/Cisco-IOS-XR-cli-cfg"/>"""
 
+# RPC to get CLI configuration differences
+CLI_DIFF_RPC_REQ = """
+<get-cli-config-diff xmlns="http://cisco.com/ns/yang/Cisco-IOS-XR-cli-diff-act"/>"""
+
 # possible encoding values for optional argument "config_encoding"
 CONFIG_ENCODINGS = ["cli", "xml"]

--- a/napalm/iosxr_netconf/iosxr_netconf.py
+++ b/napalm/iosxr_netconf/iosxr_netconf.py
@@ -149,6 +149,9 @@ class IOSXRNETCONFDriver(NetworkDriver):
         """Open the candidate config and merge."""
         self.replace = False
         configuration = self._load_config(filename=filename, config=config)
+        if self.config_encoding == "cli":
+            configuration = '<config><cli xmlns="http://cisco.com/ns/yang/Cisco-IOS-XR-cli-cfg">' \
+                                + configuration + "</cli></config>"
         try:
             self.device.edit_config(
                 config=configuration, error_option="rollback-on-error"

--- a/napalm/iosxr_netconf/iosxr_netconf.py
+++ b/napalm/iosxr_netconf/iosxr_netconf.py
@@ -133,6 +133,9 @@ class IOSXRNETCONFDriver(NetworkDriver):
         """Open the candidate config and replace."""
         self.replace = True
         configuration = self._load_config(filename=filename, config=config)
+        if self.config_encoding == "cli":
+            configuration = '<config><cli xmlns="http://cisco.com/ns/yang/Cisco-IOS-XR-cli-cfg">' \
+                                + configuration + "</cli></config>"
         configuration = "<source>" + configuration + "</source>"
         try:
             self.device.copy_config(source=configuration, target="candidate")

--- a/napalm/iosxr_netconf/iosxr_netconf.py
+++ b/napalm/iosxr_netconf/iosxr_netconf.py
@@ -2985,22 +2985,36 @@ class IOSXRNETCONFDriver(NetworkDriver):
 
         return users
 
-    def get_config(self, retrieve="all", full=False):
+    def get_config(self, retrieve="all", full=False, encoding="cli"):
         """Return device configuration."""
         # NOTE: 'full' argument ignored. 'with-default' capability not supported.
 
         # default values
         config = {"startup": "", "running": "", "candidate": ""}
+        if encoding == "cli":
+            subtree_filter = ("subtree", C.CLI_CONFIG_RPC_REQ_FILTER)
+        elif encoding == "xml":
+            subtree_filter = None
+        else:
+            raise NotImplementedError(f"config encoding must be one of {C.CONFIG_ENCODINGS}")
 
         if retrieve.lower() in ["running", "all"]:
-            config["running"] = str(self.device.get_config(source="running").xml)
+            config["running"] = str(self.device.get_config(source="running", filter=subtree_filter).xml)
         if retrieve.lower() in ["candidate", "all"]:
-            config["candidate"] = str(self.device.get_config(source="candidate").xml)
+            config["candidate"] = str(self.device.get_config(source="candidate", filter=subtree_filter).xml)
+
         parser = ETREE.XMLParser(remove_blank_text=True)
         # Validate XML config strings and remove rpc-reply tag
         for datastore in config:
             if config[datastore] != "":
-                config[datastore] = ETREE.tostring(
-                      ETREE.XML(config[datastore], parser=parser)[0], pretty_print=True,
-                      encoding='unicode')
+                if encoding == "cli":
+                    cli_tree = ETREE.XML(config[datastore], parser=parser)[0]
+                    if cli_tree:
+                        config[datastore] = cli_tree[0].text.strip()
+                    else:
+                        config[datastore] = ""
+                else:
+                    config[datastore] = ETREE.tostring(
+                          ETREE.XML(config[datastore], parser=parser)[0], pretty_print=True,
+                          encoding='unicode')
         return config

--- a/napalm/iosxr_netconf/iosxr_netconf.py
+++ b/napalm/iosxr_netconf/iosxr_netconf.py
@@ -43,6 +43,7 @@ from napalm.base.exceptions import ReplaceConfigException
 
 logger = logging.getLogger(__name__)
 
+
 class IOSXRNETCONFDriver(NetworkDriver):
     """IOS-XR NETCONF driver class: inherits NetworkDriver from napalm.base."""
 
@@ -134,8 +135,11 @@ class IOSXRNETCONFDriver(NetworkDriver):
         self.replace = True
         configuration = self._load_config(filename=filename, config=config)
         if self.config_encoding == "cli":
-            configuration = '<config><cli xmlns="http://cisco.com/ns/yang/Cisco-IOS-XR-cli-cfg">' \
-                                + configuration + "</cli></config>"
+            configuration = (
+                '<config><cli xmlns="http://cisco.com/ns/yang/Cisco-IOS-XR-cli-cfg">'
+                + configuration
+                + "</cli></config>"
+            )
         configuration = "<source>" + configuration + "</source>"
         try:
             self.device.copy_config(source=configuration, target="candidate")
@@ -150,8 +154,11 @@ class IOSXRNETCONFDriver(NetworkDriver):
         self.replace = False
         configuration = self._load_config(filename=filename, config=config)
         if self.config_encoding == "cli":
-            configuration = '<config><cli xmlns="http://cisco.com/ns/yang/Cisco-IOS-XR-cli-cfg">' \
-                                + configuration + "</cli></config>"
+            configuration = (
+                '<config><cli xmlns="http://cisco.com/ns/yang/Cisco-IOS-XR-cli-cfg">'
+                + configuration
+                + "</cli></config>"
+            )
         try:
             self.device.edit_config(
                 config=configuration, error_option="rollback-on-error"
@@ -165,7 +172,9 @@ class IOSXRNETCONFDriver(NetworkDriver):
         """Compare candidate config with running."""
         diff = ""
         if encoding not in C.CLI_DIFF_RPC_REQ:
-            raise NotImplementedError(f"config encoding must be one of {C.CONFIG_ENCODINGS}")
+            raise NotImplementedError(
+                f"config encoding must be one of {C.CONFIG_ENCODINGS}"
+            )
 
         if self.pending_changes:
             parser = ETREE.XMLParser(remove_blank_text=True)
@@ -3001,12 +3010,18 @@ class IOSXRNETCONFDriver(NetworkDriver):
         elif encoding == "xml":
             subtree_filter = None
         else:
-            raise NotImplementedError(f"config encoding must be one of {C.CONFIG_ENCODINGS}")
+            raise NotImplementedError(
+                f"config encoding must be one of {C.CONFIG_ENCODINGS}"
+            )
 
         if retrieve.lower() in ["running", "all"]:
-            config["running"] = str(self.device.get_config(source="running", filter=subtree_filter).xml)
+            config["running"] = str(
+                self.device.get_config(source="running", filter=subtree_filter).xml
+            )
         if retrieve.lower() in ["candidate", "all"]:
-            config["candidate"] = str(self.device.get_config(source="candidate", filter=subtree_filter).xml)
+            config["candidate"] = str(
+                self.device.get_config(source="candidate", filter=subtree_filter).xml
+            )
 
         parser = ETREE.XMLParser(remove_blank_text=True)
         # Validate XML config strings and remove rpc-reply tag
@@ -3020,6 +3035,8 @@ class IOSXRNETCONFDriver(NetworkDriver):
                         config[datastore] = ""
                 else:
                     config[datastore] = ETREE.tostring(
-                          ETREE.XML(config[datastore], parser=parser)[0], pretty_print=True,
-                          encoding='unicode')
+                        ETREE.XML(config[datastore], parser=parser)[0],
+                        pretty_print=True,
+                        encoding="unicode",
+                    )
         return config

--- a/napalm/iosxr_netconf/iosxr_netconf.py
+++ b/napalm/iosxr_netconf/iosxr_netconf.py
@@ -69,6 +69,9 @@ class IOSXRNETCONFDriver(NetworkDriver):
         self.port = optional_args.get("port", 830)
         self.lock_on_connect = optional_args.get("config_lock", False)
         self.key_file = optional_args.get("key_file", None)
+        self.config_encoding = optional_args.get("config_encoding", "cli")
+        if self.config_encoding not in C.CONFIG_ENCODINGS:
+            raise ValueError(f"config encoding must be one of {C.CONFIG_ENCODINGS}")
 
         self.platform = "iosxr"
         self.device = None


### PR DESCRIPTION
Define new optional argument (config_encoding) to specify the expected encoding in load_merge_config and load_replace_config. The get_config and compare_config methods now accept an encoding argument that can be set to "xml" or "cli". All encoding arguments default to "cli". 