### PR TITLE
Fix mapping for Juniper devices with Netmiko

### DIFF
--- a/napalm/base/constants.py
+++ b/napalm/base/constants.py
@@ -64,7 +64,7 @@ NETMIKO_MAP = {
     "nxos_ssh": "cisco_nxos",
     "iosxr": "cisco_iosxr",
     "eos": "arista_eos",
-    "junos": "juniper_eos",
+    "junos": "juniper_junos",
 }
 LLDP_CAPAB_TRANFORM_TABLE = {
     "o": "other",


### PR DESCRIPTION
`junos` was incorrectly mapped to `juniper_eos` instead of
`juniper_junos`. It shouldn't matter much as, AFAIK, `junos` is not
using Netmiko.