### PR TITLE
fix flaky test_unit.py::test__compare_getter_list

### DIFF
--- a/test/base/validate/test_unit.py
+++ b/test/base/validate/test_unit.py
@@ -1,5 +1,6 @@
 """Tests for the validate methods."""
 import pytest
+import copy
 
 from napalm.base import validate
 
@@ -403,7 +404,7 @@ class TestValidate:
     @pytest.mark.parametrize("src, dst, result", _compare_getter)
     def test__compare_getter_list(self, src, dst, result):
         """Test for _compare_getter_list."""
-        assert validate.compare(src, dst) == result
+        assert validate.compare(copy.deepcopy(src), copy.deepcopy(dst)) == copy.deepcopy(result)
 
     def test_numeric_comparison(self):
         assert validate._compare_numeric("<2", 1)


### PR DESCRIPTION
This PR aims to fix the flaky test `test_unit.py::test__compare_getter_list`. In previous versions, the test will run into failure when running for multiple times. And the reason is that the parameters `src, dst, result` got changed because of the `pop()` operations in `napalm/base/validate.py`. A deep copy can fix this issue. The test failure can be reproduced by 
`pip install pytest-flakefinder`
`pytest --flake-finder --flake-runs=2 test/base/validate/test_unit.py`
Notice that the PR is modifying the test to make it more robust without changing the source code.