### PR TITLE
Fix issue in lldp neighbors discovery for IOS devices.

### DIFF
--- a/napalm/ios/ios.py
+++ b/napalm/ios/ios.py
@@ -44,6 +44,7 @@ from napalm.base.helpers import (
     generate_regex_or,
     sanitize_configs,
 )
+from netaddr.core import AddrFormatError
 from napalm.base.netmiko_helpers import netmiko_args
 
 # Easier to store these as constants
@@ -985,9 +986,20 @@ class IOSDriver(NetworkDriver):
                 port = lldp_entry["remote_port"]
                 # Match IOS behaviour of taking remote chassis ID
                 # When lacking a system name (in show lldp neighbors)
+                # This implementation is compliant with the spec, as we can't assume remote_chassis_id or remote_port
+                # are mac address. See IEEE 802.1AB-2005 and rfc2922, specifically PtopoChassisId
                 if not hostname:
-                    hostname = napalm.base.helpers.mac(lldp_entry["remote_chassis_id"])
-                    port = napalm.base.helpers.mac(port)
+                    try:
+                        hostname = napalm.base.helpers.mac(
+                            lldp_entry["remote_chassis_id"]
+                        )
+                    except AddrFormatError:
+                        hostname = lldp_entry["remote_chassis_id"]
+
+                    try:
+                        port = napalm.base.helpers.mac(port)
+                    except AddrFormatError:
+                        pass
                 lldp_dict = {"port": port, "hostname": hostname}
                 lldp[intf_name].append(lldp_dict)
 

--- a/test/ios/mocked_data/test_get_lldp_neighbors/no_mac_support/expected_result.json
+++ b/test/ios/mocked_data/test_get_lldp_neighbors/no_mac_support/expected_result.json
@@ -1,0 +1,15 @@
+{
+  "GigabitEthernet9/48": [
+      {
+        "port": "Gi0",
+        "hostname": "COMPUTER.company.example.com"
+      }
+    ]
+  ,
+  "GigabitEthernet9/8": [
+      {
+        "port": "A1:8B:95:B5:E4:6F",
+        "hostname": "NICEHOSTNAME"
+      }
+    ]
+}

--- a/test/ios/mocked_data/test_get_lldp_neighbors/no_mac_support/show_lldp_neighbors.txt
+++ b/test/ios/mocked_data/test_get_lldp_neighbors/no_mac_support/show_lldp_neighbors.txt
@@ -1,0 +1,8 @@
+
+Capability codes:
+    (R) Router, (B) Bridge, (T) Telephone, (C) DOCSIS Cable Device
+    (W) WLAN Access Point, (P) Repeater, (S) Station, (O) Other
+
+Device ID           Local Intf     Hold-time  Capability      Port ID
+ACOMPUTER.company.exGi9/48         120        B               Gi0
+NICEHOSTNAME        Gi9/8          3601                       a18b.95b5.e46f

--- a/test/ios/mocked_data/test_get_lldp_neighbors/no_mac_support/show_lldp_neighbors_detail.txt
+++ b/test/ios/mocked_data/test_get_lldp_neighbors/no_mac_support/show_lldp_neighbors_detail.txt
@@ -1,0 +1,68 @@
+------------------------------------------------
+Local Intf: Gi9/48
+Chassis id: 4a07.d0f3.fbb6
+Port id: Gi0
+Port Description: GigabitEthernet0
+System Name: COMPUTER.company.example.com
+
+System Description: 
+Cisco IOS Software, C3600 Software (AP3G2-K9W8-M), Version 15.3(3)JC15, RELEASE SOFTWARE (fc1)
+Technical Support: http://www.cisco.com/techsupport
+Copyright (c) 1986-2018 by Cisco Systems, Inc.
+Compiled Thu 07-Jun-18 16:43 by prod_rel_team
+
+Time remaining: 95 seconds
+System Capabilities: B
+Enabled Capabilities: B
+Management Addresses:
+    IP: 10.31.18.65
+Auto Negotiation - supported, enabled
+Physical media capabilities:
+    1000baseT(FD)
+    1000baseT(HD)
+    100base-TX(FD)
+    100base-TX(HD)
+    10base-T(FD)
+    10base-T(HD)
+Media Attachment Unit type: 30
+Vlan ID: - not advertised
+PoE+ Power-via-MDI TLV:
+ Power Pair: Signal
+ Power Class: Class 4
+ Power Device Type: Type 1 PD
+ Power Source: PSE
+ Power Priority: high
+ Power Requested: 13000 mW
+ Power Allocated: 13000 mW
+
+------------------------------------------------
+Local Intf: Gi9/8
+Chassis id: NICEHOSTNAME
+Port id: a18b.95b5.e46f
+Port Description - not advertised
+System Name - not advertised
+System Description - not advertised
+
+Time remaining: 2690 seconds
+System Capabilities - not advertised
+Enabled Capabilities - not advertised
+Management Addresses - not advertised
+Auto Negotiation - supported, enabled
+Physical media capabilities:
+    1000baseT(FD)
+Media Attachment Unit type - not advertised
+Vlan ID: - not advertised
+
+MED Information:
+
+    MED Codes:
+          (NP) Network Policy, (LI) Location Identification
+          (PS) Power Source Entity, (PD) Power Device
+          (IN) Inventory
+
+    Inventory information - not advertised
+    Capabilities: 
+    Device type: Endpoint Class I
+    Network Policies - not advertised
+    Power requirements - not advertised
+    Location - not advertised


### PR DESCRIPTION
Hello everyone,

The parsing logic incorrectly assumes that `remote_chassis_id` and `remote_port` will always contain MAC addresses. According to the spec this is not always the case.

This pr adds the ability to handle uncommon cases, and a testcase to show the issue.
The data in the testcase was taken from a production device and anonymized (mac addresses and hostnames changed).

Thanks again for making Napalm, it's a godsend.

Cheers,
Carlo
