### PR TITLE
Add ttp_parse helper function to codebase

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -47,5 +47,8 @@ ignore_missing_imports = True
 [mypy-textfsm]
 ignore_missing_imports = True
 
+[mypy-ttp]
+ignore_missing_imports = True
+
 [mypy-pytest]
 ignore_missing_imports = True

--- a/napalm/base/helpers.py
+++ b/napalm/base/helpers.py
@@ -19,7 +19,7 @@ from netaddr import IPAddress
 from netaddr import mac_unix
 
 try:
-    from ttp import ttp, quick_parse as ttp_quick_parse
+    from ttp import quick_parse as ttp_quick_parse
 
     TTP_INSTALLED = True
 except ImportError:
@@ -281,7 +281,7 @@ def ttp_parse(
     template: str,
     raw_text: str,
     structure: str = "flat_list",
-) -> List[Dict]:
+) -> Union[None, List, Dict]:
     """
     Applies a TTP template over a raw text and return the parsing results.
 
@@ -301,6 +301,8 @@ def ttp_parse(
     if not TTP_INSTALLED:
         msg = "\nTTP is not installed. Please PIP install ttp:\n" "pip install ttp\n"
         raise napalm.base.exceptions.ModuleImportError(msg)
+
+    result = None
 
     for c in cls.__class__.mro():
         if c is object:
@@ -332,12 +334,13 @@ def ttp_parse(
 
         # parse data
         try:
-            return ttp_quick_parse(
+            result = ttp_quick_parse(
                 data=str(raw_text),
                 template=template,
                 result_kwargs={"structure": structure},
                 parse_kwargs={"one": True},
             )
+            break
         except Exception as e:
             msg = "TTP template:\n'{template}'\nError: {error}".format(
                 template=template, error=e
@@ -345,6 +348,8 @@ def ttp_parse(
             logging.exception(e)
             logging.error(msg)
             raise napalm.base.exceptions.TemplateRenderException(msg)
+
+    return result
 
 
 def find_txt(

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -14,3 +14,5 @@ types-requests==2.27.9
 types-six==1.16.10
 types-setuptools==57.4.9
 types-PyYAML==6.0.4
+ttp==0.8.4
+ttp_templates==0.1.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,5 @@ ciscoconfparse
 scp
 lxml>=4.3.0
 ncclient
+ttp
+ttp_templates

--- a/test/base/test_helpers.py
+++ b/test/base/test_helpers.py
@@ -37,6 +37,20 @@ try:
 except ImportError:
     HAS_NETADDR = False
 
+try:
+    from ttp import ttp  # noqa
+
+    HAS_TTP = True
+except ImportError:
+    HAS_TTP = False
+
+try:
+    from ttp_templates import get_template  # noqa
+
+    HAS_TTP_TEMPLATES = True
+except ImportError:
+    HAS_TTP_TEMPLATES = False
+
 # NAPALM base
 import napalm.base.helpers
 import napalm.base.constants as C
@@ -672,6 +686,74 @@ class TestBaseHelpers(unittest.TestCase):
         )
         ret = napalm.base.helpers.sanitize_config(config, C.CISCO_SANITIZE_FILTERS)
         self.assertEqual(ret, expected)
+
+    def test_ttp_parse(self):
+        """
+        Tests helper function ```ttp_parse```:
+
+            * check if raises TemplateRenderException when template does not exist
+            * check if raises TemplateRenderException for /utils/ttp_templates/bad_template.txt
+            * check if returns expected result as output for ./utils/ttp_templates/good_template.txt
+            * check if returns expected result as output for inline template
+            * check if returns expected result as output for template from ttp templates
+        """
+
+        self.assertTrue(
+            HAS_TTP, "Install TTP: python3 -m pip install ttp"
+        )  # before anything else, let's see if TTP is available
+        _TTP_TEST_STRING = """
+interface Gi1/1
+ description FOO
+!
+interface Gi1/2
+ description BAR
+!
+        """
+        _TTP_TEST_TEMPLATE = '<group>\ninterface {{ interface }}\n description {{ description | re(".+") }}\n! {{ _end_ }}\n</group>'
+        _EXPECTED_RESULT = [
+            {"description": "FOO", "interface": "Gi1/1"},
+            {"description": "BAR", "interface": "Gi1/2"},
+        ]
+        self.assertRaises(
+            napalm.base.exceptions.TemplateRenderException,
+            napalm.base.helpers.ttp_parse,
+            self.network_driver,
+            "__this_template_does_not_exist__",
+            _TTP_TEST_STRING,
+        )
+
+        self.assertRaises(
+            napalm.base.exceptions.TemplateRenderException,
+            napalm.base.helpers.ttp_parse,
+            self.network_driver,
+            "bad_template",
+            _TTP_TEST_STRING,
+        )
+
+        # use ./utils/ttp_templates/good_template.txt
+        result = napalm.base.helpers.ttp_parse(
+            self.network_driver, "good_template", _TTP_TEST_STRING
+        )
+        self.assertEqual(result, _EXPECTED_RESULT)
+
+        # use inline template
+        result = napalm.base.helpers.ttp_parse(
+            self.network_driver, _TTP_TEST_TEMPLATE, _TTP_TEST_STRING
+        )
+        self.assertEqual(result, _EXPECTED_RESULT)
+
+        self.assertTrue(
+            HAS_TTP_TEMPLATES,
+            "Install TTP Templates: python3 -m pip install ttp-templates",
+        )  # before anything else, let's see if TTP_Templates is available
+
+        # use template from ttp templates package
+        result = napalm.base.helpers.ttp_parse(
+            self.network_driver,
+            "ttp://platform/test_platform_show_run_pipe_sec_interface.txt",
+            _TTP_TEST_STRING,
+        )
+        self.assertEqual(result, _EXPECTED_RESULT)
 
 
 class FakeNetworkDriver(NetworkDriver):

--- a/test/base/test_helpers.py
+++ b/test/base/test_helpers.py
@@ -709,7 +709,7 @@ interface Gi1/2
  description BAR
 !
         """
-        _TTP_TEST_TEMPLATE = '<group>\ninterface {{ interface }}\n description {{ description | re(".+") }}\n! {{ _end_ }}\n</group>'
+        _TTP_TEST_TEMPLATE = '<group>\ninterface {{ interface }}\n description {{ description | re(".+") }}\n! {{ _end_ }}\n</group>'  # noqa:E501
         _EXPECTED_RESULT = [
             {"description": "FOO", "interface": "Gi1/1"},
             {"description": "BAR", "interface": "Gi1/2"},

--- a/test/base/utils/ttp_templates/bad_template.txt
+++ b/test/base/utils/ttp_templates/bad_template.txt
@@ -1,0 +1,5 @@
+<group
+interface {{ interface }}
+ description {{ description | re(".+") }}
+! {{ _end_ }}
+</group>

--- a/test/base/utils/ttp_templates/good_template.txt
+++ b/test/base/utils/ttp_templates/good_template.txt
@@ -1,0 +1,5 @@
+<group>
+interface {{ interface }}
+ description {{ description | re(".+") }}
+! {{ _end_ }}
+</group>


### PR DESCRIPTION
# What this PR does

This PR developed as part of NANOG84 Hackathon efforts.

This PR add new helper function `ttp_parse`.

# Motivation

Debugging and developing regular expressions can be tedious process, for some use cases it is possible to use TTP as a drop in to produce same results but with less efforts. Besides parsing, TTP also might bring other use cases like results data validation, formatting, testing or postprocessing.

# How this was tested

Updated `test/base/test_helpers.py` file with `test_ttp_parse` test that does 5 sub-tests:

* check if raises TemplateRenderException when template does not exist
* check if raises TemplateRenderException for /utils/ttp_templates/bad_template.txt
* check if returns expected result as output for ./utils/ttp_templates/good_template.txt
* check if returns expected result as output for inline template
* check if returns expected result as output for template from ttp templates

