### PR TITLE
Fix #1554: Improve compare_config for NXOS partial merging

### DIFF
--- a/docs/support/nxos.rst
+++ b/docs/support/nxos.rst
@@ -66,30 +66,29 @@ As a result, merges are **not atomic**.
 Diffs
 _____
 
-Diffs for merges are simply the lines in the merge candidate config. 
-[Netutils](https://netutils.readthedocs.io/en/latest/) is used for creating the merge diff between the candidate and running configurations. 
+Diffs for merges are simply the lines in the merge candidate config. `Netutils <https://netutils.readthedocs.io/en/latest/>`__ is used for creating the merge diff between the candidate and running configurations.
 One caveat of using netutils diff of configurations is that the diff is performed offline and not online in the device.
 
 Example assuming that the device config contains:
 
-```
-interface loopback0
-  ip address 10.1.4.4/32
-  ip router ospf 100 area 0.0.0.1
-```
+.. code-block::
+
+    interface loopback0
+      ip address 10.1.4.4/32
+      ip router ospf 100 area 0.0.0.1
 
 Then what you will get with the diff:
 
-```python
-candidate_cfg = """
-interface loopback0
-  ip address 10.1.4.5/32
-  ip router ospf 100 area 0.0.0.1
-"""
+.. code-block:: python
 
-nxos1.load_merge_candidate(config=candidate_cfg)
+    candidate_cfg = """
+    interface loopback0
+      ip address 10.1.4.5/32
+      ip router ospf 100 area 0.0.0.1
+    """
 
-print(nxos1.compare_config())
-interface loopback0
-  ip address 10.1.4.5/32
-```
+    nxos1.load_merge_candidate(config=candidate_cfg)
+
+    print(nxos1.compare_config())
+    interface loopback0
+      ip address 10.1.4.5/32

--- a/docs/support/nxos.rst
+++ b/docs/support/nxos.rst
@@ -66,4 +66,30 @@ As a result, merges are **not atomic**.
 Diffs
 _____
 
-Diffs for merges are simply the lines in the merge candidate config.
+Diffs for merges are simply the lines in the merge candidate config. 
+[Netutils](https://netutils.readthedocs.io/en/latest/) is used for creating the merge diff between the candidate and running configurations. 
+One caveat of using netutils diff of configurations is that the diff is performed offline and not online in the device.
+
+Example assuming that the device config contains:
+
+```
+interface loopback0
+  ip address 10.1.4.4/32
+  ip router ospf 100 area 0.0.0.1
+```
+
+Then what you will get with the diff:
+
+```python
+candidate_cfg = """
+interface loopback0
+  ip address 10.1.4.5/32
+  ip router ospf 100 area 0.0.0.1
+"""
+
+nxos1.load_merge_candidate(config=candidate_cfg)
+
+print(nxos1.compare_config())
+interface loopback0
+  ip address 10.1.4.5/32
+```

--- a/napalm/nxos/nxos.py
+++ b/napalm/nxos/nxos.py
@@ -46,6 +46,7 @@ from netaddr import IPAddress
 from netaddr.core import AddrFormatError
 from netmiko import file_transfer
 from requests.exceptions import ConnectionError
+from netutils.config.compliance import diff_network_config
 
 import napalm.base.constants as c
 
@@ -209,22 +210,29 @@ class NXOSDriverBase(NetworkDriver):
 
     def _get_merge_diff(self) -> str:
         """
-        The merge diff is not necessarily what needs to be loaded
-        for example under NTP, even though the 'ntp commit' command might be
-        alread configured, it is mandatory to be sent
-        otherwise it won't take the new configuration - see:
-        https://github.com/napalm-automation/napalm-nxos/issues/59
-        therefore this method will return the real diff (but not necessarily what is
-        being sent by the merge_load_config()
+        Uses netutils diff_network_config to create a partial configuration with the proper hierarchy.
+        Note: the netutils utility performs the diff offline.
+
+        Returns: diff with the proper hierarchy of commands that are missing from the current config.
+        Examples:
+        Candidate configuration:
+        interface loopback0
+          ip address 10.1.4.5/32
+          ip router ospf 100 area 0.0.0.1
+
+        Base (on device) - relevant section:
+        ...
+        interface loopback0
+          ip address 10.1.4.4/32
+          ip router ospf 100 area 0.0.0.1
+        ...
+
+        Diff that respects the required command hierarchy:
+        interface loopback0
+          ip address 10.1.4.5/32
         """
-        diff = []
         running_config = self.get_config(retrieve="running")["running"]
-        running_lines = running_config.splitlines()
-        for line in self.merge_candidate.splitlines():
-            if line not in running_lines and line:
-                if line[0].strip() != "!":
-                    diff.append(line)
-        return "\n".join(diff)
+        return diff_network_config(self.merge_candidate, running_config, "cisco_nxos")
 
     def _get_diff(self) -> str:
         """Get a diff between running config and a proposed file."""

--- a/napalm/nxos/nxos.py
+++ b/napalm/nxos/nxos.py
@@ -210,10 +210,12 @@ class NXOSDriverBase(NetworkDriver):
 
     def _get_merge_diff(self) -> str:
         """
-        Uses netutils diff_network_config to create a partial configuration with the proper hierarchy.
+        Uses netutils diff_network_config to create a partial configuration
+        with the proper hierarchy.
         Note: the netutils utility performs the diff offline.
 
-        Returns: diff with the proper hierarchy of commands that are missing from the current config.
+        Returns: diff with the proper hierarchy of commands
+        that are missing from the current config.
         Examples:
         Candidate configuration:
         interface loopback0

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ ciscoconfparse
 scp
 lxml>=4.3.0
 ncclient
+netutils


### PR DESCRIPTION
NXOS partial merges were not aware of command hierarchy when showing the differences to be applied via the `compare_config` method. We (myself and @mundruid) have changed the merge diffing to use the [netutils](https://netutils.readthedocs.io/en/latest/) package. Docstrings and documentation updated as well.

Tests would be a stretch goal for another day since this code path is not tested at the moment.

See an example below of old and new behavior:

```
Intended configuration:

candidate_cfg = """
interface loopback0
  ip address 10.1.4.5/32
  ip router ospf 100 area 0.0.0.1
"""

Base - full configuration on device with the relevant section below:
...
interface loopback0
  ip address 10.1.4.4/32
  ip router ospf 100 area 0.0.0.1
...

nxos1.load_merge_candidate(config=candidate_cfg)

Before:

print(nxos1.compare_config())
  ip address 10.1.4.5/32


With netutils, respecting required command hierarchy:

print(nxos1.compare_config())
interface loopback0
  ip address 10.1.4.5/32
```

Fixes #1554 