### PR TITLE
Look up the KeepAliveTime and HoldTime keys in the VRF tree

### DIFF
--- a/napalm/iosxr/iosxr.py
+++ b/napalm/iosxr/iosxr.py
@@ -1170,13 +1170,13 @@ class IOSXRDriver(NetworkDriver):
             vrf_keepalive = napalm.base.helpers.convert(
                 int,
                 napalm.base.helpers.find_txt(
-                    instance_active_list, "GlobalProcessInfo/VRF/KeepAliveTime"
+                    vrf_tree, "GlobalProcessInfo/VRF/KeepAliveTime"
                 ),
             )
             vrf_holdtime = napalm.base.helpers.convert(
                 int,
                 napalm.base.helpers.find_txt(
-                    instance_active_list, "GlobalProcessInfo/VRF/HoldTime"
+                    vrf_tree, "GlobalProcessInfo/VRF/HoldTime"
                 ),
             )
             if vrf_name not in bgp_neighbors_detail.keys():


### PR DESCRIPTION
Due to a copy-paste probably, the code is currently looking under the
``instance_active_list``, which as the name suggests is a list of XML
trees, therefore any xpath query fails, with the following message.
Thanks to the newly added logging on the ``find_txt`` helper, the
following appeared in the logs:

```
'list' object has no attribute 'xpath'
'list' object has no attribute 'xpath'
'list' object has no attribute 'xpath'
'list' object has no attribute 'xpath'
'list' object has no attribute 'xpath'
'list' object has no attribute 'xpath'
```

This corrects this, by referencing the actual XML tree for the VRF
instead of the list of VRFs.