### PR TITLE
Remove deprecated pytest-pythonpath

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,7 +5,6 @@ flake8-import-order==0.18.1
 pytest==6.2.5
 pytest-cov==3.0.0
 pytest-json==0.4.0
-pytest-pythonpath==0.7.4
 pylama==8.2.1
 mock==4.0.3
 tox==3.24.5


### PR DESCRIPTION
```
NOTE: This plugin is obsolete as of pytest 7.0.0. Thanks to this PR from
Brian Okken, you can now modify the PYTHONPATH using the pythonpath
configuration option. See documentation here:
https://docs.pytest.org/en/7.0.x/reference/reference.html#confval-pythonpath
```