### PR TITLE
Fix description on SVI in NXOS

### DIFF
--- a/napalm/nxos/nxos.py
+++ b/napalm/nxos/nxos.py
@@ -1012,13 +1012,17 @@ class NXOSDriver(NXOSDriverBase):
                 mac_address = interface_details["svi_mac"].strip()
             else:
                 mac_address = None
+
+            desc = interface_details.get(
+                "desc", interface_details.get("svi_desc", "")
+            ).strip('"')
             interfaces[interface_name] = {
                 "is_up": is_up,
                 "is_enabled": (
                     interface_details.get("state") == "up"
                     or interface_details.get("svi_admin_state") == "up"
                 ),
-                "description": str(interface_details.get("desc", "").strip('"')),
+                "description": desc,
                 "last_flapped": self._compute_timestamp(
                     interface_details.get("eth_link_flapped", "")
                 ),

--- a/test/nxos/mocked_data/test_get_interfaces/vlan_interface/expected_result.json
+++ b/test/nxos/mocked_data/test_get_interfaces/vlan_interface/expected_result.json
@@ -16,5 +16,14 @@
         "mac_address": "00:2A:6A:D3:00:00",
         "mtu": 1500,
         "speed": 1000
+    },
+    "Vlan199": {
+        "is_enabled": false,
+        "description": "This is a description",
+        "last_flapped": -1.0,
+        "is_up": false,
+        "mac_address": "00:2A:6A:D3:00:00",
+        "mtu": 1500,
+        "speed": 1000
     }
 }

--- a/test/nxos/mocked_data/test_get_interfaces/vlan_interface/show_interface.json
+++ b/test/nxos/mocked_data/test_get_interfaces/vlan_interface/show_interface.json
@@ -24,6 +24,19 @@
         "svi_mtu": "1500",
         "svi_bw": "1000000",
         "svi_delay": "10"
+      },
+      {
+        "interface": "Vlan199",
+        "svi_admin_state": "down",
+        "state_rsn_desc": "Administratively down",
+        "svi_line_proto": "down",
+        "svi_mac": "002a.6ad3.0000",
+        "svi_ip_addr": "192.168.0.11",
+        "svi_ip_mask": "24",
+        "svi_mtu": "1500",
+        "svi_bw": "1000000",
+        "svi_delay": "10",
+        "svi_desc": "This is a description"
       }
     ]
   }


### PR DESCRIPTION
Currently, all SVI in some NXOS devices report "" for description, because it comes from the property on `svi_desc`.

Signed-off-by: DavidVentura <davidventura27@gmail.com>