### PR TITLE
docs: Fix a few typos

### DIFF
--- a/docs/support/ios.rst
+++ b/docs/support/ios.rst
@@ -116,7 +116,7 @@ File Operation Prompts
 ______________________
 
 By default IOS will prompt for confirmation on file operations. These prompts need to be disabled before the NAPALM-ios driver performs any such operation on the device.
-This can be controlled using the `auto_file_prompt` optional arguement:
+This can be controlled using the `auto_file_prompt` optional argument:
 
 * `auto_file_prompt=True` (default): NAPALM will automatically add `file prompt quiet` to the device configuration before performing file operations,
   and un-configure it again afterwards. If the device already had the command in its configuration then it will be silently removed as a result, and

--- a/napalm/eos/eos.py
+++ b/napalm/eos/eos.py
@@ -656,7 +656,7 @@ class EOSDriver(NetworkDriver):
 
     def get_bgp_neighbors(self):
         def get_re_group(res, key, default=None):
-            """Small helper to retrive data from re match groups"""
+            """Small helper to retrieve data from re match groups"""
             try:
                 return res.group(key)
             except KeyError:

--- a/napalm/ios/ios.py
+++ b/napalm/ios/ios.py
@@ -3005,7 +3005,7 @@ class IOSDriver(NetworkDriver):
                     # next-hop is not known in this vrf, route leaked from
                     # other vrf or from vpnv4 table?
                     # get remote AS nr. from as-path if it is ebgp neighbor
-                    # localy sourced prefix is not in routing table as a bgp route (i hope...)
+                    # locally sourced prefix is not in routing table as a bgp route (i hope...)
                     if search_re_dict["bgpie"]["result"] == "external":
                         bgpras = (
                             search_re_dict["aspath"]["result"]

--- a/napalm/junos/junos.py
+++ b/napalm/junos/junos.py
@@ -176,10 +176,10 @@ class JunOSDriver(NetworkDriver):
 
     def _rpc(self, get, child=None, **kwargs):
         """
-        This allows you to construct an arbitrary RPC call to retreive common stuff. For example:
+        This allows you to construct an arbitrary RPC call to retrieve common stuff. For example:
         Configuration:  get: "<get-configuration/>"
         Interface information:  get: "<get-interface-information/>"
-        A particular interfacece information:
+        A particular interface information:
               get: "<get-interface-information/>"
               child: "<interface-name>ge-0/0/0</interface-name>"
         """
@@ -1169,7 +1169,7 @@ class JunOSDriver(NetworkDriver):
 
         def build_prefix_limit(**args):
             """
-            Transform the lements of a dictionary into nested dictionaries.
+            Transform the elements of a dictionary into nested dictionaries.
 
             Example:
                 {
@@ -1824,7 +1824,7 @@ class JunOSDriver(NetworkDriver):
         try:
             routes_table.get(**rt_kargs)
         except RpcTimeoutError:
-            # on devices with milions of routes
+            # on devices with millions of routes
             # in case the destination is too generic (e.g.: 10/8)
             # will take very very long to determine all routes and
             # moreover will return a huge list

--- a/napalm/pyIOSXR/iosxr.py
+++ b/napalm/pyIOSXR/iosxr.py
@@ -690,7 +690,7 @@ class IOSXR(object):
 
     def discard_config(self):
         """
-        Clear uncommited changes in the current session.
+        Clear uncommitted changes in the current session.
 
         Clear previously loaded configuration on the device without committing it.
         """

--- a/test/base/test_helpers.py
+++ b/test/base/test_helpers.py
@@ -81,7 +81,7 @@ class TestBaseHelpers(unittest.TestCase):
               custom path
             * check if can load correct template from custom path
             * check if template passed as string can be loaded
-            * check that the search path setup by MRO is correct when loading an incorrecet template
+            * check that the search path setup by MRO is correct when loading an incorrect template
         """
 
         self.assertTrue(HAS_JINJA)  # firstly check if jinja2 is installed

--- a/test/pyiosxr/test_iosxr.py
+++ b/test/pyiosxr/test_iosxr.py
@@ -257,7 +257,7 @@ class TestIOSXRDevice(unittest.TestCase):
 
     def test__getattr__no_show(self):
 
-        """Test special attribute __getattr__ agains a no-show command"""
+        """Test special attribute __getattr__ against a no-show command"""
 
         raised = False
 


### PR DESCRIPTION
There are small typos in:
- docs/support/ios.rst
- napalm/eos/eos.py
- napalm/ios/ios.py
- napalm/junos/junos.py
- napalm/pyIOSXR/iosxr.py
- test/base/test_helpers.py
- test/pyiosxr/test_iosxr.py

Fixes:
- Should read `uncommitted` rather than `uncommited`.
- Should read `retrieve` rather than `retrive`.
- Should read `retrieve` rather than `retreive`.
- Should read `millions` rather than `milions`.
- Should read `locally` rather than `localy`.
- Should read `interface` rather than `interfacece`.
- Should read `incorrect` rather than `incorrecet`.
- Should read `elements` rather than `lements`.
- Should read `argument` rather than `arguement`.
- Should read `against` rather than `agains`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md