### PR TITLE
if we are ignoring warnings on commit, also ignore them on discard

### DIFF
--- a/napalm/junos/junos.py
+++ b/napalm/junos/junos.py
@@ -383,7 +383,7 @@ class JunOSDriver(NetworkDriver):
 
     def discard_config(self):
         """Discard changes (rollback 0)."""
-        self.device.cu.rollback(rb_id=0)
+        self.device.cu.rollback(rb_id=0, ignore_warning=self.ignore_warning)
         if not self.lock_disable and not self.session_config_lock:
             self._unlock()
         if self.config_private:


### PR DESCRIPTION
Make a similar change to #1480 to allow more graceful recovery from expected configuration warnings (see [this comment](https://github.com/napalm-automation/napalm/pull/1480#issuecomment-905961019)).

The changes in [py-junos-eznc pull 1131](https://github.com/Juniper/py-junos-eznc/pull/1131) are included in junos_eznc-2.6.3 (I'm not sure which version first included the change).