### PR TITLE
Bump version of coveralls to fix code coverage report

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ matrix:
     - python: nightly
 
 install:
-  - pip install tox==3.14.0 tox-travis==0.12 coveralls==1.8.2
+  - pip install tox==3.14.0 tox-travis==0.12 coveralls==2.2.0
 
 deploy:
   provider: pypi


### PR DESCRIPTION
The coverage badge seems to have been in a failed state for some time and the badge displays 0% code coverage.

This PR bumps the version of coveralls that Travis is using to one that is compatible with the current version of pytest-cov.

From the Travis log:
```
0.21s$ coveralls
Submitting coverage to coveralls.io...
Traceback (most recent call last):
  File "/home/travis/virtualenv/python3.7.1/lib/python3.7/site-packages/coverage/data.py", line 293, in read_file
    self.read_fileobj(f)
  File "/home/travis/virtualenv/python3.7.1/lib/python3.7/site-packages/coverage/data.py", line 271, in read_fileobj
    data = self._read_raw_data(file_obj)
  File "/home/travis/virtualenv/python3.7.1/lib/python3.7/site-packages/coverage/data.py", line 311, in _read_raw_data
    go_away = file_obj.read(len(cls._GO_AWAY))
  File "/home/travis/virtualenv/python3.7.1/lib/python3.7/codecs.py", line 322, in decode
    (result, consumed) = self._buffer_decode(data, self.errors, final)
UnicodeDecodeError: 'utf-8' codec can't decode bytes in position 98-99: invalid continuation byte
During handling of the above exception, another exception occurred:
Traceback (most recent call last):
  File "/home/travis/virtualenv/python3.7.1/bin/coveralls", line 8, in <module>
    sys.exit(main())
  File "/home/travis/virtualenv/python3.7.1/lib/python3.7/site-packages/coveralls/cli.py", line 77, in main
    result = coverallz.wear()
  File "/home/travis/virtualenv/python3.7.1/lib/python3.7/site-packages/coveralls/api.py", line 168, in wear
    json_string = self.create_report()
  File "/home/travis/virtualenv/python3.7.1/lib/python3.7/site-packages/coveralls/api.py", line 184, in create_report
    data = self.create_data()
  File "/home/travis/virtualenv/python3.7.1/lib/python3.7/site-packages/coveralls/api.py", line 238, in create_data
    self._data = {'source_files': self.get_coverage()}
  File "/home/travis/virtualenv/python3.7.1/lib/python3.7/site-packages/coveralls/api.py", line 253, in get_coverage
    workman.load()
  File "/home/travis/virtualenv/python3.7.1/lib/python3.7/site-packages/coverage/control.py", line 677, in load
    self.data_files.read(self.data)
  File "/home/travis/virtualenv/python3.7.1/lib/python3.7/site-packages/coverage/data.py", line 653, in read
    data.read_file(self.filename)
  File "/home/travis/virtualenv/python3.7.1/lib/python3.7/site-packages/coverage/data.py", line 297, in read_file
    filename, exc.__class__.__name__, exc,
coverage.misc.CoverageException: Couldn't read data from '/home/travis/build/napalm-automation/napalm/.coverage': UnicodeDecodeError: 'utf-8' codec can't decode bytes in position 98-99: invalid continuation byte
```