### PR TITLE
Use regex module if available

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -26,6 +26,10 @@ ignore_errors = True
 [mypy-napalm.base.test.*]
 ignore_errors = True
 
+[mypy-regex.*]
+ignore_errors = True
+ignore_missing_imports = True
+
 [mypy-netaddr.*]
 ignore_missing_imports = True
 

--- a/napalm/base/helpers.py
+++ b/napalm/base/helpers.py
@@ -4,7 +4,11 @@ import logging
 
 # std libs
 import os
-import re
+
+try:
+    import regex as re
+except ModuleNotFoundError:
+    import re  # type:ignore
 import sys
 from typing import Optional, Dict, Any, List, Union, Tuple, TypeVar, Callable
 from collections.abc import Iterable

--- a/napalm/base/mock.py
+++ b/napalm/base/mock.py
@@ -20,7 +20,11 @@ import napalm.base.exceptions
 import inspect
 import json
 import os
-import re
+
+try:
+    import regex as re
+except ModuleNotFoundError:
+    import re  # type:ignore
 
 
 from pydoc import locate

--- a/napalm/base/test/double.py
+++ b/napalm/base/test/double.py
@@ -1,6 +1,10 @@
 """Base class for Test doubles."""
 import json
-import re
+
+try:
+    import regex as re
+except ModuleNotFoundError:
+    import re
 import os
 import sys
 

--- a/napalm/base/utils/string_parsers.py
+++ b/napalm/base/utils/string_parsers.py
@@ -1,5 +1,8 @@
 """ Common methods to normalize a string """
-import re
+try:
+    import regex as re
+except ModuleNotFoundError:
+    import re  # type:ignore
 from typing import Union, List, Iterable, Dict, Optional
 
 

--- a/napalm/base/validate.py
+++ b/napalm/base/validate.py
@@ -5,7 +5,11 @@ See: https://napalm.readthedocs.io/en/latest/validate.html
 """
 import yaml
 import copy
-import re
+
+try:
+    import regex as re
+except ModuleNotFoundError:
+    import re  # type:ignore
 from typing import Dict, List, Union, TypeVar, Optional, TYPE_CHECKING
 
 if TYPE_CHECKING:

--- a/napalm/eos/eos.py
+++ b/napalm/eos/eos.py
@@ -19,7 +19,10 @@ Read napalm.readthedocs.org for more information.
 """
 
 # std libs
-import re
+try:
+    import regex as re
+except ModuleNotFoundError:
+    import re
 import time
 import inspect
 

--- a/napalm/eos/utils/versions.py
+++ b/napalm/eos/utils/versions.py
@@ -1,5 +1,8 @@
 """Some functions to work with EOS version numbers"""
-import re
+try:
+    import regex as re
+except ModuleNotFoundError:
+    import re
 
 
 class EOSVersion:

--- a/napalm/ios/ios.py
+++ b/napalm/ios/ios.py
@@ -15,7 +15,11 @@
 import copy
 import functools
 import os
-import re
+
+try:
+    import regex as re
+except ModuleNotFoundError:
+    import re
 import socket
 import telnetlib
 import tempfile

--- a/napalm/iosxr/iosxr.py
+++ b/napalm/iosxr/iosxr.py
@@ -14,7 +14,10 @@
 # the License.
 
 # import stdlib
-import re
+try:
+    import regex as re
+except ModuleNotFoundError:
+    import re  # type:ignore
 import copy
 from collections import defaultdict
 import logging

--- a/napalm/iosxr/utilities.py
+++ b/napalm/iosxr/utilities.py
@@ -1,4 +1,7 @@
-import re
+try:
+    import regex as re
+except ModuleNotFoundError:
+    import re  # type:ignore
 
 
 def strip_config_header(config):

--- a/napalm/iosxr_netconf/iosxr_netconf.py
+++ b/napalm/iosxr_netconf/iosxr_netconf.py
@@ -19,7 +19,10 @@
 from __future__ import unicode_literals
 
 # import stdlib
-import re
+try:
+    import regex as re
+except ModuleNotFoundError:
+    import re
 import copy
 import difflib
 import logging

--- a/napalm/junos/junos.py
+++ b/napalm/junos/junos.py
@@ -16,7 +16,10 @@
 """Driver for JunOS devices."""
 
 # import stdlib
-import re
+try:
+    import regex as re
+except ModuleNotFoundError:
+    import re  # type:ignore
 import json
 import logging
 import collections

--- a/napalm/junos/utils/junos_views.py
+++ b/napalm/junos/utils/junos_views.py
@@ -2,7 +2,11 @@
 Load tables/views
 """
 import yaml
-import re
+
+try:
+    import regex as re
+except ModuleNotFoundError:
+    import re  # type:ignore
 from jnpr.junos.factory import FactoryLoader
 from os.path import splitext
 

--- a/napalm/nxos/nxos.py
+++ b/napalm/nxos/nxos.py
@@ -15,7 +15,11 @@
 
 import json
 import os
-import re
+
+try:
+    import regex as re
+except ModuleNotFoundError:
+    import re  # type:ignore
 import tempfile
 import time
 import uuid

--- a/napalm/nxos_ssh/nxos_ssh.py
+++ b/napalm/nxos_ssh/nxos_ssh.py
@@ -15,7 +15,11 @@
 
 # import stdlib
 from builtins import super
-import re
+
+try:
+    import regex as re
+except ModuleNotFoundError:
+    import re  # type:ignore
 import socket
 
 # import third party lib

--- a/napalm/pyIOSXR/iosxr.py
+++ b/napalm/pyIOSXR/iosxr.py
@@ -24,7 +24,10 @@ Contributors fooelisa, mirceaulinic, et all
 """
 
 # stdlib
-import re
+try:
+    import regex as re
+except ModuleNotFoundError:
+    import re  # type:ignore
 import time
 import difflib
 import logging

--- a/test/ios/TestIOSDriver.py
+++ b/test/ios/TestIOSDriver.py
@@ -17,7 +17,11 @@
 import unittest
 from napalm.ios import ios
 from napalm.base.test.base import TestConfigNetworkDriver, TestGettersNetworkDriver
-import re
+
+try:
+    import regex as re
+except ModuleNotFoundError:
+    import re
 
 
 class TestConfigIOSDriver(unittest.TestCase, TestConfigNetworkDriver):


### PR DESCRIPTION
The [regex module](https://pypi.org/project/regex/) is a drop-in replacement for `re`, with better support for concurrency, as it drops the GIL while parsing

When running concurrently on hundreds of devices, this allows significantly better responsiveness for the process