### PR TITLE
Add source_interface argument to ping

### DIFF
--- a/napalm/base/base.py
+++ b/napalm/base/base.py
@@ -1273,6 +1273,7 @@ class NetworkDriver(object):
         size=c.PING_SIZE,
         count=c.PING_COUNT,
         vrf=c.PING_VRF,
+        source_interface=c.PING_SOURCE_INTERFACE,
     ):
         """
         Executes ping on the device and returns a dictionary with the result
@@ -1290,6 +1291,8 @@ class NetworkDriver(object):
         :type count: optional
         :param vrf: Use a specific VRF to execute the ping
         :type vrf: optional
+        :param source_interface: Use an IP from a source interface as source address of echo request
+        :type source_interface: optional
 
         Output dictionary has one of following keys:
 

--- a/napalm/base/constants.py
+++ b/napalm/base/constants.py
@@ -57,6 +57,7 @@ PING_TIMEOUT = 2
 PING_SIZE = 100
 PING_COUNT = 5
 PING_VRF = ""
+PING_SOURCE_INTERFACE = ""
 
 NETMIKO_MAP = {
     "ios": "cisco_ios",

--- a/napalm/eos/eos.py
+++ b/napalm/eos/eos.py
@@ -2006,6 +2006,7 @@ class EOSDriver(NetworkDriver):
         size=c.PING_SIZE,
         count=c.PING_COUNT,
         vrf=c.PING_VRF,
+        source_interface=c.PING_SOURCE_INTERFACE,
     ):
         """
         Execute ping on the device and returns a dictionary with the result.
@@ -2036,6 +2037,8 @@ class EOSDriver(NetworkDriver):
         command += " repeat {}".format(count)
         if source != "":
             command += " source {}".format(source)
+        if source_interface != "":
+            command += " interface {}".format(source_interface)
 
         commands.append(command)
         output = self.device.run_commands(commands, encoding="text")[-1]["output"]

--- a/napalm/ios/ios.py
+++ b/napalm/ios/ios.py
@@ -3178,6 +3178,7 @@ class IOSDriver(NetworkDriver):
         size=C.PING_SIZE,
         count=C.PING_COUNT,
         vrf=C.PING_VRF,
+        source_interface=C.PING_SOURCE_INTERFACE,
     ):
         """
         Execute ping on the device and returns a dictionary with the result.
@@ -3208,6 +3209,8 @@ class IOSDriver(NetworkDriver):
         command += " repeat {}".format(count)
         if source != "":
             command += " source {}".format(source)
+        elif source_interface != "":
+            command += " source {}".format(source_interface)
 
         output = self._send_command(command)
         if "%" in output:

--- a/napalm/junos/junos.py
+++ b/napalm/junos/junos.py
@@ -2061,6 +2061,7 @@ class JunOSDriver(NetworkDriver):
         size=C.PING_SIZE,
         count=C.PING_COUNT,
         vrf=C.PING_VRF,
+        source_interface=C.PING_SOURCE_INTERFACE,
     ):
 
         ping_dict = {}
@@ -2071,6 +2072,7 @@ class JunOSDriver(NetworkDriver):
         size_str = ""
         count_str = ""
         vrf_str = ""
+        source_interface_str = ""
 
         if source:
             source_str = " source {source}".format(source=source)
@@ -2084,17 +2086,22 @@ class JunOSDriver(NetworkDriver):
             count_str = " count {count}".format(count=count)
         if vrf:
             vrf_str = " routing-instance {vrf}".format(vrf=vrf)
+        if source_interface:
+            source_interface_str = " interface {source_interface}".format(
+                source_interface=source_interface
+            )
 
         ping_command = (
-            "ping {destination}{source}{ttl}{timeout}{size}{count}{vrf}".format(
-                destination=destination,
-                source=source_str,
-                ttl=maxttl_str,
-                timeout=timeout_str,
-                size=size_str,
-                count=count_str,
-                vrf=vrf_str,
-            )
+            "ping {destination}{source}{ttl}{timeout}{size}{count}{vrf}{source_interface}"
+        ).format(
+            destination=destination,
+            source=source_str,
+            ttl=maxttl_str,
+            timeout=timeout_str,
+            size=size_str,
+            count=count_str,
+            vrf=vrf_str,
+            source_interface=source_interface_str,
         )
 
         ping_rpc = E("command", ping_command)

--- a/napalm/nxos/nxos.py
+++ b/napalm/nxos/nxos.py
@@ -276,6 +276,7 @@ class NXOSDriverBase(NetworkDriver):
         size=c.PING_SIZE,
         count=c.PING_COUNT,
         vrf=c.PING_VRF,
+        source_interface=c.PING_SOURCE_INTERFACE,
     ):
         """
         Execute ping on the device and returns a dictionary with the result.
@@ -311,6 +312,8 @@ class NXOSDriverBase(NetworkDriver):
         command += " count {}".format(count)
         if source != "":
             command += " source {}".format(source)
+        elif source_interface != "":
+            command += " source {}".format(source_interface)
 
         if vrf != "":
             command += " vrf {}".format(vrf)


### PR DESCRIPTION
Some vendors allow the definition of a `source interface` instead of the `source address` for the ping command with different keyword. For instance, [Junos](https://www.juniper.net/documentation/us/en/software/junos/icmp/topics/ref/command/ping.html).
Others don't use different keyword, so both arguments (`source` and `source_interface`) will end up using the same one.
