### PR TITLE
change the function cli when result is xml object

### DIFF
--- a/napalm/junos/junos.py
+++ b/napalm/junos/junos.py
@@ -1115,7 +1115,11 @@ class JunOSDriver(NetworkDriver):
                 )
             )
             raw_txt = self.device.cli(safe_command, warning=False)
-            cli_output[str(command)] = str(_process_pipe(command, raw_txt))
+            if isinstance(raw_txt, etree._Element):
+                raw_txt = etree.tostring(raw_txt.get_parent()).decode()
+                cli_output[str(command)] = raw_txt
+            else:
+                cli_output[str(command)] = str(_process_pipe(command, raw_txt))
         return cli_output
 
     def get_bgp_config(self, group="", neighbor=""):


### PR DESCRIPTION
when the command is `show xxx | display xml`, the result shows the raw XML format.
before this change: result like below
```
{"command | display xml": "<Element xxx xxxx>"}
```
the result of this change below
```
{"command | display xml": "
<rpc-reply>
    <xxx>
     </xxx>
</rpc-reply>"
}
```