### PR TITLE
Add get_vlans getter to EOS network driver

### DIFF
--- a/napalm/eos/eos.py
+++ b/napalm/eos/eos.py
@@ -1990,3 +1990,16 @@ class EOSDriver(NetworkDriver):
                     )
             ping_dict["success"].update({"results": results_array})
         return ping_dict
+
+    def get_vlans(self):
+        command = ["show vlan"]
+        output = self.device.run_commands(command, encoding="json")[0]["vlans"]
+
+        vlans = {}
+        for vlan, vlan_config in output.items():
+            vlans[vlan] = {
+                "name": vlan_config["name"],
+                "interfaces": list(vlan_config["interfaces"].keys()),
+            }
+
+        return vlans

--- a/napalm/ios/ios.py
+++ b/napalm/ios/ios.py
@@ -3047,8 +3047,8 @@ class IOSDriver(NetworkDriver):
                                         destination, _vrf, nh, ip_version
                                     )
                                 nh_line_found = (
-                                    False
-                                )  # for next RT entry processing ...
+                                    False  # for next RT entry processing ...
+                                )
                                 routes[route_match].append(route_entry)
         return routes
 

--- a/test/eos/mocked_data/test_get_vlans/normal/expected_result.json
+++ b/test/eos/mocked_data/test_get_vlans/normal/expected_result.json
@@ -1,0 +1,216 @@
+{
+	"1": {
+		"name": "default",
+		"interfaces": [
+			"Port-Channel1",
+			"Ethernet1",
+			"Ethernet2",
+			"Ethernet3",
+			"Ethernet4",
+			"Ethernet49/1",
+			"Ethernet50/1"
+		]
+	},
+	"10": {
+		"name": "VLAN0010",
+		"interfaces": [
+			"Port-Channel1",
+			"Ethernet1",
+			"Ethernet2",
+			"Ethernet49/1",
+			"Ethernet50/1"
+		]
+	},
+	"11": {
+		"name": "VLAN0011",
+		"interfaces": [
+			"Port-Channel1",
+			"Ethernet1",
+			"Ethernet2",
+			"Ethernet49/1",
+			"Ethernet50/1"
+		]
+	},
+	"12": {
+		"name": "VLAN0012",
+		"interfaces": [
+			"Port-Channel1",
+			"Ethernet1",
+			"Ethernet2",
+			"Ethernet49/1",
+			"Ethernet50/1"
+		]
+	},
+	"13": {
+		"name": "VLAN0013",
+		"interfaces": [
+			"Port-Channel1",
+			"Ethernet1",
+			"Ethernet2",
+			"Ethernet49/1",
+			"Ethernet50/1"
+		]
+	},
+	"14": {
+		"name": "VLAN0014",
+		"interfaces": [
+			"Port-Channel1",
+			"Ethernet1",
+			"Ethernet2",
+			"Ethernet49/1",
+			"Ethernet50/1"
+		]
+	},
+	"15": {
+		"name": "VLAN0015",
+		"interfaces": [
+			"Port-Channel1",
+			"Ethernet1",
+			"Ethernet2",
+			"Ethernet49/1",
+			"Ethernet50/1"
+		]
+	},
+	"100": {
+		"name": "VLAN0100",
+		"interfaces": [
+			"Port-Channel1",
+			"Ethernet1",
+			"Ethernet2",
+			"Ethernet1/1/1",
+			"Ethernet2/1/1",
+			"Ethernet3/1/1"
+		]
+	},
+	"101": {
+		"name": "VLAN0101",
+		"interfaces": [
+			"Port-Channel1",
+			"Ethernet1",
+			"Ethernet2",
+			"Ethernet1/1/1",
+			"Ethernet2/1/1",
+			"Ethernet3/1/1"
+		]
+	},
+	"102": {
+		"name": "VLAN0102",
+		"interfaces": [
+			"Port-Channel1",
+			"Ethernet1",
+			"Ethernet2",
+			"Ethernet1/1/1",
+			"Ethernet2/1/1",
+			"Ethernet3/1/1"
+		]
+	},
+	"103": {
+		"name": "VLAN0103",
+		"interfaces": [
+			"Port-Channel1",
+			"Ethernet1",
+			"Ethernet2",
+			"Ethernet1/1/1",
+			"Ethernet2/1/1",
+			"Ethernet3/1/1"
+		]
+	},
+	"104": {
+		"name": "VLAN0104",
+		"interfaces": [
+			"Port-Channel1",
+			"Ethernet1",
+			"Ethernet2",
+			"Ethernet1/1/1",
+			"Ethernet2/1/1",
+			"Ethernet3/1/1"
+		]
+	},
+	"105": {
+		"name": "VLAN0105",
+		"interfaces": [
+			"Port-Channel1",
+			"Ethernet1",
+			"Ethernet2",
+			"Ethernet1/1/1",
+			"Ethernet2/1/1",
+			"Ethernet3/1/1"
+		]
+	},
+	"200": {
+		"name": "VLAN0200",
+		"interfaces": [
+			"Port-Channel1",
+			"Ethernet1",
+			"Ethernet2",
+			"Ethernet4/1/1",
+			"Ethernet4/1/2",
+			"Ethernet4/1/3",
+			"Ethernet4/1/4"
+		]
+	},
+	"201": {
+		"name": "VLAN0201",
+		"interfaces": [
+			"Port-Channel1",
+			"Ethernet1",
+			"Ethernet2",
+			"Ethernet4/1/1",
+			"Ethernet4/1/2",
+			"Ethernet4/1/3",
+			"Ethernet4/1/4"
+		]
+	},
+	"202": {
+		"name": "VLAN0202",
+		"interfaces": [
+			"Port-Channel1",
+			"Ethernet1",
+			"Ethernet2",
+			"Ethernet4/1/1",
+			"Ethernet4/1/2",
+			"Ethernet4/1/3",
+			"Ethernet4/1/4"
+		]
+	},
+	"203": {
+		"name": "VLAN0203",
+		"interfaces": [
+			"Port-Channel1",
+			"Ethernet1",
+			"Ethernet2",
+			"Ethernet4/1/1",
+			"Ethernet4/1/2",
+			"Ethernet4/1/3",
+			"Ethernet4/1/4"
+		]
+	},
+	"204": {
+		"name": "VLAN0204",
+		"interfaces": [
+			"Port-Channel1",
+			"Ethernet1",
+			"Ethernet2",
+			"Ethernet4/1/1",
+			"Ethernet4/1/2",
+			"Ethernet4/1/3",
+			"Ethernet4/1/4"
+		]
+	},
+	"205": {
+		"name": "VLAN0205",
+		"interfaces": [
+			"Port-Channel1",
+			"Ethernet1",
+			"Ethernet2",
+			"Ethernet4/1/1",
+			"Ethernet4/1/2",
+			"Ethernet4/1/3",
+			"Ethernet4/1/4"
+		]
+	},
+	"1000": {
+		"name": "VLAN1000",
+		"interfaces": []
+	}
+}

--- a/test/eos/mocked_data/test_get_vlans/normal/show_vlan.json
+++ b/test/eos/mocked_data/test_get_vlans/normal/show_vlan.json
@@ -1,0 +1,489 @@
+{
+	"sourceDetail": "",
+	"vlans": {
+		"1": {
+			"status": "active",
+			"name": "default",
+			"interfaces": {
+				"Port-Channel1": {
+					"privatePromoted": false
+				},
+				"Ethernet1": {
+					"privatePromoted": false
+				},
+				"Ethernet2": {
+					"privatePromoted": false
+				},
+				"Ethernet3": {
+					"privatePromoted": false
+				},
+				"Ethernet4": {
+					"privatePromoted": false
+				},
+				"Ethernet49/1": {
+					"privatePromoted": false
+				},
+				"Ethernet50/1": {
+					"privatePromoted": false
+				}
+			},
+			"dynamic": false
+		},
+		"10": {
+			"status": "active",
+			"name": "VLAN0010",
+			"interfaces": {
+				"Port-Channel1": {
+					"privatePromoted": false
+				},
+				"Ethernet1": {
+					"privatePromoted": false
+				},
+				"Ethernet2": {
+					"privatePromoted": false
+				},
+				"Ethernet49/1": {
+					"privatePromoted": false
+				},
+				"Ethernet50/1": {
+					"privatePromoted": false
+				}
+			},
+			"dynamic": false
+		},
+		"11": {
+			"status": "active",
+			"name": "VLAN0011",
+			"interfaces": {
+				"Port-Channel1": {
+					"privatePromoted": false
+				},
+				"Ethernet1": {
+					"privatePromoted": false
+				},
+				"Ethernet2": {
+					"privatePromoted": false
+				},
+				"Ethernet49/1": {
+					"privatePromoted": false
+				},
+				"Ethernet50/1": {
+					"privatePromoted": false
+				}
+			},
+			"dynamic": false
+		},
+		"12": {
+			"status": "active",
+			"name": "VLAN0012",
+			"interfaces": {
+				"Port-Channel1": {
+					"privatePromoted": false
+				},
+				"Ethernet1": {
+					"privatePromoted": false
+				},
+				"Ethernet2": {
+					"privatePromoted": false
+				},
+				"Ethernet49/1": {
+					"privatePromoted": false
+				},
+				"Ethernet50/1": {
+					"privatePromoted": false
+				}
+			},
+			"dynamic": false
+		},
+		"13": {
+			"status": "active",
+			"name": "VLAN0013",
+			"interfaces": {
+				"Port-Channel1": {
+					"privatePromoted": false
+				},
+				"Ethernet1": {
+					"privatePromoted": false
+				},
+				"Ethernet2": {
+					"privatePromoted": false
+				},
+				"Ethernet49/1": {
+					"privatePromoted": false
+				},
+				"Ethernet50/1": {
+					"privatePromoted": false
+				}
+			},
+			"dynamic": false
+		},
+		"14": {
+			"status": "active",
+			"name": "VLAN0014",
+			"interfaces": {
+				"Port-Channel1": {
+					"privatePromoted": false
+				},
+				"Ethernet1": {
+					"privatePromoted": false
+				},
+				"Ethernet2": {
+					"privatePromoted": false
+				},
+				"Ethernet49/1": {
+					"privatePromoted": false
+				},
+				"Ethernet50/1": {
+					"privatePromoted": false
+				}
+			},
+			"dynamic": false
+		},
+		"15": {
+			"status": "active",
+			"name": "VLAN0015",
+			"interfaces": {
+				"Port-Channel1": {
+					"privatePromoted": false
+				},
+				"Ethernet1": {
+					"privatePromoted": false
+				},
+				"Ethernet2": {
+					"privatePromoted": false
+				},
+				"Ethernet49/1": {
+					"privatePromoted": false
+				},
+				"Ethernet50/1": {
+					"privatePromoted": false
+				}
+			},
+			"dynamic": false
+		},
+		"100": {
+			"status": "active",
+			"name": "VLAN0100",
+			"interfaces": {
+				"Port-Channel1": {
+					"privatePromoted": false
+				},
+				"Ethernet1": {
+					"privatePromoted": false
+				},
+				"Ethernet2": {
+					"privatePromoted": false
+				},
+				"Ethernet1/1/1": {
+					"privatePromoted": false
+				},
+				"Ethernet2/1/1": {
+					"privatePromoted": false
+				},
+				"Ethernet3/1/1": {
+					"privatePromoted": false
+				}
+			},
+			"dynamic": false
+		},
+		"101": {
+			"status": "active",
+			"name": "VLAN0101",
+			"interfaces": {
+				"Port-Channel1": {
+					"privatePromoted": false
+				},
+				"Ethernet1": {
+					"privatePromoted": false
+				},
+				"Ethernet2": {
+					"privatePromoted": false
+				},
+				"Ethernet1/1/1": {
+					"privatePromoted": false
+				},
+				"Ethernet2/1/1": {
+					"privatePromoted": false
+				},
+				"Ethernet3/1/1": {
+					"privatePromoted": false
+				}
+			},
+			"dynamic": false
+		},
+		"102": {
+			"status": "active",
+			"name": "VLAN0102",
+			"interfaces": {
+				"Port-Channel1": {
+					"privatePromoted": false
+				},
+				"Ethernet1": {
+					"privatePromoted": false
+				},
+				"Ethernet2": {
+					"privatePromoted": false
+				},
+				"Ethernet1/1/1": {
+					"privatePromoted": false
+				},
+				"Ethernet2/1/1": {
+					"privatePromoted": false
+				},
+				"Ethernet3/1/1": {
+					"privatePromoted": false
+				}
+			},
+			"dynamic": false
+		},
+		"103": {
+			"status": "active",
+			"name": "VLAN0103",
+			"interfaces": {
+				"Port-Channel1": {
+					"privatePromoted": false
+				},
+				"Ethernet1": {
+					"privatePromoted": false
+				},
+				"Ethernet2": {
+					"privatePromoted": false
+				},
+				"Ethernet1/1/1": {
+					"privatePromoted": false
+				},
+				"Ethernet2/1/1": {
+					"privatePromoted": false
+				},
+				"Ethernet3/1/1": {
+					"privatePromoted": false
+				}
+			},
+			"dynamic": false
+		},
+		"104": {
+			"status": "active",
+			"name": "VLAN0104",
+			"interfaces": {
+				"Port-Channel1": {
+					"privatePromoted": false
+				},
+				"Ethernet1": {
+					"privatePromoted": false
+				},
+				"Ethernet2": {
+					"privatePromoted": false
+				},
+				"Ethernet1/1/1": {
+					"privatePromoted": false
+				},
+				"Ethernet2/1/1": {
+					"privatePromoted": false
+				},
+				"Ethernet3/1/1": {
+					"privatePromoted": false
+				}
+			},
+			"dynamic": false
+		},
+		"105": {
+			"status": "active",
+			"name": "VLAN0105",
+			"interfaces": {
+				"Port-Channel1": {
+					"privatePromoted": false
+				},
+				"Ethernet1": {
+					"privatePromoted": false
+				},
+				"Ethernet2": {
+					"privatePromoted": false
+				},
+				"Ethernet1/1/1": {
+					"privatePromoted": false
+				},
+				"Ethernet2/1/1": {
+					"privatePromoted": false
+				},
+				"Ethernet3/1/1": {
+					"privatePromoted": false
+				}
+			},
+			"dynamic": false
+		},
+		"200": {
+			"status": "active",
+			"name": "VLAN0200",
+			"interfaces": {
+				"Port-Channel1": {
+					"privatePromoted": false
+				},
+				"Ethernet1": {
+					"privatePromoted": false
+				},
+				"Ethernet2": {
+					"privatePromoted": false
+				},
+				"Ethernet4/1/1": {
+					"privatePromoted": false
+				},
+				"Ethernet4/1/2": {
+					"privatePromoted": false
+				},
+				"Ethernet4/1/3": {
+					"privatePromoted": false
+				},
+				"Ethernet4/1/4": {
+					"privatePromoted": false
+				}
+			},
+			"dynamic": false
+		},
+		"201": {
+			"status": "active",
+			"name": "VLAN0201",
+			"interfaces": {
+				"Port-Channel1": {
+					"privatePromoted": false
+				},
+				"Ethernet1": {
+					"privatePromoted": false
+				},
+				"Ethernet2": {
+					"privatePromoted": false
+				},
+				"Ethernet4/1/1": {
+					"privatePromoted": false
+				},
+				"Ethernet4/1/2": {
+					"privatePromoted": false
+				},
+				"Ethernet4/1/3": {
+					"privatePromoted": false
+				},
+				"Ethernet4/1/4": {
+					"privatePromoted": false
+				}
+			},
+			"dynamic": false
+		},
+		"202": {
+			"status": "active",
+			"name": "VLAN0202",
+			"interfaces": {
+				"Port-Channel1": {
+					"privatePromoted": false
+				},
+				"Ethernet1": {
+					"privatePromoted": false
+				},
+				"Ethernet2": {
+					"privatePromoted": false
+				},
+				"Ethernet4/1/1": {
+					"privatePromoted": false
+				},
+				"Ethernet4/1/2": {
+					"privatePromoted": false
+				},
+				"Ethernet4/1/3": {
+					"privatePromoted": false
+				},
+				"Ethernet4/1/4": {
+					"privatePromoted": false
+				}
+			},
+			"dynamic": false
+		},
+		"203": {
+			"status": "active",
+			"name": "VLAN0203",
+			"interfaces": {
+				"Port-Channel1": {
+					"privatePromoted": false
+				},
+				"Ethernet1": {
+					"privatePromoted": false
+				},
+				"Ethernet2": {
+					"privatePromoted": false
+				},
+				"Ethernet4/1/1": {
+					"privatePromoted": false
+				},
+				"Ethernet4/1/2": {
+					"privatePromoted": false
+				},
+				"Ethernet4/1/3": {
+					"privatePromoted": false
+				},
+				"Ethernet4/1/4": {
+					"privatePromoted": false
+				}
+			},
+			"dynamic": false
+		},
+		"204": {
+			"status": "active",
+			"name": "VLAN0204",
+			"interfaces": {
+				"Port-Channel1": {
+					"privatePromoted": false
+				},
+				"Ethernet1": {
+					"privatePromoted": false
+				},
+				"Ethernet2": {
+					"privatePromoted": false
+				},
+				"Ethernet4/1/1": {
+					"privatePromoted": false
+				},
+				"Ethernet4/1/2": {
+					"privatePromoted": false
+				},
+				"Ethernet4/1/3": {
+					"privatePromoted": false
+				},
+				"Ethernet4/1/4": {
+					"privatePromoted": false
+				}
+			},
+			"dynamic": false
+		},
+		"205": {
+			"status": "active",
+			"name": "VLAN0205",
+			"interfaces": {
+				"Port-Channel1": {
+					"privatePromoted": false
+				},
+				"Ethernet1": {
+					"privatePromoted": false
+				},
+				"Ethernet2": {
+					"privatePromoted": false
+				},
+				"Ethernet4/1/1": {
+					"privatePromoted": false
+				},
+				"Ethernet4/1/2": {
+					"privatePromoted": false
+				},
+				"Ethernet4/1/3": {
+					"privatePromoted": false
+				},
+				"Ethernet4/1/4": {
+					"privatePromoted": false
+				}
+			},
+			"dynamic": false
+		},
+		"1000": {
+			"status": "active",
+			"name": "VLAN1000",
+			"interfaces": {},
+			"dynamic": false
+		}
+	}
+}


### PR DESCRIPTION
This would add the get_vlans() getter to the EOS network driver, which is currently not supported for the platform

