### PR TITLE
Allow positional arguments for run_commands in eapi Node override

### DIFF
--- a/napalm/eos/pyeapi_syntax_wrapper.py
+++ b/napalm/eos/pyeapi_syntax_wrapper.py
@@ -25,7 +25,7 @@ class Node(pyeapi.client.Node):
         """
         self.cli_version = version
 
-    def run_commands(self, commands, **kwargs):
+    def run_commands(self, commands, *args, **kwargs):
         """
         Run commands wrapper
         :param commands: list of commands
@@ -39,4 +39,4 @@ class Node(pyeapi.client.Node):
             else:
                 commands = [cli_convert(cmd, self.cli_version) for cmd in commands]
 
-        return super(Node, self).run_commands(commands, **kwargs)
+        return super(Node, self).run_commands(commands, *args, **kwargs)


### PR DESCRIPTION
eapi has some code internal to pyeapi whereby they call `self.run_commands` using positional arguments.

This can cause issues if you try to access the underlying pyeapi method directly from NAPALM (which I was doing in a certain context).

Here is an example call inside pyeapi that was breaking:

My code:

```python
    napalm = task.host.get_connection("napalm", task.nornir.config)
    eapi_conn = napalm.device

    # This would break complaining about passing in too many positional arguments
    show_version = eapi_conn.enable("show version")
    pprint(show_version)
```

Pyeapi internal code that would get called via the `enable()` method and was breaking because of the positional arguments:

https://github.com/arista-eosplus/pyeapi/blob/develop/pyeapi/client.py#L712