### PR TITLE
add alternative lldp local interface key

### DIFF
--- a/napalm/ios/utils/textfsm_templates/show_lldp_neighbors_detail.tpl
+++ b/napalm/ios/utils/textfsm_templates/show_lldp_neighbors_detail.tpl
@@ -8,7 +8,7 @@ Value REMOTE_SYSTEM_CAPAB (.*)
 Value REMOTE_SYSTEM_ENABLE_CAPAB (.*)
 
 Start
-  ^Local Intf\s*?[:-]\s+${LOCAL_INTERFACE}
+  ^Local Int(?:er)?f(?:ace)?\s*?[:-]\s+${LOCAL_INTERFACE}
   ^Chassis id\s*?[:-]\s+${REMOTE_CHASSIS_ID}
   ^Port id\s*?[:-]\s+${REMOTE_PORT}
   ^Port Description\s*?[:-]\s+${REMOTE_PORT_DESCRIPTION}


### PR DESCRIPTION
On an NCS-5500 the key is `Local Interface` instead of `Local Intf` when issuing `show lldp neighbors detail`. Search for both options.