### PR TITLE
Fix pyIOSXR netmiko exception import path

### DIFF
--- a/napalm/pyIOSXR/iosxr.py
+++ b/napalm/pyIOSXR/iosxr.py
@@ -34,9 +34,11 @@ from xml.sax.saxutils import escape as escape_xml
 
 # third party lib
 from lxml import etree as ET
-from netmiko import ConnectHandler
-from netmiko.ssh_exception import NetMikoTimeoutException
-from netmiko.ssh_exception import NetMikoAuthenticationException
+from netmiko import (
+    ConnectHandler,
+    NetMikoAuthenticationException,
+    NetMikoTimeoutException,
+)
 
 # local modules
 from napalm.pyIOSXR.exceptions import LockError


### PR DESCRIPTION
https://github.com/ktbyers/netmiko/commit/4782157c920bb7f17f61b6ea9897ff2aa3bd78d6#diff-d624fe8122a167b02cbacae5860d4ecafb637c8837c02d285c122844a94667bc changed the path of these exceptions.