### PR TITLE
Fix #1549: Check peer admin status from the BGP options

### DIFF
--- a/napalm/junos/junos.py
+++ b/napalm/junos/junos.py
@@ -765,7 +765,7 @@ class JunOSDriver(NetworkDriver):
             "remote_as": 0,
             "remote_id": "",
             "is_up": False,
-            "is_enabled": False,
+            "is_enabled": True,
             "description": "",
             "uptime": 0,
             "address_family": {},
@@ -828,6 +828,11 @@ class JunOSDriver(NetworkDriver):
                     for key, value in neighbor_details.items()
                     if key in keys
                 }
+                bgp_opts = (
+                    neighbor_details.pop("bgp_options_extended", "").lower().split()
+                )
+                if "shutdown" in bgp_opts:
+                    peer["is_enabled"] = False
                 peer["local_as"] = napalm.base.helpers.as_number(peer["local_as"])
                 peer["remote_as"] = napalm.base.helpers.as_number(peer["remote_as"])
                 peer["address_family"] = self._parse_route_stats(

--- a/napalm/junos/utils/junos_views.yml
+++ b/napalm/junos/utils/junos_views.yml
@@ -80,7 +80,6 @@ junos_bgp_view:
     description: description
     peer_fwd_rti: peer-fwd-rti
     is_up: { peer-state: True=Established }
-    is_enabled: { peer-state: False=True }
     received_prefixes: { bgp-rib/received-prefix-count: int }
     accepted_prefixes: { bgp-rib/accepted-prefix-count: int }
     sent_prefixes: { bgp-rib/advertised-prefix-count: int }
@@ -90,6 +89,7 @@ junos_bgp_view:
     peer_as: { peer-as: int }
     local_id: local-id
     remote_id: { peer-id: unicode }
+    bgp_options_extended: { bgp-option-information/bgp-options-extended: str }
 
 ####
 #### LLDP table

--- a/test/junos/mocked_data/test_get_bgp_neighbors/normal/expected_result.json
+++ b/test/junos/mocked_data/test_get_bgp_neighbors/normal/expected_result.json
@@ -174,6 +174,27 @@
         "local_as": 20001,
         "is_enabled": true,
         "uptime": 696506
+      },
+      "192.169.1.2": {
+        "description": "",
+        "remote_id": "",
+        "address_family": {
+          "ipv6": {
+            "received_prefixes": -1,
+            "sent_prefixes": -1,
+            "accepted_prefixes": -1
+          },
+          "ipv4": {
+            "received_prefixes": -1,
+            "sent_prefixes": -1,
+            "accepted_prefixes": -1
+          }
+        },
+        "remote_as": 20000,
+        "is_up": false,
+        "local_as": 20001,
+        "is_enabled": false,
+        "uptime": 696506
       }
     }
   }

--- a/test/junos/mocked_data/test_get_bgp_neighbors/normal/get-bgp-neighbor-informationfrontend.xml
+++ b/test/junos/mocked_data/test_get_bgp_neighbors/normal/get-bgp-neighbor-informationfrontend.xml
@@ -251,6 +251,28 @@
     <flap-count>0</flap-count>
   </bgp-peer>
   <bgp-peer style="detail">
+    <peer-address>192.169.1.2</peer-address>
+    <peer-as>20000</peer-as>
+    <local-address>192.169.1.3</local-address>
+    <local-as>20001</local-as>
+    <peer-type>External</peer-type>
+    <peer-state>Idle</peer-state>
+    <peer-flags/>
+    <last-state>Idle</last-state>
+    <last-event>Start</last-event>
+    <last-error>None</last-error>
+    <bgp-option-information>
+      <export-policy>NORMAL-FRONTEND</export-policy>
+      <bgp-options>Preference LocalAddress AddressFamily PeerAS Multipath Refresh</bgp-options>
+      <bgp-options2>VpnApplyExport PeerSpecficLoopsAllowed</bgp-options2>
+      <bgp-options-extended>GracefulShutdownRcv Shutdown</bgp-options-extended>
+      <address-families>inet-unicast inet6-unicast</address-families>
+      <holdtime>90</holdtime>
+      <preference>170</preference>
+    </bgp-option-information>
+    <flap-count>0</flap-count>
+  </bgp-peer>
+  <bgp-peer style="detail">
     <peer-address>2a01:280:100::1</peer-address>
     <peer-as>20000</peer-as>
     <local-address>2a01:280:100::</local-address>

--- a/test/junos/mocked_data/test_get_bgp_neighbors/normal/get-bgp-summary-informationfrontend.xml
+++ b/test/junos/mocked_data/test_get_bgp_neighbors/normal/get-bgp-summary-informationfrontend.xml
@@ -134,6 +134,16 @@
     <peer-state>Active</peer-state>
   </bgp-peer>
   <bgp-peer style="terse">
+    <peer-address>192.169.1.2</peer-address>
+    <peer-as>20000</peer-as>
+    <input-messages>0</input-messages>
+    <output-messages>0</output-messages>
+    <route-queue-count>0</route-queue-count>
+    <flap-count>0</flap-count>
+    <elapsed-time seconds="696506">1w1d1h</elapsed-time>
+    <peer-state>Idle</peer-state>
+  </bgp-peer>
+  <bgp-peer style="terse">
     <peer-address>2a01:280:100::1</peer-address>
     <peer-as>20000</peer-as>
     <input-messages>81</input-messages>


### PR DESCRIPTION
To avoid an additional RPC request to check the actual configuration, we
can probably use the Shutdown flag under the BGP extended options:

```xml
<bgp-options>Preference LocalAddress AddressFamily PeerAS Multipath Refresh</bgp-options>
<bgp-options2>VpnApplyExport PeerSpecficLoopsAllowed</bgp-options2>
<bgp-options-extended>GracefulShutdownRcv Shutdown</bgp-options-extended>
```

This should be a more reliable way to check the admin status, instead of
incorrectly deducing the admin state from the operational state.