### PR TITLE
Multiple next-hop self config stanzas generate a list

### DIFF
--- a/napalm/junos/junos.py
+++ b/napalm/junos/junos.py
@@ -1029,7 +1029,7 @@ class JunOSDriver(NetworkDriver):
                 policies = [policies]
             # Return True if "next-hop self" was found in any of the policies p
             for p in policies:
-                if nhs_policies[p] is True:
+                if nhs_policies[p] is True or isinstance(nhs_policies[p], list):
                     return True
             return False
 


### PR DESCRIPTION
For example, for the following policy:

```
luca@bsr1.atl2> show configuration policy-options policy-statement INTERNAL-ATL2-RR-OUT
term LOCAL-BE {
    from {
        protocol static;
        community PACKET-BE;
    }
    then {
        local-preference 500;
        next-hop self;
        accept;
    }
}
term LOCAL-PUBLIC {
    from {
        protocol static;
        prefix-list ANNOUNCE-ATL2-V4;
    }
    then {
        local-preference 500;
        next-hop self;
        accept;
    }
}
term LOCAL-CUSTOMERS {
    from {
        protocol bgp;
        community PACKET-ATL2-CUSTOMER;
        route-filter 0.0.0.0/0 upto /24;
    }
    then {
        next-hop self;
        accept;
    }
}
term GLOBAL-IP {
    from {
        protocol bgp;
        community PACKET-ATL2-GLOBAL-IP;
    }
    then {
        next-hop self;
        accept;
    }
}
term EVPN-REJECT-DEFAULT {
    from {
        protocol evpn;
        route-filter 0.0.0.0/0 exact;
    }
    then reject;
}
term EVPN-PACKET-INTERNAL {
    from {
        family evpn;
        community PACKET-INTERNAL-RT;
    }
    then accept;
}
then reject;
```

`nhs_policies[p]` would be a list: `[True, True, True, True]`.

Therefore, in case `nhs_policies[p]` is a list, then there's at least
one next-hop self knob configured in the policy, so it can be marked as
NHS-type policy.