### PR TITLE
Add config filter for XR-only module set

### DIFF
--- a/napalm/iosxr_netconf/constants.py
+++ b/napalm/iosxr_netconf/constants.py
@@ -43,6 +43,7 @@ NS = {
     "tr": "http://cisco.com/ns/yang/Cisco-IOS-XR-traceroute-act",
     "sys": "http://cisco.com/ns/yang/Cisco-IOS-XR-wdsysmon-fd-oper",
     "mem": "http://cisco.com/ns/yang/Cisco-IOS-XR-nto-misc-oper",
+    "ylib": "urn:ietf:params:xml:ns:yang:ietf-yang-library",
 }
 
 # GET RPC to retrieve device facts
@@ -413,5 +414,22 @@ CLI_CONFIG_RPC_REQ_FILTER = """
 CLI_DIFF_RPC_REQ = """
 <get-cli-config-diff xmlns="http://cisco.com/ns/yang/Cisco-IOS-XR-cli-diff-act"/>"""
 
+# RPC filter to get module namespaces for a module-set using GET RPC
+YANG_LIB_RPC_REQ_FILTER = """
+<yang-library xmlns="urn:ietf:params:xml:ns:yang:ietf-yang-library">
+  <module-set>
+    <name>{module_set}</name>
+    <module>
+       <namespace/>
+    </module>
+  </module-set>
+</yang-library>"""
+
 # possible encoding values for optional argument "config_encoding"
 CONFIG_ENCODINGS = ["cli", "xml"]
+
+# module-set to be used by configuration methods
+MODULE_SET = "XR-only"
+
+# Exception Messages
+INVALID_MODEL_REFERENCE = "Unexpected YANG model reference in config"

--- a/napalm/iosxr_netconf/iosxr_netconf.py
+++ b/napalm/iosxr_netconf/iosxr_netconf.py
@@ -148,9 +148,15 @@ class IOSXRNETCONFDriver(NetworkDriver):
     def _filter_config_tree(self, tree):
         """Return filtered config etree based on YANG module set."""
         if self.module_set_ns:
-            def unexpected(n): return n not in self.module_set_ns
+
+            def unexpected(n):
+                return n not in self.module_set_ns
+
         else:
-            def unexpected(n): return n.startswith("http://openconfig.net/yang")
+
+            def unexpected(n):
+                return n.startswith("http://openconfig.net/yang")
+
         for subtree in tree:
             if unexpected(subtree.tag[1:].split("}")[0]):
                 tree.remove(subtree)
@@ -161,9 +167,15 @@ class IOSXRNETCONFDriver(NetworkDriver):
         """Return list of unexpected modules based on YANG module set."""
         modules = []
         if self.module_set_ns:
-            def unexpected(n): return n not in self.module_set_ns
+
+            def unexpected(n):
+                return n not in self.module_set_ns
+
         else:
-            def unexpected(n): return n.startswith("http://openconfig.net/yang")
+
+            def unexpected(n):
+                return n.startswith("http://openconfig.net/yang")
+
         for subtree in tree:
             namespace = subtree.tag[1:].split("}")[0]
             if unexpected(namespace):

--- a/tox.ini
+++ b/tox.ini
@@ -21,7 +21,7 @@ commands =
     py.test --cov=napalm --cov-report term-missing -vs --pylama {posargs}
 
 [testenv:black]
-deps = black==18.9b0
+deps = black==19.10b0
 
 basepython = python3.6
 commands =


### PR DESCRIPTION
Exchange of configuration in XML format is limited to models in the `XR-only` module set.  The namespaces associated with the module set are gathered in the `open` method.  The `load_merge_candidate` and `load_replace_candidate` methods raise an exception (`MergeConfigException` and `ReplaceConfigException`,respectively) if unexpected data is detected.  The `get_config` and `compare_config` methods filter out any configuration associated with models not in the module set.  The models in the module set are determined using the YANG library model. If a device  doesn't support the YANG library model, explicit filtering is performed.