### PR TITLE
Escape vlan_name before building regex string

### DIFF
--- a/napalm/ios/ios.py
+++ b/napalm/ios/ios.py
@@ -3598,7 +3598,7 @@ class IOSDriver(NetworkDriver):
         for vlan_id, vlan_name in find_vlan:
             output = self._send_command("show vlan id {}".format(vlan_id))
             interface_regex = r"{}\s+{}\s+\S+\s+([A-Z][a-z].*)$".format(
-                vlan_id, vlan_name
+                vlan_id, re.format(vlan_name)
             )
             interfaces = re.findall(interface_regex, output, re.MULTILINE)
             if len(interfaces) == 1:


### PR DESCRIPTION
Sanitise input before building the regex with it

Current code fails when vlan_name begins with a regex special character such as "*"