### PR TITLE
Improvement/documentation optional parameters

### DIFF
--- a/napalm/base/base.py
+++ b/napalm/base/base.py
@@ -1289,6 +1289,8 @@ class NetworkDriver(object):
         :type size: optional
         :param count: Number of ping request to send
         :type count: optional
+        :param vrf: Use a specific VRF to execute the ping
+        :type vrf: optional
 
         Output dictionary has one of following keys:
 
@@ -1360,6 +1362,8 @@ class NetworkDriver(object):
         :type ttl: optional
         :param timeout: Number of seconds to wait for response
         :type timeout: optional
+        :param vrf: Use a specific VRF to execute the traceroute
+        :type vrf: optional
 
         Output dictionary has one of the following keys:
 

--- a/napalm/base/base.py
+++ b/napalm/base/base.py
@@ -165,8 +165,10 @@ class NetworkDriver(object):
 
         :param cls: Instance of the driver class.
         :param template_name: Identifies the template name.
-        :param template_source (optional): Custom config template rendered and loaded on device
-        :param template_path (optional): Absolute path to directory for the configuration templates
+        :param template_source: Custom config template rendered and loaded on device
+        :type template_source optional
+        :param template_path: Absolute path to directory for the configuration templates
+        :type template_path optional
         :param template_vars: Dictionary with arguments to be used when the template is rendered.
         :raise DriverTemplateNotImplemented: No template defined for the device type.
         :raise TemplateNotImplemented: The template specified in template_name does not exist in \
@@ -1044,8 +1046,10 @@ class NetworkDriver(object):
         destination.
 
         :param destination: The destination prefix to be used when filtering the routes.
-        :param protocol (optional): Retrieve the routes only for a specific protocol.
-        :param longer (optional): Retrieve more specific routes as well.
+        :param protocol: Retrieve the routes only for a specific protocol.
+        :type protocol: optional
+        :param longer: Retrieve more specific routes as well.
+        :type longer: optional
 
         Each inner dictionary contains the following fields:
 
@@ -1275,11 +1279,16 @@ class NetworkDriver(object):
         Executes ping on the device and returns a dictionary with the result
 
         :param destination: Host or IP Address of the destination
-        :param source (optional): Source address of echo request
-        :param ttl (optional): Maximum number of hops
-        :param timeout (optional): Maximum seconds to wait after sending final packet
-        :param size (optional): Size of request (bytes)
-        :param count (optional): Number of ping request to send
+        :param source: Source address of echo request
+        :type source: optional
+        :param ttl: Maximum number of hops
+        :type ttl: optional
+        :param timeout: Maximum seconds to wait after sending final packet
+        :type timeout: optional
+        :param size: Size of request (bytes)
+        :type size: optional
+        :param count: Number of ping request to send
+        :type count: optional
 
         Output dictionary has one of following keys:
 
@@ -1345,9 +1354,12 @@ class NetworkDriver(object):
         Executes traceroute on the device and returns a dictionary with the result.
 
         :param destination: Host or IP Address of the destination
-        :param source (optional): Use a specific IP Address to execute the traceroute
-        :param ttl (optional): Maimum number of hops
-        :param timeout (optional): Number of seconds to wait for response
+        :param source: Use a specific IP Address to execute the traceroute
+        :type source: optional
+        :param ttl: Maimum number of hops
+        :type ttl: optional
+        :param timeout: Number of seconds to wait for response
+        :type timeout: optional
 
         Output dictionary has one of the following keys:
 

--- a/napalm/base/base.py
+++ b/napalm/base/base.py
@@ -1295,7 +1295,7 @@ class NetworkDriver(object):
             * success
             * error
 
-        In case of success, inner dictionary will have the followin keys:
+        In case of success, inner dictionary will have the following keys:
 
             * probes_sent (int)
             * packet_loss (int)
@@ -1356,7 +1356,7 @@ class NetworkDriver(object):
         :param destination: Host or IP Address of the destination
         :param source: Use a specific IP Address to execute the traceroute
         :type source: optional
-        :param ttl: Maimum number of hops
+        :param ttl: Maximum number of hops
         :type ttl: optional
         :param timeout: Number of seconds to wait for response
         :type timeout: optional

--- a/napalm/base/helpers.py
+++ b/napalm/base/helpers.py
@@ -350,8 +350,8 @@ def ip(addr, version=None):
     not the same.
 
     :param raw: the raw string containing the value of the IP Address
-    :param version: (optional) insist on a specific IP address version.
-    :type version: int.
+    :param version: insist on a specific IP address version.
+    :type version: int, optional.
     :return: a string containing the IP Address in a standard format (no leading zeros, \
     zeros-grouping, lowercase)
 
@@ -395,9 +395,10 @@ def canonical_interface_name(interface, addl_name_map=None):
     easily troubleshot, found, or known.
 
     :param interface: The interface you are attempting to expand.
-    :param addl_name_map (optional): A dict containing key/value pairs that updates
+    :param addl_name_map: A dict containing key/value pairs that updates
     the base mapping. Used if an OS has specific differences. e.g. {"Po": "PortChannel"} vs
     {"Po": "Port-Channel"}
+    :type addl_name_map: optional
     """
 
     name_map = {}
@@ -419,12 +420,14 @@ def abbreviated_interface_name(interface, addl_name_map=None, addl_reverse_map=N
     """Function to return an abbreviated representation of the interface name.
 
     :param interface: The interface you are attempting to abbreviate.
-    :param addl_name_map (optional): A dict containing key/value pairs that updates
+    :param addl_name_map: A dict containing key/value pairs that updates
     the base mapping. Used if an OS has specific differences. e.g. {"Po": "PortChannel"} vs
     {"Po": "Port-Channel"}
-    :param addl_reverse_map (optional): A dict containing key/value pairs that updates
+    :type addl_name_map: optional
+    :param addl_reverse_map: A dict containing key/value pairs that updates
     the reverse mapping. Used if an OS has specific differences. e.g. {"PortChannel": "Po"} vs
     {"PortChannel": "po"}
+    :type addl_reverse_map: optional
     """
 
     name_map = {}

--- a/napalm/ios/ios.py
+++ b/napalm/ios/ios.py
@@ -3265,6 +3265,8 @@ class IOSDriver(NetworkDriver):
         :type ttl: optional
         :param timeout: Number of seconds to wait for response -> int (1-3600)
         :type timeout: optional
+        :param vrf: Use a specific VRF to execute the traceroute
+        :type vrf: optional
 
         Output dictionary has one of the following keys:
 

--- a/napalm/ios/ios.py
+++ b/napalm/ios/ios.py
@@ -3259,9 +3259,12 @@ class IOSDriver(NetworkDriver):
         Executes traceroute on the device and returns a dictionary with the result.
 
         :param destination: Host or IP Address of the destination
-        :param source (optional): Use a specific IP Address to execute the traceroute
-        :param ttl (optional): Maimum number of hops -> int (0-255)
-        :param timeout (optional): Number of seconds to wait for response -> int (1-3600)
+        :param source: Use a specific IP Address to execute the traceroute
+        :type source: optional
+        :param ttl: Maimum number of hops -> int (0-255)
+        :type ttl: optional
+        :param timeout: Number of seconds to wait for response -> int (1-3600)
+        :type timeout: optional
 
         Output dictionary has one of the following keys:
 

--- a/napalm/ios/ios.py
+++ b/napalm/ios/ios.py
@@ -3261,7 +3261,7 @@ class IOSDriver(NetworkDriver):
         :param destination: Host or IP Address of the destination
         :param source: Use a specific IP Address to execute the traceroute
         :type source: optional
-        :param ttl: Maimum number of hops -> int (0-255)
+        :param ttl: Maximum number of hops -> int (0-255)
         :type ttl: optional
         :param timeout: Number of seconds to wait for response -> int (1-3600)
         :type timeout: optional


### PR DESCRIPTION
Correct some small things in the documentation:
 * typos
 * optional parameters currently do not get rendered correctly
 * add missing parameters to docstring of ping and traceroute 