### PR TITLE
Handle control plane interface

### DIFF
--- a/napalm/ios/ios.py
+++ b/napalm/ios/ios.py
@@ -1088,7 +1088,10 @@ class IOSDriver(NetworkDriver):
 
             interface_regex_1 = r"^(\S+?)\s+is\s+(.+?),\s+line\s+protocol\s+is\s+(\S+)"
             interface_regex_2 = r"^(\S+)\s+is\s+(up|down)"
-            interface_regex_3 = r"^(Control Plane Interface)\s+is\s+(.+?),\s+line\s+protocol\s+is\s+(\S+)"
+            interface_regex_3 = (
+                r"^(Control Plane Interface)"
+                r"\s+is\s+(.+?),\s+line\s+protocol\s+is\s+(\S+)"
+            )
             for pattern in (interface_regex_1, interface_regex_2, interface_regex_3):
                 interface_match = re.search(pattern, line)
                 if interface_match:

--- a/napalm/ios/ios.py
+++ b/napalm/ios/ios.py
@@ -1088,7 +1088,8 @@ class IOSDriver(NetworkDriver):
 
             interface_regex_1 = r"^(\S+?)\s+is\s+(.+?),\s+line\s+protocol\s+is\s+(\S+)"
             interface_regex_2 = r"^(\S+)\s+is\s+(up|down)"
-            for pattern in (interface_regex_1, interface_regex_2):
+            interface_regex_3 = r"^(Control Plane Interface)\s+is\s+(.+?),\s+line\s+protocol\s+is\s+(\S+)"
+            for pattern in (interface_regex_1, interface_regex_2, interface_regex_3):
                 interface_match = re.search(pattern, line)
                 if interface_match:
                     interface = interface_match.group(1)

--- a/test/ios/mocked_data/test_get_interfaces/control-plane-interface/expected_result.json
+++ b/test/ios/mocked_data/test_get_interfaces/control-plane-interface/expected_result.json
@@ -1,0 +1,11 @@
+{
+	"Control Plane Interface": {
+		"speed": 10000,
+		"mac_address": "00:00:00:00:00:00",
+		"is_up": false,
+		"last_flapped": -1.0,
+		"description": "",
+        "mtu": 0,
+		"is_enabled": true
+	}
+}

--- a/test/ios/mocked_data/test_get_interfaces/control-plane-interface/show_interfaces.txt
+++ b/test/ios/mocked_data/test_get_interfaces/control-plane-interface/show_interfaces.txt
@@ -1,0 +1,21 @@
+Control Plane Interface is down, line protocol is down
+  Hardware is Control-Plane, address is 0000.0000.0000 (bia 0000.0000.0000)
+  MTU 0 bytes, BW 10000000 Kbit, DLY 0 usec,
+     reliability 0/255, txload 1/255, rxload 1/255
+  Encapsulation UNKNOWN, loopback not set
+  ARP type: ARPA, ARP Timeout 00:00:00
+  Last input never, output never, output hang never
+  Last clearing of "show interface" counters never
+  Input queue: 0/75/0/0 (size/max/drops/flushes); Total output drops: 0
+  5 minute input rate 0 bits/sec, 0 packets/sec
+  5 minute output rate 0 bits/sec, 0 packets/sec
+  L2 Switched: ucast: 0 pkt, 0 bytes - mcast: 0 pkt, 0 bytes
+  L3 in Switched: ucast: 0 pkt, 0 bytes - mcast: 0 pkt, 0 bytes mcast
+  L3 out Switched: ucast: 0 pkt, 0 bytes mcast: 0 pkt, 0 bytes
+     0 packets input, 0 bytes, 0 no buffer
+     Received 0 broadcasts (0 IP multicast)
+     0 runts, 0 giants, 0 throttles
+     0 input errors, 0 CRC, 0 frame, 0 overrun, 0 ignored
+     0 packets output, 0 bytes, 0 underruns
+     0 output errors, 0 interface resets
+     0 output buffer failures, 0 output buffers swapped out


### PR DESCRIPTION
See #1410 

I approached the fix by simply adding an additional regex pattern for the interface line. There are multiple approaches that are a matter of opinion, e.g. just modify existing pattern with an or to include the text but I chose this route. 

Also a matter of opinion is whether to handle this case and return the data or just skip it and exclude from the response as it seems to just be a bogus interface with no MAC, MTU, etc; however, I assume let the user handle that decision and just return the data as it is on the device which I think is inline with NAPALM principles.

Tests should also work to cover this case.