### PR TITLE
Remove Print Statement from nxos_ssh.py

### DIFF
--- a/napalm/nxos_ssh/nxos_ssh.py
+++ b/napalm/nxos_ssh/nxos_ssh.py
@@ -1720,7 +1720,6 @@ class NXOSSSHDriver(NXOSDriverBase):
                         if_counter[k] = int(row[v]) if v in row else 0
                     all_stats_d[interface] = if_counter
                     break
-        print(all_stats_d)
 
         for row in counters_table_raw:
             if_counter = {}


### PR DESCRIPTION
Removes unneeded print statement from interfaces_counters in nxos_ssh.py.