### PR TITLE
Eos stateful

### DIFF
--- a/napalm/eos/eos.py
+++ b/napalm/eos/eos.py
@@ -451,16 +451,12 @@ class EOSDriver(NetworkDriver):
                     self.config_session,
                     time.strftime("%H:%M:%S", time.gmtime(revert_in)),
                 ),
-                # "commit timer {}".format(
-                #     time.strftime("%H:%M:%S", time.gmtime(revert_in))
-                # ),
             ]
             self._run_commands(commands, encoding="text")
         else:
             commands = [
                 "copy startup-config flash:rollback-0",
                 "configure session {} commit".format(self.config_session),
-                # "commit",
                 "write memory",
             ]
 

--- a/napalm/eos/eos.py
+++ b/napalm/eos/eos.py
@@ -206,6 +206,10 @@ class EOSDriver(NetworkDriver):
     def close(self):
         """Implementation of NAPALM method close."""
         self.discard_config()
+        if hasattr(self.device.connection, "close") and callable(
+            self.device.connection.close
+        ):
+            self.device.connection.close()
 
     def is_alive(self):
         if self.transport == "ssh":
@@ -220,6 +224,10 @@ class EOSDriver(NetworkDriver):
                 # If unable to send, we can tell for sure that the connection is unusable
                 return {"is_alive": False}
 
+        if hasattr(self.device.connection, "is_alive") and callable(
+            self.device.connection.is_alive
+        ):
+            return self.device.connection.is_alive()
         return {"is_alive": True}  # always true as eAPI is HTTP-based
 
     def _run_commands(self, commands, **kwargs):
@@ -394,6 +402,8 @@ class EOSDriver(NetworkDriver):
             return None
 
         try:
+            if not any(l == "end" for l in commands):
+                commands.append("end")  # exit config mode
             if self.eos_autoComplete is not None:
                 self._run_commands(
                     commands,

--- a/test/eos/conftest.py
+++ b/test/eos/conftest.py
@@ -42,6 +42,10 @@ class PatchedEOSDriver(eos.EOSDriver):
 class FakeEOSDevice(BaseTestDouble):
     """EOS device test double."""
 
+    def __init__(self):
+        super(FakeEOSDevice, self).__init__()
+        self.connection = object()
+
     def run_commands(self, command_list, encoding="json"):
         """Fake run_commands."""
         result = list()

--- a/test/eos/test_heredoc.py
+++ b/test/eos/test_heredoc.py
@@ -55,6 +55,7 @@ class TestConfigMangling(object):
             },
             "management ssh",
             "idle-timeout 15",
+            "end",
         ]
 
         self.device.device.run_commands.assert_called_with(
@@ -108,6 +109,7 @@ class TestConfigMangling(object):
                 "input": "This is a multi-line HEREDOC\ncomment for standard ACL test3",
             },
             "permit host 192.0.2.3",
+            "end",
         ]
 
         self.device.device.run_commands.assert_called_with(
@@ -147,6 +149,7 @@ class TestConfigMangling(object):
             },
             "management ssh",
             "idle-timeout 15",
+            "end",
         ]
 
         self.device.device.run_commands.assert_called_with(


### PR DESCRIPTION
In conjunction with #1643, if an arbitrary transport class is stateful, we should be trying to maintain state (exiting config mode after entering, closing when closing, etc).