### PR TITLE
Revert "Pin to textfsm<=1.1.2"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ cffi>=1.11.3
 paramiko>=2.6.0
 requests>=2.7.0
 future
-textfsm<=1.1.2
+textfsm
 jinja2
 netaddr
 pyYAML


### PR DESCRIPTION
Reverts napalm-automation/napalm#1687 as https://github.com/google/textfsm/issues/105 seems to be fixed.