### PR TITLE
Use aply-groups inheritance on get-configuration RPC calls

### DIFF
--- a/napalm/base/base.py
+++ b/napalm/base/base.py
@@ -1460,7 +1460,7 @@ class NetworkDriver(object):
             {
                 'error': 'unknown host 8.8.8.8.8'
             }
-            """
+        """
         raise NotImplementedError
 
     def get_users(self):

--- a/napalm/base/helpers.py
+++ b/napalm/base/helpers.py
@@ -147,7 +147,7 @@ def cisco_conf_parse_objects(cfg_section, config):
 
 
 def regex_find_txt(pattern, text, default=""):
-    """""
+    """ ""
     RegEx search for pattern in text. Will try to match the data type of the "default" value
     or return the default value if no match is found.
     This is to parse IOS config like below:

--- a/napalm/eos/eos.py
+++ b/napalm/eos/eos.py
@@ -1361,11 +1361,13 @@ class EOSDriver(NetworkDriver):
                             )
                         except CommandError:
                             # Newer EOS can't mix longer-prefix and detail
-                            command = "show ip{ipv} bgp {dest} {longer} vrf {_vrf}".format(
-                                ipv=ipv,
-                                dest=destination,
-                                longer="longer-prefixes" if longer else "",
-                                _vrf=_vrf,
+                            command = (
+                                "show ip{ipv} bgp {dest} {longer} vrf {_vrf}".format(
+                                    ipv=ipv,
+                                    dest=destination,
+                                    longer="longer-prefixes" if longer else "",
+                                    _vrf=_vrf,
+                                )
                             )
                             vrf_cache.update(
                                 {

--- a/napalm/junos/junos.py
+++ b/napalm/junos/junos.py
@@ -102,9 +102,7 @@ class JunOSDriver(NetworkDriver):
         self.junos_config_inheritance = optional_args.get(
             "junos_config_inherit", "inherit"
         )
-        self.junos_config_groups = optional_args.get(
-            "junos_config_groups", "groups"
-        )
+        self.junos_config_groups = optional_args.get("junos_config_groups", "groups")
         self.junos_config_options = {
             "database": self.junos_config_database,
             "inherit": self.junos_config_inheritance,
@@ -419,8 +417,8 @@ class JunOSDriver(NetworkDriver):
             routing_engine = junos_views.junos_routing_engine_table_srx_cluster(
                 self.device
             )
-            temperature_thresholds = junos_views.junos_temperature_thresholds_srx_cluster(
-                self.device
+            temperature_thresholds = (
+                junos_views.junos_temperature_thresholds_srx_cluster(self.device)
             )
         else:
             environment = junos_views.junos_environment_table(self.device)
@@ -1912,12 +1910,14 @@ class JunOSDriver(NetworkDriver):
         if vrf:
             vrf_str = " routing-instance {vrf}".format(vrf=vrf)
 
-        traceroute_command = "traceroute {destination}{source}{maxttl}{wait}{vrf}".format(
-            destination=destination,
-            source=source_str,
-            maxttl=maxttl_str,
-            wait=wait_str,
-            vrf=vrf_str,
+        traceroute_command = (
+            "traceroute {destination}{source}{maxttl}{wait}{vrf}".format(
+                destination=destination,
+                source=source_str,
+                maxttl=maxttl_str,
+                wait=wait_str,
+                vrf=vrf_str,
+            )
         )
 
         traceroute_rpc = E("command", traceroute_command)
@@ -1999,14 +1999,16 @@ class JunOSDriver(NetworkDriver):
         if vrf:
             vrf_str = " routing-instance {vrf}".format(vrf=vrf)
 
-        ping_command = "ping {destination}{source}{ttl}{timeout}{size}{count}{vrf}".format(
-            destination=destination,
-            source=source_str,
-            ttl=maxttl_str,
-            timeout=timeout_str,
-            size=size_str,
-            count=count_str,
-            vrf=vrf_str,
+        ping_command = (
+            "ping {destination}{source}{ttl}{timeout}{size}{count}{vrf}".format(
+                destination=destination,
+                source=source_str,
+                ttl=maxttl_str,
+                timeout=timeout_str,
+                size=size_str,
+                count=count_str,
+                vrf=vrf_str,
+            )
         )
 
         ping_rpc = E("command", ping_command)

--- a/napalm/junos/junos.py
+++ b/napalm/junos/junos.py
@@ -99,6 +99,20 @@ class JunOSDriver(NetworkDriver):
         self.junos_config_database = optional_args.get(
             "junos_config_database", "committed"
         )
+        self.junos_config_inheritance = optional_args.get(
+            "junos_config_inherit", "inherit"
+        )
+        self.junos_config_groups = optional_args.get(
+            "junos_config_groups", "groups"
+        )
+        self.junos_config_options = {
+            "database": self.junos_config_database,
+            "inherit": self.junos_config_inheritance,
+            "groups": self.junos_config_groups,
+        }
+        self.junos_config_options = optional_args.get(
+            "junos_config_options", self.junos_config_options
+        )
 
         if self.key_file:
             self.device = Device(
@@ -1130,10 +1144,10 @@ class JunOSDriver(NetworkDriver):
 
         if group:
             bgp = junos_views.junos_bgp_config_group_table(self.device)
-            bgp.get(group=group, options={"database": self.junos_config_database})
+            bgp.get(group=group, options=self.junos_config_options)
         else:
             bgp = junos_views.junos_bgp_config_table(self.device)
-            bgp.get(options={"database": self.junos_config_database})
+            bgp.get(options=self.junos_config_options)
             neighbor = ""  # if no group is set, no neighbor should be set either
         bgp_items = bgp.items()
 
@@ -1146,7 +1160,7 @@ class JunOSDriver(NetworkDriver):
         # The resulting dict (nhs_policies) will be used by _check_nhs to determine if "nhs"
         # is configured or not in the policies applied to a BGP neighbor
         policy = junos_views.junos_policy_nhs_config_table(self.device)
-        policy.get(options={"database": self.junos_config_database})
+        policy.get(options=self.junos_config_options)
         nhs_policies = dict()
         for policy_name, is_nhs_list in policy.items():
             # is_nhs_list is a list with one element. Ex: [('is_nhs', True)]
@@ -1484,7 +1498,7 @@ class JunOSDriver(NetworkDriver):
     def get_ntp_peers(self):
         """Return the NTP peers configured on the device."""
         ntp_table = junos_views.junos_ntp_peers_config_table(self.device)
-        ntp_table.get(options={"database": self.junos_config_database})
+        ntp_table.get(options=self.junos_config_options)
 
         ntp_peers = ntp_table.items()
 
@@ -1496,7 +1510,7 @@ class JunOSDriver(NetworkDriver):
     def get_ntp_servers(self):
         """Return the NTP servers configured on the device."""
         ntp_table = junos_views.junos_ntp_servers_config_table(self.device)
-        ntp_table.get(options={"database": self.junos_config_database})
+        ntp_table.get(options=self.junos_config_options)
 
         ntp_servers = ntp_table.items()
 
@@ -1771,7 +1785,7 @@ class JunOSDriver(NetworkDriver):
         snmp_information = {}
 
         snmp_config = junos_views.junos_snmp_config_table(self.device)
-        snmp_config.get(options={"database": self.junos_config_database})
+        snmp_config.get(options=self.junos_config_options)
         snmp_items = snmp_config.items()
 
         if not snmp_items:
@@ -1808,7 +1822,7 @@ class JunOSDriver(NetworkDriver):
         probes = {}
 
         probes_table = junos_views.junos_rpm_probes_config_table(self.device)
-        probes_table.get(options={"database": self.junos_config_database})
+        probes_table.get(options=self.junos_config_options)
         probes_table_items = probes_table.items()
 
         for probe_test in probes_table_items:
@@ -2109,7 +2123,7 @@ class JunOSDriver(NetworkDriver):
         _DEFAULT_USER_DETAILS = {"level": 20, "password": "", "sshkeys": []}
         root = {}
         root_table = junos_views.junos_root_table(self.device)
-        root_table.get(options={"database": self.junos_config_database})
+        root_table.get(options=self.junos_config_options)
         root_items = root_table.items()
         for user_entry in root_items:
             username = "root"
@@ -2140,7 +2154,7 @@ class JunOSDriver(NetworkDriver):
         _DEFAULT_USER_DETAILS = {"level": 0, "password": "", "sshkeys": []}
 
         users_table = junos_views.junos_users_table(self.device)
-        users_table.get(options={"database": self.junos_config_database})
+        users_table.get(options=self.junos_config_options)
         users_items = users_table.items()
         root_user = self._get_root()
 
@@ -2288,7 +2302,7 @@ class JunOSDriver(NetworkDriver):
         network_instances = {}
 
         ri_table = junos_views.junos_nw_instances_table(self.device)
-        ri_table.get(options={"database": self.junos_config_database})
+        ri_table.get(options=self.junos_config_options)
         ri_entries = ri_table.items()
 
         vrf_interfaces = []

--- a/napalm/pyIOSXR/iosxr.py
+++ b/napalm/pyIOSXR/iosxr.py
@@ -570,10 +570,12 @@ class IOSXR(object):
             with open(filename) as f:
                 configuration = f.read()
 
-        rpc_command = "<CLI><Configuration>{configuration}</Configuration></CLI>".format(
-            configuration=escape_xml(
-                configuration
-            )  # need to escape, otherwise will try to load invalid XML
+        rpc_command = (
+            "<CLI><Configuration>{configuration}</Configuration></CLI>".format(
+                configuration=escape_xml(
+                    configuration
+                )  # need to escape, otherwise will try to load invalid XML
+            )
         )
 
         try:
@@ -710,7 +712,9 @@ class IOSXR(object):
 
         :param rb_id: Rollback a specific number of steps. Default: 1
         """
-        rpc_command = "<Unlock/><Rollback><Previous>{rb_id}</Previous></Rollback><Lock/>".format(
-            rb_id=rb_id
+        rpc_command = (
+            "<Unlock/><Rollback><Previous>{rb_id}</Previous></Rollback><Lock/>".format(
+                rb_id=rb_id
+            )
         )
         self._execute_rpc(rpc_command)


### PR DESCRIPTION
The behaviour for get-configuration RPC calls has been changed in
2af90cc75, in order to ensure we're gathering from the right database.

The way junos-eznc works is that if there aren't any specific options
passed in, it uses apply-groups by default. But when there are options
passed in, as we do starting with 2af90cc75, it doesn't default the
values of `inherit` and `groups`, and therefore when gathering the
config it won't expand the apply-groups, see
https://github.com/Juniper/py-junos-eznc/blob/ab0e8603eac56fa1d049695c7ef86eb64582ab8f/lib/jnpr/junos/factory/cfgtable.py#L517-L520.

Changing this now, by adding a few new optional arguments, which allow
the user to select the desired behaviour.