### PR TITLE
Replace confparse w netutils

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -41,6 +41,8 @@ ignore_missing_imports = True
 [mypy-lxml.*]
 ignore_missing_imports = True
 
+[mypy-netutils.*]
+ignore_missing_imports = True
 
 [mypy-textfsm]
 ignore_missing_imports = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -41,8 +41,6 @@ ignore_missing_imports = True
 [mypy-lxml.*]
 ignore_missing_imports = True
 
-[mypy-ciscoconfparse]
-ignore_missing_imports = True
 
 [mypy-textfsm]
 ignore_missing_imports = True

--- a/napalm/base/helpers.py
+++ b/napalm/base/helpers.py
@@ -166,7 +166,7 @@ def netutils_parse_objects(
     cfg_section: str, config: Union[str, List[str]]
 ) -> List[str]:
     """
-    Use CiscoConfParse to find and return a section of Cisco IOS config.
+    Use Netutils to find and return a section of Cisco IOS config.
     Similar to "show run | section <cfg_section>"
 
     :param cfg_section: The section of the config to return eg. "router bgp"

--- a/napalm/base/helpers.py
+++ b/napalm/base/helpers.py
@@ -137,9 +137,17 @@ def netutils_parse_parents(
     :param child:  The child line required under the given parent
     :param config: The device running/startup config
     """
+    # Check if the config is a list, if it is a list, then join it to make a string.
+    logger.error(config)
+    if isinstance(config, list):
+        config = "\n".join(config)
+        config = config + "\n"
+        logger.error(config)
+
     # Config tree is the entire configuration in a tree format,
     # followed by getting the individual lines that has the formats:
-    # ConfigLine(config_line=' ip address 192.0.2.10 255.255.255.0', parents=('interface GigabitEthernet1',))
+    # ConfigLine(config_line=' ip address 192.0.2.10 255.255.255.0',
+    # parents=('interface GigabitEthernet1',))
     # ConfigLine(config_line='Current configuration : 1624 bytes', parents=())
     config_tree = IOSConfigParser(str(config))
     configuration_lines = config_tree.build_config_relationship()
@@ -172,9 +180,15 @@ def netutils_parse_objects(
     :param cfg_section: The section of the config to return eg. "router bgp"
     :param config: The running/startup config of the device to parse
     """
+    # Check if the config is a list, if it is a list, then join it to make a string.
+    if isinstance(config, list):
+        config = "\n".join(config)
+        config = config + "\n"
+
     # Config tree is the entire configuration in a tree format,
     # followed by getting the individual lines that has the formats:
-    # ConfigLine(config_line=' ip address 192.0.2.10 255.255.255.0', parents=('interface GigabitEthernet1',))
+    # ConfigLine(config_line=' ip address 192.0.2.10 255.255.255.0',
+    # parents=('interface GigabitEthernet1',))
     # ConfigLine(config_line='Current configuration : 1624 bytes', parents=())
     config_tree = IOSConfigParser(str(config))
     lines = config_tree.build_config_relationship()

--- a/napalm/base/helpers.py
+++ b/napalm/base/helpers.py
@@ -138,11 +138,9 @@ def netutils_parse_parents(
     :param config: The device running/startup config
     """
     # Check if the config is a list, if it is a list, then join it to make a string.
-    logger.error(config)
     if isinstance(config, list):
         config = "\n".join(config)
         config = config + "\n"
-        logger.error(config)
 
     # Config tree is the entire configuration in a tree format,
     # followed by getting the individual lines that has the formats:

--- a/napalm/ios/ios.py
+++ b/napalm/ios/ios.py
@@ -1323,7 +1323,7 @@ class IOSDriver(NetworkDriver):
         # Get BGP config using ciscoconfparse because some old devices dont support "| sec bgp"
         cfg = self.get_config(retrieve="running")
         cfg = cfg["running"].splitlines()
-        bgp_config_text = napalm.base.helpers.cisco_conf_parse_objects(
+        bgp_config_text = napalm.base.helpers.netutils_parse_objects(
             "router bgp", cfg
         )
         bgp_asn = napalm.base.helpers.regex_find_txt(
@@ -1363,7 +1363,7 @@ class IOSDriver(NetworkDriver):
             if "vrf" in str(afi_list):
                 continue
             else:
-                neighbor_config = napalm.base.helpers.cisco_conf_parse_objects(
+                neighbor_config = napalm.base.helpers.netutils_parse_objects(
                     bgp_neighbor, bgp_config_text
                 )
             # For group_name- use peer-group name, else VRF name, else "_" for no group
@@ -1454,7 +1454,7 @@ class IOSDriver(NetworkDriver):
                     "neighbors": bgp_group_neighbors.get("_", {}),
                 }
                 continue
-            neighbor_config = napalm.base.helpers.cisco_conf_parse_objects(
+            neighbor_config = napalm.base.helpers.netutils_parse_objects(
                 group_name, bgp_config_text
             )
             multipath = False
@@ -1462,7 +1462,7 @@ class IOSDriver(NetworkDriver):
                 r"\s+address-family.*", group_name, neighbor_config
             )
             for afi in afi_list:
-                afi_config = napalm.base.helpers.cisco_conf_parse_objects(
+                afi_config = napalm.base.helpers.netutils_parse_objects(
                     afi, bgp_config_text
                 )
                 multipath = bool(

--- a/napalm/ios/ios.py
+++ b/napalm/ios/ios.py
@@ -1351,7 +1351,7 @@ class IOSDriver(NetworkDriver):
             if neighbor:
                 if bgp_neighbor != neighbor:
                     continue
-            afi_list = napalm.base.helpers.cisco_conf_parse_parents(
+            afi_list = napalm.base.helpers.netutils_parse_parents(
                 r"\s+address-family.*", bgp_neighbor, bgp_config_text
             )
             try:
@@ -1458,7 +1458,7 @@ class IOSDriver(NetworkDriver):
                 group_name, bgp_config_text
             )
             multipath = False
-            afi_list = napalm.base.helpers.cisco_conf_parse_parents(
+            afi_list = napalm.base.helpers.netutils_parse_parents(
                 r"\s+address-family.*", group_name, neighbor_config
             )
             for afi in afi_list:

--- a/napalm/ios/ios.py
+++ b/napalm/ios/ios.py
@@ -1320,7 +1320,7 @@ class IOSDriver(NetworkDriver):
                 }
             return prefix_limit
 
-        # Get BGP config using ciscoconfparse because some old devices dont support "| sec bgp"
+        # Get BGP config using netutils because some old devices dont support "| sec bgp"
         cfg = self.get_config(retrieve="running")
         cfg = cfg["running"].splitlines()
         bgp_config_text = napalm.base.helpers.netutils_parse_objects(

--- a/napalm/ios/ios.py
+++ b/napalm/ios/ios.py
@@ -1323,9 +1323,7 @@ class IOSDriver(NetworkDriver):
         # Get BGP config using netutils because some old devices dont support "| sec bgp"
         cfg = self.get_config(retrieve="running")
         cfg = cfg["running"].splitlines()
-        bgp_config_text = napalm.base.helpers.netutils_parse_objects(
-            "router bgp", cfg
-        )
+        bgp_config_text = napalm.base.helpers.netutils_parse_objects("router bgp", cfg)
         bgp_asn = napalm.base.helpers.regex_find_txt(
             r"router bgp (\d+)", bgp_config_text, default=0
         )

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ pyYAML
 pyeapi>=0.8.2
 netmiko>=3.3.0,<4.0.0
 junos-eznc>=2.2.1
-ciscoconfparse
 scp
 lxml>=4.3.0
 ncclient
+netutils>=1.0.0


### PR DESCRIPTION
Fixes #1550 

This replaces parsing with [Netutils](https://netutils.readthedocs.io/en/latest/) to handle parsing of configuration lines. 

Testing thus far has been in a separate Python script that will get added as well to the PR. There were no previous tests written for the previous parser, so I found a basic BGP config for the first part to get the section bgp. The second and third configurations are tests with data from Cisco's documentation.

```
 python try_netutils_config_parse.py
>>> NAPALM CURRENT HELPER (SECTION PARSING)
['router bgp 65010', ' bgp log-neighbor-changes', ' network 192.168.1.0', ' neighbor 192.0.2.1 remote-as 65550']
['router bgp 65010', ' bgp log-neighbor-changes', ' network 192.168.1.0', ' neighbor 192.0.2.1 remote-as 65550']
<<<< NETUTILS HELPER

>>> NAPALM CURRENT HELPER (BGP PARSING)
[' bgp listen range 172.21.0.0/16 peer-group group172', ' neighbor group172 peer-group', ' neighbor group172 remote-as 45000', ' neighbor group172 activate']
[' bgp listen range 172.21.0.0/16 peer-group group172', ' neighbor group172 peer-group', ' neighbor group172 remote-as 45000', ' neighbor group172 activate']
<<<< NETUTILS HELPER

>>> NAPALM CURRENT HELPER (BGP Parsing)
[' address-family ipv4 multicast', ' address-family ipv4 vrf vpn1']
[' address-family ipv4 multicast', ' address-family ipv4 vrf vpn1']
<<<< NETUTILS HELPER
```

This shows the use cases that have been presented in `ios.py` around BGP parsing and section parsing. 