### PR TITLE
Fix #1387

### DIFF
--- a/napalm/ios/ios.py
+++ b/napalm/ios/ios.py
@@ -3442,7 +3442,8 @@ class IOSDriver(NetworkDriver):
 
             # remove interfaces in the VRF from the default VRF
             for item in interfaces:
-                del instances["default"]["interfaces"]["interface"][item]
+                if item in instances["default"]["interfaces"]["interface"]:
+                    del instances["default"]["interfaces"]["interface"][item]
 
             instances[vrf_name] = {
                 "name": vrf_name,


### PR DESCRIPTION
This fixes a KeyError when running `get_network_instances` on a C9500-40X
