### PR TITLE
Force Netmiko to be less than Netmiko version 4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ jinja2
 netaddr
 pyYAML
 pyeapi>=0.8.2
-netmiko>=3.1.0
+netmiko>=3.3.0,<4.0.0
 junos-eznc>=2.2.1
 ciscoconfparse
 scp


### PR DESCRIPTION
I am going to be releasing Netmiko 4.X some time in the next month or two.

Netmiko 4.X is very likely going to break NAPALM, so what I want to do is the following:
1. Pin NAPALM to use Netmiko version 3.X.X.
2. Release a version of NAPALM with this Netmiko pinning.
3. Release Netmiko 4.X.X. [Probably November/December]
4. Fix NAPALM such that it is compatible with Netmiko 4.X.X

This will ensure that NAPALM doesn't break when I release Netmiko 4.X.

Additionally, this will give us a lot more time to fix NAPALM to properly work with Netmiko 4.X.