### PR TITLE
Propagate NetMikoTimeoutException error message to ConnectionException

### DIFF
--- a/napalm/base/base.py
+++ b/napalm/base/base.py
@@ -91,8 +91,8 @@ class NetworkDriver(object):
                 timeout=self.timeout,
                 **netmiko_optional_args
             )
-        except NetMikoTimeoutException:
-            raise ConnectionException("Cannot connect to {}".format(self.hostname))
+        except NetMikoTimeoutException as e:
+            raise ConnectionException("Cannot connect to {}\n\n{}".format(self.hostname, e))
 
         # Disable enable mode if force_no_enable is true (for NAPALM drivers
         # that support force_no_enable)

--- a/napalm/base/base.py
+++ b/napalm/base/base.py
@@ -92,7 +92,9 @@ class NetworkDriver(object):
                 **netmiko_optional_args
             )
         except NetMikoTimeoutException as e:
-            raise ConnectionException("Cannot connect to {}\n\n{}".format(self.hostname, e))
+            raise ConnectionException(
+                "Cannot connect to {}\n\n{}".format(self.hostname, e)
+            )
 
         # Disable enable mode if force_no_enable is true (for NAPALM drivers
         # that support force_no_enable)
@@ -1460,7 +1462,7 @@ class NetworkDriver(object):
             {
                 'error': 'unknown host 8.8.8.8.8'
             }
-            """
+        """
         raise NotImplementedError
 
     def get_users(self):

--- a/napalm/base/helpers.py
+++ b/napalm/base/helpers.py
@@ -147,7 +147,7 @@ def cisco_conf_parse_objects(cfg_section, config):
 
 
 def regex_find_txt(pattern, text, default=""):
-    """""
+    """ ""
     RegEx search for pattern in text. Will try to match the data type of the "default" value
     or return the default value if no match is found.
     This is to parse IOS config like below:

--- a/napalm/eos/eos.py
+++ b/napalm/eos/eos.py
@@ -1350,11 +1350,13 @@ class EOSDriver(NetworkDriver):
                             )
                         except CommandError:
                             # Newer EOS can't mix longer-prefix and detail
-                            command = "show ip{ipv} bgp {dest} {longer} vrf {_vrf}".format(
-                                ipv=ipv,
-                                dest=destination,
-                                longer="longer-prefixes" if longer else "",
-                                _vrf=_vrf,
+                            command = (
+                                "show ip{ipv} bgp {dest} {longer} vrf {_vrf}".format(
+                                    ipv=ipv,
+                                    dest=destination,
+                                    longer="longer-prefixes" if longer else "",
+                                    _vrf=_vrf,
+                                )
                             )
                             vrf_cache.update(
                                 {

--- a/napalm/junos/junos.py
+++ b/napalm/junos/junos.py
@@ -405,8 +405,8 @@ class JunOSDriver(NetworkDriver):
             routing_engine = junos_views.junos_routing_engine_table_srx_cluster(
                 self.device
             )
-            temperature_thresholds = junos_views.junos_temperature_thresholds_srx_cluster(
-                self.device
+            temperature_thresholds = (
+                junos_views.junos_temperature_thresholds_srx_cluster(self.device)
             )
         else:
             environment = junos_views.junos_environment_table(self.device)
@@ -1898,12 +1898,14 @@ class JunOSDriver(NetworkDriver):
         if vrf:
             vrf_str = " routing-instance {vrf}".format(vrf=vrf)
 
-        traceroute_command = "traceroute {destination}{source}{maxttl}{wait}{vrf}".format(
-            destination=destination,
-            source=source_str,
-            maxttl=maxttl_str,
-            wait=wait_str,
-            vrf=vrf_str,
+        traceroute_command = (
+            "traceroute {destination}{source}{maxttl}{wait}{vrf}".format(
+                destination=destination,
+                source=source_str,
+                maxttl=maxttl_str,
+                wait=wait_str,
+                vrf=vrf_str,
+            )
         )
 
         traceroute_rpc = E("command", traceroute_command)
@@ -1985,14 +1987,16 @@ class JunOSDriver(NetworkDriver):
         if vrf:
             vrf_str = " routing-instance {vrf}".format(vrf=vrf)
 
-        ping_command = "ping {destination}{source}{ttl}{timeout}{size}{count}{vrf}".format(
-            destination=destination,
-            source=source_str,
-            ttl=maxttl_str,
-            timeout=timeout_str,
-            size=size_str,
-            count=count_str,
-            vrf=vrf_str,
+        ping_command = (
+            "ping {destination}{source}{ttl}{timeout}{size}{count}{vrf}".format(
+                destination=destination,
+                source=source_str,
+                ttl=maxttl_str,
+                timeout=timeout_str,
+                size=size_str,
+                count=count_str,
+                vrf=vrf_str,
+            )
         )
 
         ping_rpc = E("command", ping_command)

--- a/napalm/pyIOSXR/iosxr.py
+++ b/napalm/pyIOSXR/iosxr.py
@@ -579,10 +579,12 @@ class IOSXR(object):
             with open(filename) as f:
                 configuration = f.read()
 
-        rpc_command = "<CLI><Configuration>{configuration}</Configuration></CLI>".format(
-            configuration=escape_xml(
-                configuration
-            )  # need to escape, otherwise will try to load invalid XML
+        rpc_command = (
+            "<CLI><Configuration>{configuration}</Configuration></CLI>".format(
+                configuration=escape_xml(
+                    configuration
+                )  # need to escape, otherwise will try to load invalid XML
+            )
         )
 
         try:
@@ -719,7 +721,9 @@ class IOSXR(object):
 
         :param rb_id: Rollback a specific number of steps. Default: 1
         """
-        rpc_command = "<Unlock/><Rollback><Previous>{rb_id}</Previous></Rollback><Lock/>".format(
-            rb_id=rb_id
+        rpc_command = (
+            "<Unlock/><Rollback><Previous>{rb_id}</Previous></Rollback><Lock/>".format(
+                rb_id=rb_id
+            )
         )
         self._execute_rpc(rpc_command)


### PR DESCRIPTION
Hi,

Currently NAPALM reports any NetmikoTimeoutException as "Cannot connect to <host>".

It unfortunately hides potential reason for the error, if netmiko communicates it in its error message.
In my cause, for example, this (unfortunately unhelpful) error meant "permission denied accessing ssh key", which is hard to guess from "cannot connect to" message, so this PR simply adds whole netmiko error message after a dash.

There is related https://github.com/ktbyers/netmiko/pull/2052 issue in my case for hopefully making netmiko error messages contain more information, but regardless of how non-desciptive they might be, don't think there should be any harm propagating info from there to NAPALM users (and any apps using it), and might help to understand what the problem is.
( https://github.com/ktbyers/netmiko/pull/2052#issuecomment-732409571 comment there might also highlight the issue with too-compact error messages)

Thanks.