### PR TITLE
Fix typo in mock.py

### DIFF
--- a/napalm/base/mock.py
+++ b/napalm/base/mock.py
@@ -177,7 +177,7 @@ class MockDriver(NetworkDriver):
         mocked_data(self.path, "commit_config", count)
 
     def discard_config(self):
-        count = self._count_calls("commit_config")
+        count = self._count_calls("discard_config")
         self._raise_if_closed()
         self.merge = None
         self.filename = None


### PR DESCRIPTION
Fix discard_config counting up commit_config calls instead of discard_config.