### PR TITLE
config merge operation for iOS devices not clear if rollback was successful

### DIFF
--- a/napalm/ios/ios.py
+++ b/napalm/ios/ios.py
@@ -542,6 +542,12 @@ class IOSDriver(NetworkDriver):
                 raise ReplaceConfigException(msg)
         else:
             # Merge operation
+            filename = self.merge_cfg
+            cfg_file = self._gen_full_path(filename)
+            if not self._check_file_exists(cfg_file):
+                raise MergeConfigException("Merge source config file does not exist")
+            cmd = "copy {} running-config".format(cfg_file)
+            output = self._commit_handler(cmd)
             if "Invalid input detected" in output:
                 rollback = self.rollback()
                 if 'Rollback Done' in rollback:
@@ -552,8 +558,8 @@ class IOSDriver(NetworkDriver):
                             )
                     raise MergeConfigException(merge_error)
                 else:
-                    err_header = "Configuration merge failed; automatic
-                    rollback failed, user intervention required"
+                    err_header = """Configuration merge failed; automatic
+                    rollback failed, user intervention required"""
                     merge_error = "{0}:\n{1}{2}\n{3}".format(err_header,
                             output,rollback)
                     raise MergeConfigException(merge_error)

--- a/napalm/ios/ios.py
+++ b/napalm/ios/ios.py
@@ -561,7 +561,7 @@ class IOSDriver(NetworkDriver):
                 else:
                     err_header = """Configuration merge failed; automatic
                     rollback failed, user intervention required"""
-                    merge_error = "{0}:\n{1}{2}\n{3}".format(
+                    merge_error = "{0}:\n{1}{2}".format(
                         err_header, output, rollback
                     )
                     raise MergeConfigException(merge_error)

--- a/napalm/ios/ios.py
+++ b/napalm/ios/ios.py
@@ -550,21 +550,21 @@ class IOSDriver(NetworkDriver):
             output = self._commit_handler(cmd)
             if "Invalid input detected" in output:
                 rollback = self.rollback()
-                if 'Rollback Done' in rollback:
+                if "Rollback Done" in rollback:
                     err_header = """Configuration merge failed, but automatic
                     rollback successfully restored original configuration"""
-                    merge_error = "{0}:\n{1}".format(err_header,
-                            output,
-                            )
+                    merge_error = "{0}:\n{1}".format(
+                        err_header,
+                        output,
+                    )
                     raise MergeConfigException(merge_error)
                 else:
                     err_header = """Configuration merge failed; automatic
                     rollback failed, user intervention required"""
-                    merge_error = "{0}:\n{1}{2}\n{3}".format(err_header,
-                            output,rollback)
+                    merge_error = "{0}:\n{1}{2}\n{3}".format(
+                        err_header, output, rollback
+                    )
                     raise MergeConfigException(merge_error)
-
-
 
         # After a commit - we no longer know whether this is configured or not.
         self.prompt_quiet_configured = None
@@ -601,7 +601,7 @@ class IOSDriver(NetworkDriver):
         # Save config to startup
         self.device.save_config()
 
-        return(output)
+        return output
 
     def _inline_tcl_xfer(
         self, source_file=None, source_config=None, dest_file=None, file_system=None


### PR DESCRIPTION
When the config merge operation fails napalm quits with  : "Configuration merge failed; automatic rollback attempted " But it does not tell you, if the rollback was successful or failed. Now it does .

I hope you find it useful. 