### PR TITLE
add outgoing_interface in get_route_to for isoxr

### DIFF
--- a/napalm/iosxr/iosxr.py
+++ b/napalm/iosxr/iosxr.py
@@ -1857,12 +1857,17 @@ class IOSXRDriver(NetworkDriver):
                 for route_entry in route.xpath("RoutePath/Entry"):
                     # get all possible entries
                     next_hop = napalm.base.helpers.find_txt(route_entry, "Address")
-                    outgoing_interface = napalm.base.helpers.find_txt(route_entry, "InterfaceName")
+                    outgoing_interface = napalm.base.helpers.find_txt(
+                        route_entry, "InterfaceName"
+                    )
                     single_route_details = {}
                     single_route_details.update(route_details)
                     single_route_details.update(
-                        {"current_active": first_route, "next_hop": next_hop,
-                         "outgoing_interface": outgoing_interface}
+                        {
+                            "current_active": first_route,
+                            "next_hop": next_hop,
+                            "outgoing_interface": outgoing_interface,
+                        }
                     )
                     routes[destination].append(single_route_details)
                     first_route = False

--- a/napalm/iosxr/iosxr.py
+++ b/napalm/iosxr/iosxr.py
@@ -1857,10 +1857,12 @@ class IOSXRDriver(NetworkDriver):
                 for route_entry in route.xpath("RoutePath/Entry"):
                     # get all possible entries
                     next_hop = napalm.base.helpers.find_txt(route_entry, "Address")
+                    outgoing_interface = napalm.base.helpers.find_txt(route_entry, "InterfaceName")
                     single_route_details = {}
                     single_route_details.update(route_details)
                     single_route_details.update(
-                        {"current_active": first_route, "next_hop": next_hop}
+                        {"current_active": first_route, "next_hop": next_hop,
+                         "outgoing_interface": outgoing_interface}
                     )
                     routes[destination].append(single_route_details)
                     first_route = False

--- a/test/iosxr/mocked_data/test_get_route_to/SR638170159/expected_result.json
+++ b/test/iosxr/mocked_data/test_get_route_to/SR638170159/expected_result.json
@@ -1,1 +1,1 @@
-{"1.0.4.0/24": [{"protocol": "bgp", "outgoing_interface": "", "age": 1804805, "current_active": true, "routing_table": "default", "last_active": false, "protocol_attributes": {}, "next_hop": "37.49.232.13", "selected_next_hop": false, "inactive_reason": "", "preference": 12}]}
+{"1.0.4.0/24": [{"protocol": "bgp", "outgoing_interface": "None", "age": 1804805, "current_active": true, "routing_table": "default", "last_active": false, "protocol_attributes": {}, "next_hop": "37.49.232.13", "selected_next_hop": false, "inactive_reason": "", "preference": 12}]}


### PR DESCRIPTION
This PR solves #1310. 

It is just a quick change in order to have the correct outgoing_interface when asking for a route to an IOSXR device.
It should work for all XR versions as long as the XML output does not change (which has not been the case since XR 4).

Hope this helps.
 