### PR TITLE
Cast uptime values to int before processing

### DIFF
--- a/napalm/nxos/nxos.py
+++ b/napalm/nxos/nxos.py
@@ -837,10 +837,10 @@ class NXOSDriver(NXOSDriverBase):
             "sys_ver_str", show_version.get("kickstart_ver_str", "")
         )
 
-        uptime_days = show_version.get("kern_uptm_days", 0)
-        uptime_hours = show_version.get("kern_uptm_hrs", 0)
-        uptime_mins = show_version.get("kern_uptm_mins", 0)
-        uptime_secs = show_version.get("kern_uptm_secs", 0)
+        uptime_days = int(show_version.get("kern_uptm_days", 0))
+        uptime_hours = int(show_version.get("kern_uptm_hrs", 0))
+        uptime_mins = int(show_version.get("kern_uptm_mins", 0))
+        uptime_secs = int(show_version.get("kern_uptm_secs", 0))
 
         uptime = 0
         uptime += uptime_days * 24 * 60 * 60


### PR DESCRIPTION
I ran into a TypeError here: TypeError: unsupported operand type(s) for +=: 'int' and 'str'
Casting the uptime values (days, hours, mins, seconds) to int before processing fixes this issue.