### PR TITLE
refactor: replace netaddr with ipaddress

### DIFF
--- a/napalm/eos/eos.py
+++ b/napalm/eos/eos.py
@@ -23,15 +23,12 @@ import re
 import time
 import importlib
 import inspect
+import ipaddress
 import json
 import socket
 
 from datetime import datetime
 from collections import defaultdict
-from netaddr import IPAddress
-from netaddr import IPNetwork
-
-from netaddr.core import AddrFormatError
 
 # third party libs
 import pyeapi
@@ -1134,7 +1131,7 @@ class EOSDriver(NetworkDriver):
                 # will try to parse the neighbor name
                 # which sometimes is the IP Address of the neigbor
                 # or the name of the BGP group
-                IPAddress(group_or_neighbor)
+                ipaddress.ip_address(group_or_neighbor)
                 # if passes the test => it is an IP Address, thus a Neighbor!
                 peer_address = group_or_neighbor
                 if peer_address not in bgp_neighbors:
@@ -1162,7 +1159,7 @@ class EOSDriver(NetworkDriver):
                 bgp_neighbors[peer_address].update(
                     parse_options(options, default_value)
                 )
-            except AddrFormatError:
+            except ValueError:
                 # exception trying to parse group name
                 # group_or_neighbor represents the name of the group
                 group_name = group_or_neighbor
@@ -1425,7 +1422,7 @@ class EOSDriver(NetworkDriver):
             protocol = "connected"
 
         ipv = ""
-        if IPNetwork(destination).version == 6:
+        if ipaddress.ip_network(destination).version == 6:
             ipv = "v6"
 
         commands = []
@@ -1532,7 +1529,7 @@ class EOSDriver(NetworkDriver):
                                 .get("peerEntry", {})
                                 .get("peerAddr", "")
                             )
-                        except AddrFormatError:
+                        except ValueError:
                             remote_address = napalm.base.helpers.ip(
                                 bgp_route_details.get("peerEntry", {}).get(
                                     "peerAddr", ""
@@ -1911,7 +1908,7 @@ class EOSDriver(NetworkDriver):
             summary_commands.append("show ipv6 bgp summary vrf all")
         else:
             try:
-                peer_ver = IPAddress(neighbor_address).version
+                peer_ver = ipaddress.ip_address(neighbor_address).version
             except Exception as e:
                 raise e
 

--- a/napalm/ios/ios.py
+++ b/napalm/ios/ios.py
@@ -14,6 +14,7 @@
 # the License.
 import copy
 import functools
+import ipaddress
 import os
 import re
 import socket
@@ -22,8 +23,6 @@ import tempfile
 import uuid
 from collections import defaultdict
 
-from netaddr import IPNetwork
-from netaddr.core import AddrFormatError
 from netmiko import FileTransfer, InLineTransfer
 
 import napalm.base.constants as C
@@ -3074,8 +3073,8 @@ class IOSDriver(NetworkDriver):
         vrf = ""
         ip_version = None
         try:
-            ip_version = IPNetwork(destination).version
-        except AddrFormatError:
+            ip_version = ipaddress.ip_network(destination).version
+        except ValueError:
             return "Please specify a valid destination!"
         if ip_version == 4:  # process IPv4 routing table
             if vrf == "":
@@ -3083,8 +3082,8 @@ class IOSDriver(NetworkDriver):
             else:
                 vrfs = [vrf]  # VRFs where IPv4 is enabled
             vrfs.append("default")  # global VRF
-            ipnet_dest = IPNetwork(destination)
-            prefix = str(ipnet_dest.network)
+            ipnet_dest = ipaddress.ip_network(destination)
+            prefix = str(ipnet_dest.network_address)
             netmask = ""
             routes = {}
             if "/" in destination:

--- a/napalm/iosxr/iosxr.py
+++ b/napalm/iosxr/iosxr.py
@@ -16,14 +16,12 @@
 # import stdlib
 import re
 import copy
+import ipaddress
 from collections import defaultdict
 import logging
 
 # import third party lib
 from lxml import etree as ETREE
-
-from netaddr import IPAddress  # needed for traceroute, to check IP version
-from netaddr.core import AddrFormatError
 
 from napalm.pyIOSXR import IOSXR
 from napalm.pyIOSXR.exceptions import ConnectError
@@ -1733,8 +1731,8 @@ class IOSXRDriver(NetworkDriver):
 
         ipv = 4
         try:
-            ipv = IPAddress(network).version
-        except AddrFormatError:
+            ipv = ipaddress.ip_address(network).version
+        except ValueError:
             logger.error("Wrong destination IP Address format supplied to get_route_to")
             raise TypeError("Wrong destination IP Address!")
 
@@ -2187,8 +2185,8 @@ class IOSXRDriver(NetworkDriver):
 
         ipv = 4
         try:
-            ipv = IPAddress(destination).version
-        except AddrFormatError:
+            ipv = ipaddress.ip_address(destination).version
+        except ValueError:
             logger.error(
                 "Incorrect format of IP Address in traceroute \
              with value provided:%s"

--- a/napalm/iosxr_netconf/iosxr_netconf.py
+++ b/napalm/iosxr_netconf/iosxr_netconf.py
@@ -22,6 +22,7 @@ from __future__ import unicode_literals
 import re
 import copy
 import difflib
+import ipaddress
 import logging
 
 # import third party lib
@@ -31,8 +32,6 @@ from ncclient.operations.rpc import RPCError
 from ncclient.operations.errors import TimeoutExpiredError
 from lxml import etree as ETREE
 from lxml.etree import XMLSyntaxError
-from netaddr import IPAddress  # needed for traceroute, to check IP version
-from netaddr.core import AddrFormatError
 
 # import NAPALM base
 from napalm.iosxr_netconf import constants as C
@@ -2481,8 +2480,8 @@ class IOSXRNETCONFDriver(NetworkDriver):
 
         ipv = 4
         try:
-            ipv = IPAddress(network).version
-        except AddrFormatError:
+            ipv = ipaddress.ip_address(network).version
+        except ValueError:
             logger.error("Wrong destination IP Address format supplied to get_route_to")
             raise TypeError("Wrong destination IP Address!")
 
@@ -2952,8 +2951,8 @@ class IOSXRNETCONFDriver(NetworkDriver):
 
         ipv = 4
         try:
-            ipv = IPAddress(destination).version
-        except AddrFormatError:
+            ipv = ipaddress.ip_address(destination).version
+        except ValueError:
             logger.error(
                 "Incorrect format of IP Address in traceroute \
              with value provided:%s"

--- a/napalm/nxos/nxos.py
+++ b/napalm/nxos/nxos.py
@@ -13,6 +13,7 @@
 # License for the specific language governing permissions and limitations under
 # the License.
 
+import ipaddress
 import json
 import os
 import re
@@ -42,8 +43,6 @@ from typing_extensions import (
     DefaultDict,
 )
 
-from netaddr import IPAddress
-from netaddr.core import AddrFormatError
 from netmiko import file_transfer
 from requests.exceptions import ConnectionError
 from netutils.config.compliance import diff_network_config
@@ -356,8 +355,8 @@ class NXOSDriverBase(NetworkDriver):
 
         version = ""
         try:
-            version = "6" if IPAddress(destination).version == 6 else ""
-        except AddrFormatError:
+            version = "6" if ipaddress.ip_address(destination).version == 6 else ""
+        except ValueError:
             # Allow use of DNS names
             pass
 
@@ -470,8 +469,8 @@ class NXOSDriverBase(NetworkDriver):
 
         version = ""
         try:
-            version = "6" if IPAddress(destination).version == 6 else ""
-        except AddrFormatError:
+            version = "6" if ipaddress.ip_address(destination).version == 6 else ""
+        except ValueError:
             # Allow use of DNS names
             pass
 

--- a/napalm/nxos_ssh/nxos_ssh.py
+++ b/napalm/nxos_ssh/nxos_ssh.py
@@ -15,12 +15,9 @@
 
 # import stdlib
 from builtins import super
+import ipaddress
 import re
 import socket
-
-# import third party lib
-from netaddr import IPAddress, IPNetwork
-from netaddr.core import AddrFormatError
 
 # import NAPALM Base
 from napalm.base import helpers
@@ -953,7 +950,7 @@ class NXOSSSHDriver(NXOSDriverBase):
             # Skip first two lines and last line of command output
             if line == "" or "-----" in line or "Peer IP Address" in line:
                 continue
-            elif IPAddress(len(line.split()[0])).is_unicast:
+            elif not ipaddress.ip_address(len(line.split()[0])).is_multicast:
                 peer_addr = line.split()[0]
                 ntp_entities[peer_addr] = {}
             else:
@@ -1340,8 +1337,8 @@ class NXOSSSHDriver(NXOSDriverBase):
 
         ip_version = None
         try:
-            ip_version = IPNetwork(destination).version
-        except AddrFormatError:
+            ip_version = ipaddress.ip_network(destination).version
+        except ValueError:
             return "Please specify a valid destination!"
         if ip_version == 4:  # process IPv4 routing table
             routes = {}

--- a/test/base/test_helpers.py
+++ b/test/base/test_helpers.py
@@ -375,10 +375,8 @@ class TestBaseHelpers(unittest.TestCase):
             * check if IPv6 address returned as expected
         """
 
-        self.assertTrue(HAS_NETADDR)
-
-        # test that raises AddrFormatError when wrong format
-        self.assertRaises(AddrFormatError, napalm.base.helpers.ip, "fake")
+        # test that raises ValueError when wrong format
+        self.assertRaises(ValueError, napalm.base.helpers.ip, "fake")
         self.assertRaises(
             ValueError,
             napalm.base.helpers.ip,

--- a/test/eos/mocked_data/test_get_bgp_neighbors/issue1759/expected_result.json
+++ b/test/eos/mocked_data/test_get_bgp_neighbors/issue1759/expected_result.json
@@ -1,0 +1,112 @@
+{
+  "global": {
+    "peers": {
+      "fe80::a8c1:abff:fe0b:7b5f%Et5": {
+        "is_up": true,
+        "is_enabled": true,
+        "uptime": "...",
+        "description": "",
+        "remote_as": 4259840008,
+        "remote_id": "172.18.0.8",
+        "local_as": 4259906562,
+        "address_family": {
+          "ipv4": {
+            "sent_prefixes": 9,
+            "received_prefixes": 2,
+            "accepted_prefixes": -1
+          },
+          "ipv6": {
+            "sent_prefixes": 9,
+            "received_prefixes": 2,
+            "accepted_prefixes": -1
+          }
+        }
+      },
+      "fe80::a8c1:abff:fe27:69e9%Et2": {
+        "is_up": true,
+        "is_enabled": true,
+        "uptime": "...",
+        "description": "",
+        "remote_as": 4259973121,
+        "remote_id": "172.18.8.1",
+        "local_as": 4259906562,
+        "address_family": {
+          "ipv4": {
+            "sent_prefixes": 9,
+            "received_prefixes": 5,
+            "accepted_prefixes": -1
+          },
+          "ipv6": {
+            "sent_prefixes": 9,
+            "received_prefixes": 5,
+            "accepted_prefixes": -1
+          }
+        }
+      },
+      "fe80::a8c1:abff:fe35:51d9%Et1": {
+        "is_up": true,
+        "is_enabled": true,
+        "uptime": "...",
+        "description": "",
+        "remote_as": 4259973120,
+        "remote_id": "172.18.8.0",
+        "local_as": 4259906562,
+        "address_family": {
+          "ipv4": {
+            "sent_prefixes": 6,
+            "received_prefixes": 5,
+            "accepted_prefixes": -1
+          },
+          "ipv6": {
+            "sent_prefixes": 6,
+            "received_prefixes": 5,
+            "accepted_prefixes": -1
+          }
+        }
+      },
+      "fe80::a8c1:abff:fe5d:9706%Et4": {
+        "is_up": true,
+        "is_enabled": true,
+        "uptime": "...",
+        "description": "",
+        "remote_as": 4259840007,
+        "remote_id": "172.18.0.7",
+        "local_as": 4259906562,
+        "address_family": {
+          "ipv4": {
+            "sent_prefixes": 9,
+            "received_prefixes": 2,
+            "accepted_prefixes": -1
+          },
+          "ipv6": {
+            "sent_prefixes": 9,
+            "received_prefixes": 2,
+            "accepted_prefixes": -1
+          }
+        }
+      },
+      "fe80::a8c1:abff:fe95:fa49%Et3": {
+        "is_up": true,
+        "is_enabled": true,
+        "uptime": "...",
+        "description": "",
+        "remote_as": 4259840005,
+        "remote_id": "172.18.0.5",
+        "local_as": 4259906562,
+        "address_family": {
+          "ipv4": {
+            "sent_prefixes": 9,
+            "received_prefixes": 2,
+            "accepted_prefixes": -1
+          },
+          "ipv6": {
+            "sent_prefixes": 9,
+            "received_prefixes": 2,
+            "accepted_prefixes": -1
+          }
+        }
+      }
+    },
+    "router_id": "172.18.4.2"
+  }
+}

--- a/test/eos/mocked_data/test_get_bgp_neighbors/issue1759/show_ip_bgp_summary_vrf_all.json
+++ b/test/eos/mocked_data/test_get_bgp_neighbors/issue1759/show_ip_bgp_summary_vrf_all.json
@@ -1,0 +1,76 @@
+{
+    "vrfs": {
+        "default": {
+            "routerId": "172.18.4.2",
+            "peers": {
+                "fe80::a8c1:abff:fe0b:7b5f%Et5": {
+                    "msgSent": 239229,
+                    "inMsgQueue": 0,
+                    "prefixReceived": 2,
+                    "upDownTime": 1664912777.128896,
+                    "version": 4,
+                    "prefixAccepted": 2,
+                    "msgReceived": 203694,
+                    "peerState": "Established",
+                    "outMsgQueue": 0,
+                    "underMaintenance": false,
+                    "asn": "65000.8"
+                },
+                "fe80::a8c1:abff:fe27:69e9%Et2": {
+                    "msgSent": 11997,
+                    "inMsgQueue": 0,
+                    "prefixReceived": 5,
+                    "upDownTime": 1664912780.356704,
+                    "version": 4,
+                    "prefixAccepted": 5,
+                    "msgReceived": 11972,
+                    "peerState": "Established",
+                    "outMsgQueue": 0,
+                    "underMaintenance": false,
+                    "asn": "65002.2049"
+                },
+                "fe80::a8c1:abff:fe35:51d9%Et1": {
+                    "msgSent": 11984,
+                    "inMsgQueue": 0,
+                    "prefixReceived": 5,
+                    "upDownTime": 1664912783.670673,
+                    "version": 4,
+                    "prefixAccepted": 5,
+                    "msgReceived": 11979,
+                    "peerState": "Established",
+                    "outMsgQueue": 0,
+                    "underMaintenance": false,
+                    "asn": "65002.2048"
+                },
+                "fe80::a8c1:abff:fe5d:9706%Et4": {
+                    "msgSent": 239170,
+                    "inMsgQueue": 0,
+                    "prefixReceived": 2,
+                    "upDownTime": 1664912777.50903,
+                    "version": 4,
+                    "prefixAccepted": 2,
+                    "msgReceived": 203718,
+                    "peerState": "Established",
+                    "outMsgQueue": 0,
+                    "underMaintenance": false,
+                    "asn": "65000.7"
+                },
+                "fe80::a8c1:abff:fe95:fa49%Et3": {
+                    "msgSent": 239116,
+                    "inMsgQueue": 0,
+                    "prefixReceived": 2,
+                    "upDownTime": 1664912777.604791,
+                    "version": 4,
+                    "prefixAccepted": 2,
+                    "msgReceived": 203718,
+                    "peerState": "Established",
+                    "outMsgQueue": 0,
+                    "underMaintenance": false,
+                    "asn": "65000.5"
+                }
+            },
+            "vrf": "default",
+            "asn": "65001.1026"
+        }
+    }
+}

--- a/test/eos/mocked_data/test_get_bgp_neighbors/issue1759/show_ipv6_bgp_neighbors_vrf_all___include_IPv_46___Unicast_6PE_____0_9_____grep__v___IPv_46__Unicast_______remote_AS___Local_AS_Desc_BGP_state__remote.text
+++ b/test/eos/mocked_data/test_get_bgp_neighbors/issue1759/show_ipv6_bgp_neighbors_vrf_all___include_IPv_46___Unicast_6PE_____0_9_____grep__v___IPv_46__Unicast_______remote_AS___Local_AS_Desc_BGP_state__remote.text
@@ -1,0 +1,30 @@
+BGP neighbor is fe80::a8c1:abff:fe0b:7b5f%Et5, remote AS 65000.8, external link
+  BGP version 4, remote router ID 172.18.0.8, VRF default
+  BGP state is Established, up for 7d01h
+    IPv4 Unicast:                     9         2              1                   0
+    IPv6 Unicast:                     9         2              1                   0
+Local AS is 65001.1026, local router ID 172.18.4.2
+BGP neighbor is fe80::a8c1:abff:fe27:69e9%Et2, remote AS 65002.2049, external link
+  BGP version 4, remote router ID 172.18.8.1, VRF default
+  BGP state is Established, up for 7d01h
+    IPv4 Unicast:                     9         5              1                   0
+    IPv6 Unicast:                     9         5              1                   0
+Local AS is 65001.1026, local router ID 172.18.4.2
+BGP neighbor is fe80::a8c1:abff:fe35:51d9%Et1, remote AS 65002.2048, external link
+  BGP version 4, remote router ID 172.18.8.0, VRF default
+  BGP state is Established, up for 7d01h
+    IPv4 Unicast:                     6         5              4                   0
+    IPv6 Unicast:                     6         5              4                   0
+Local AS is 65001.1026, local router ID 172.18.4.2
+BGP neighbor is fe80::a8c1:abff:fe5d:9706%Et4, remote AS 65000.7, external link
+  BGP version 4, remote router ID 172.18.0.7, VRF default
+  BGP state is Established, up for 7d01h
+    IPv4 Unicast:                     9         2              1                   0
+    IPv6 Unicast:                     9         2              1                   0
+Local AS is 65001.1026, local router ID 172.18.4.2
+BGP neighbor is fe80::a8c1:abff:fe95:fa49%Et3, remote AS 65000.5, external link
+  BGP version 4, remote router ID 172.18.0.5, VRF default
+  BGP state is Established, up for 7d01h
+    IPv4 Unicast:                     9         2              1                   0
+    IPv6 Unicast:                     9         2              1                   0
+Local AS is 65001.1026, local router ID 172.18.4.2

--- a/test/eos/mocked_data/test_get_bgp_neighbors/issue1759/show_ipv6_bgp_summary_vrf_all.json
+++ b/test/eos/mocked_data/test_get_bgp_neighbors/issue1759/show_ipv6_bgp_summary_vrf_all.json
@@ -1,0 +1,76 @@
+{
+    "vrfs": {
+        "default": {
+            "routerId": "172.18.4.2",
+            "peers": {
+                "fe80::a8c1:abff:fe0b:7b5f%Et5": {
+                    "msgSent": 239193,
+                    "inMsgQueue": 0,
+                    "prefixReceived": 2,
+                    "upDownTime": 1664912777.128896,
+                    "version": 4,
+                    "prefixAccepted": 2,
+                    "msgReceived": 203664,
+                    "peerState": "Established",
+                    "outMsgQueue": 0,
+                    "underMaintenance": false,
+                    "asn": "65000.8"
+                },
+                "fe80::a8c1:abff:fe27:69e9%Et2": {
+                    "msgSent": 11995,
+                    "inMsgQueue": 0,
+                    "prefixReceived": 5,
+                    "upDownTime": 1664912780.356703,
+                    "version": 4,
+                    "prefixAccepted": 5,
+                    "msgReceived": 11970,
+                    "peerState": "Established",
+                    "outMsgQueue": 0,
+                    "underMaintenance": false,
+                    "asn": "65002.2049"
+                },
+                "fe80::a8c1:abff:fe35:51d9%Et1": {
+                    "msgSent": 11982,
+                    "inMsgQueue": 0,
+                    "prefixReceived": 5,
+                    "upDownTime": 1664912783.670674,
+                    "version": 4,
+                    "prefixAccepted": 5,
+                    "msgReceived": 11977,
+                    "peerState": "Established",
+                    "outMsgQueue": 0,
+                    "underMaintenance": false,
+                    "asn": "65002.2048"
+                },
+                "fe80::a8c1:abff:fe5d:9706%Et4": {
+                    "msgSent": 239135,
+                    "inMsgQueue": 0,
+                    "prefixReceived": 2,
+                    "upDownTime": 1664912777.50903,
+                    "version": 4,
+                    "prefixAccepted": 2,
+                    "msgReceived": 203688,
+                    "peerState": "Established",
+                    "outMsgQueue": 0,
+                    "underMaintenance": false,
+                    "asn": "65000.7"
+                },
+                "fe80::a8c1:abff:fe95:fa49%Et3": {
+                    "msgSent": 239080,
+                    "inMsgQueue": 0,
+                    "prefixReceived": 2,
+                    "upDownTime": 1664912777.604791,
+                    "version": 4,
+                    "prefixAccepted": 2,
+                    "msgReceived": 203688,
+                    "peerState": "Established",
+                    "outMsgQueue": 0,
+                    "underMaintenance": false,
+                    "asn": "65000.5"
+                }
+            },
+            "vrf": "default",
+            "asn": "65001.1026"
+        }
+    }
+}


### PR DESCRIPTION
Use built-in `ipaddress` library instead of external `netaddr` library.  

Primary driver is additional features -- `ipaddress` supports IPv6 address scope, while `netaddr` does not.

Resolves #1759 