### PR TITLE
Cache interface list in get_facts for junos.

### DIFF
--- a/napalm/junos/junos.py
+++ b/napalm/junos/junos.py
@@ -132,6 +132,8 @@ class JunOSDriver(NetworkDriver):
             )
 
         self.platform = "junos"
+        # caching of interface list on device
+        self.interface_list = []
         self.profile = [self.platform]
 
     def open(self):
@@ -399,10 +401,13 @@ class JunOSDriver(NetworkDriver):
         output = self.device.facts
 
         uptime = self.device.uptime or -1
+        interface_list = self.interface_list
 
-        interfaces = junos_views.junos_iface_table(self.device)
-        interfaces.get()
-        interface_list = interfaces.keys()
+        if not interface_list:
+            interfaces = junos_views.junos_iface_table(self.device)
+            interfaces.get()
+            self.interface_list = interfaces.keys()
+            interface_list = self.interface_list
 
         return {
             "vendor": "Juniper",


### PR DESCRIPTION
In junos driver when get_facts() is called a `get-interface-information` rpc call is issued that can be a very expensive operation in some cases (eg BNG devices). Caching of interface_list in facts can greatly benefit performance. This fix can be applied to other places too, like `get_interfaces()`. Open to discussion.

Relevant issue: napalm-automation/napalm#1508