### PR TITLE
[Fix] Readthedoc build config

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -14,9 +14,10 @@ formats: all
 
 # Optionally set the version of Python and requirements required to build your docs
 python:
-  version: 3.7
+  version: 3.8
   install:
     - method: pip
       path: .
     - requirements: docs/requirements.txt
+    - requirements: requirements-dev.txt
     - requirements: requirements.txt


### PR DESCRIPTION
Linked to #1697 

* Use python 3.8 to match CI documentation build version
* Install dev dependencies to fix build issue (missing packages pytest-cov and pytest-json)

This will fix the issue for https://readthedocs.org/projects/napalm/builds/18366967/
```bash
Running Sphinx v1.8.6
ERROR: usage: py.test [options] [file_or_dir] [file_or_dir] [...]
py.test: error: unrecognized arguments: --cov=./ --json=report.json
  inifile: /dev/null
  rootdir: /home/docs/checkouts/readthedocs.org/user_builds/napalm/checkouts/develop
```