### PR TITLE
Add ncclient dependency for iosxr_netconf driver

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ junos-eznc>=2.2.1
 ciscoconfparse
 scp
 lxml>=4.3.0
+ncclient


### PR DESCRIPTION
Make ncclient dependency explicit in `requirements.txt`.