### PR TITLE
Update get_bgp_config to clarify return values

### DIFF
--- a/napalm/base/base.py
+++ b/napalm/base/base.py
@@ -647,7 +647,8 @@ class NetworkDriver(object):
         :param neighbor: Returns the configuration of a specific BGP neighbor.
 
         Main dictionary keys represent the group name and the values represent a dictionary having
-        the keys below. Neighbors which aren't members of a group will be stored in a key named "_":
+        the keys below.  A default group named "_" will contain information regarding global
+        settings and any neighbors that are not members of a group.
 
             * type (string)
             * description (string)

--- a/napalm/eos/eos.py
+++ b/napalm/eos/eos.py
@@ -1187,6 +1187,8 @@ class EOSDriver(NetworkDriver):
                     bgp_config[group_name] = default_group_dict(local_as)
                 bgp_config[group_name].update(parse_options(options, default_value))
 
+        bgp_config["_"] = default_group_dict(local_as)
+
         for peer, peer_details in bgp_neighbors.items():
             peer_group = peer_details.pop("__group", None)
             if not peer_group:

--- a/napalm/ios/ios.py
+++ b/napalm/ios/ios.py
@@ -1531,7 +1531,9 @@ class IOSDriver(NetworkDriver):
                 r" update-source (\w+)", neighbor_config
             )
             local_as = napalm.base.helpers.regex_find_txt(
-                r"local-as (\d+)", neighbor_config, default=0
+                r"local-as (\d+)",
+                neighbor_config,
+                default=bgp_asn,
             )
             password = napalm.base.helpers.regex_find_txt(
                 r"password (?:[0-9] )?([^\']+\')", neighbor_config
@@ -1608,7 +1610,7 @@ class IOSDriver(NetworkDriver):
                 r" description ([^\']+)\'", neighbor_config
             )
             local_as = napalm.base.helpers.regex_find_txt(
-                r"local-as (\d+)", neighbor_config, default=0
+                r"local-as (\d+)", neighbor_config, default=bgp_asn
             )
             import_policy = napalm.base.helpers.regex_find_txt(
                 r"route-map ([^\s]+) in", neighbor_config

--- a/napalm/ios/ios.py
+++ b/napalm/ios/ios.py
@@ -1565,29 +1565,28 @@ class IOSDriver(NetworkDriver):
                 "route_reflector_client": route_reflector_client,
             }
 
+        bgp_config["_"] = {
+            "apply_groups": [],
+            "description": "",
+            "local_as": bgp_asn,
+            "type": "",
+            "import_policy": "",
+            "export_policy": "",
+            "local_address": "",
+            "multipath": False,
+            "multihop_ttl": 0,
+            "remote_as": 0,
+            "remove_private_as": False,
+            "prefix_limit": {},
+            "neighbors": bgp_group_neighbors.get("_", {}),
+        }
         # Get the peer-group level config for each group
         for group_name in bgp_group_neighbors.keys():
             # If a group is passed in params, only continue on that group
             if group:
                 if group_name != group:
                     continue
-            # Default no group
             if group_name == "_":
-                bgp_config["_"] = {
-                    "apply_groups": [],
-                    "description": "",
-                    "local_as": 0,
-                    "type": "",
-                    "import_policy": "",
-                    "export_policy": "",
-                    "local_address": "",
-                    "multipath": False,
-                    "multihop_ttl": 0,
-                    "remote_as": 0,
-                    "remove_private_as": False,
-                    "prefix_limit": {},
-                    "neighbors": bgp_group_neighbors.get("_", {}),
-                }
                 continue
             neighbor_config = napalm.base.helpers.netutils_parse_objects(
                 group_name, bgp_config_list

--- a/napalm/iosxr/iosxr.py
+++ b/napalm/iosxr/iosxr.py
@@ -987,6 +987,15 @@ class IOSXRDriver(NetworkDriver):
         <InstanceName>default</InstanceName></Naming></Instance></BGP></Configuration></Get>"
         result_tree = ETREE.fromstring(self.device.make_rpc_call(rpc_command))
 
+        bgp_asn = napalm.base.helpers.convert(
+            int,
+            napalm.base.helpers.find_txt(
+                result_tree,
+                "Get/Configuration/BGP/Instance[1]/InstanceAS/FourByteAS/Naming/AS",
+            ),
+            0,
+        )
+
         if not group:
             neighbor = ""
 
@@ -1164,22 +1173,22 @@ class IOSXRDriver(NetworkDriver):
             }
             if group and group == group_name:
                 break
-        if "" in bgp_group_neighbors.keys():
-            bgp_config["_"] = {
-                "apply_groups": [],
-                "description": "",
-                "local_as": 0,
-                "type": "",
-                "import_policy": "",
-                "export_policy": "",
-                "local_address": "",
-                "multipath": False,
-                "multihop_ttl": 0,
-                "remote_as": 0,
-                "remove_private_as": False,
-                "prefix_limit": {},
-                "neighbors": bgp_group_neighbors.get("", {}),
-            }
+
+        bgp_config["_"] = {
+            "apply_groups": [],
+            "description": "",
+            "local_as": bgp_asn,
+            "type": "",
+            "import_policy": "",
+            "export_policy": "",
+            "local_address": "",
+            "multipath": False,
+            "multihop_ttl": 0,
+            "remote_as": 0,
+            "remove_private_as": False,
+            "prefix_limit": {},
+            "neighbors": bgp_group_neighbors.get("", {}),
+        }
 
         return bgp_config
 

--- a/napalm/iosxr/iosxr.py
+++ b/napalm/iosxr/iosxr.py
@@ -1019,7 +1019,9 @@ class IOSXRDriver(NetworkDriver):
                 int, napalm.base.helpers.find_txt(bgp_neighbor, "RemoteAS/AS_YY"), 0
             )
             local_as = napalm.base.helpers.convert(
-                int, napalm.base.helpers.find_txt(bgp_neighbor, "LocalAS/AS_YY"), 0
+                int,
+                napalm.base.helpers.find_txt(bgp_neighbor, "LocalAS/AS_YY"),
+                bgp_asn,
             )
             af_table = napalm.base.helpers.find_txt(
                 bgp_neighbor, "NeighborAFTable/NeighborAF/Naming/AFName"
@@ -1111,7 +1113,7 @@ class IOSXRDriver(NetworkDriver):
                 int, napalm.base.helpers.find_txt(bgp_group, "RemoteAS/AS_YY"), 0
             )
             local_as = napalm.base.helpers.convert(
-                int, napalm.base.helpers.find_txt(bgp_group, "LocalAS/AS_YY"), 0
+                int, napalm.base.helpers.find_txt(bgp_group, "LocalAS/AS_YY"), bgp_asn
             )
             multihop_ttl = napalm.base.helpers.convert(
                 int,

--- a/napalm/iosxr_netconf/iosxr_netconf.py
+++ b/napalm/iosxr_netconf/iosxr_netconf.py
@@ -1369,6 +1369,16 @@ class IOSXRNETCONFDriver(NetworkDriver):
         if not group:
             neighbor = ""
 
+        bgp_asn = napalm.base.helpers.convert(
+            int,
+            self._find_txt(
+                result_tree,
+                ".//bgpc:bgp/bgpc:instance/bgpc:instance-as/bgpc:four-byte-as/bgpc:as",
+                default=0,
+                namespaces=C.NS,
+            ),
+        )
+
         bgp_group_neighbors = {}
         bgp_neighbor_xpath = ".//bgpc:bgp/bgpc:instance/bgpc:instance-as/\
              bgpc:four-byte-as/bgpc:default-vrf/bgpc:bgp-entity/bgpc:neighbors/bgpc:neighbor"
@@ -1679,22 +1689,22 @@ class IOSXRNETCONFDriver(NetworkDriver):
             }
             if group and group == group_name:
                 break
-        if "" in bgp_group_neighbors.keys():
-            bgp_config["_"] = {
-                "apply_groups": [],
-                "description": "",
-                "local_as": 0,
-                "type": "",
-                "import_policy": "",
-                "export_policy": "",
-                "local_address": "",
-                "multipath": False,
-                "multihop_ttl": 0,
-                "remote_as": 0,
-                "remove_private_as": False,
-                "prefix_limit": {},
-                "neighbors": bgp_group_neighbors.get("", {}),
-            }
+
+        bgp_config["_"] = {
+            "apply_groups": [],
+            "description": "",
+            "local_as": bgp_asn,
+            "type": "",
+            "import_policy": "",
+            "export_policy": "",
+            "local_address": "",
+            "multipath": False,
+            "multihop_ttl": 0,
+            "remote_as": 0,
+            "remove_private_as": False,
+            "prefix_limit": {},
+            "neighbors": bgp_group_neighbors.get("", {}),
+        }
 
         return bgp_config
 

--- a/napalm/iosxr_netconf/iosxr_netconf.py
+++ b/napalm/iosxr_netconf/iosxr_netconf.py
@@ -1440,7 +1440,7 @@ class IOSXRNETCONFDriver(NetworkDriver):
                 ),
                 0,
             )
-            local_as = local_as_x * 65536 + local_as_y
+            local_as = (local_as_x * 65536 + local_as_y) or bgp_asn
             af_table = self._find_txt(
                 bgp_neighbor,
                 "./bgpc:neighbor-afs/bgpc:neighbor-af/bgpc:af-name",
@@ -1607,7 +1607,7 @@ class IOSXRNETCONFDriver(NetworkDriver):
                 ),
                 0,
             )
-            local_as = local_as_x * 65536 + local_as_y
+            local_as = (local_as_x * 65536 + local_as_y) or bgp_asn
             multihop_ttl = napalm.base.helpers.convert(
                 int,
                 self._find_txt(

--- a/napalm/junos/junos.py
+++ b/napalm/junos/junos.py
@@ -1250,6 +1250,30 @@ class JunOSDriver(NetworkDriver):
 
         bgp_config = {}
 
+        routing_options = junos_views.junos_routing_config_table(self.device)
+        routing_options.get(options=self.junos_config_options)
+
+        bgp_asn = int(
+            routing_options.xml.find(
+                "./routing-options/autonomous-system/as-number"
+            ).text
+        )
+
+        bgp_config["_"] = {
+            "apply_groups": [],
+            "description": "",
+            "local_as": bgp_asn,
+            "type": "",
+            "import_policy": "",
+            "export_policy": "",
+            "local_address": "",
+            "multipath": False,
+            "multihop_ttl": 0,
+            "remote_as": 0,
+            "remove_private_as": False,
+            "prefix_limit": {},
+            "neighbors": {},
+        }
         if group:
             bgp = junos_views.junos_bgp_config_group_table(self.device)
             bgp.get(group=group, options=self.junos_config_options)

--- a/napalm/junos/utils/junos_views.yml
+++ b/napalm/junos/utils/junos_views.yml
@@ -402,6 +402,15 @@ junos_bgp_config_peers_view:
     inet6_flow_teardown_timeout_prefix_limit: {family/inet6/flow/prefix-limit/teardown/idle-timeout/timeout: int}
     inet6_flow_novalidate_prefix_limit: {family/inet6/flow/prefix-limit/no-validate: unicode}
 
+junos_routing_config_table:
+  get: "routing-options/autonomous-system"
+  view: junos_routing_config_view
+
+junos_routing_config_view:
+  fields:
+    local_system_as: autonomous-system
+
+
 ####
 #### BGP Neighbors and Routing Tables Stats
 ####

--- a/test/eos/mocked_data/test_get_bgp_config/issue1504_alt_peer_group_syntax/expected_result.json
+++ b/test/eos/mocked_data/test_get_bgp_config/issue1504_alt_peer_group_syntax/expected_result.json
@@ -1,4 +1,19 @@
 {
+  "_": {
+    "type": "",
+    "multipath": false,
+    "apply_groups": [],
+    "remove_private_as": false,
+    "multihop_ttl": 0,
+    "remote_as": 0,
+    "local_address": "",
+    "local_as": 64496,
+    "description": "",
+    "import_policy": "",
+    "export_policy": "",
+    "prefix_limit": {},
+    "neighbors": {}
+  },
   "IPv6-PEERS-GROUP-NAME": {
     "type": "",
     "multipath": false,

--- a/test/eos/mocked_data/test_get_bgp_config/issue_1113_dot_asn/expected_result.json
+++ b/test/eos/mocked_data/test_get_bgp_config/issue_1113_dot_asn/expected_result.json
@@ -1,4 +1,19 @@
 {
+  "_": {
+    "type": "",
+    "multipath": false,
+    "apply_groups": [],
+    "remove_private_as": false,
+    "multihop_ttl": 0,
+    "remote_as": 0,
+    "local_address": "",
+    "local_as": 4266524237,
+    "description": "",
+    "import_policy": "",
+    "export_policy": "",
+    "prefix_limit": {},
+    "neighbors": {}
+  },
   "IPv4-PEERS-GROUP-NAME": {
     "type": "",
     "multipath": false,

--- a/test/eos/mocked_data/test_get_bgp_config/normal/expected_result.json
+++ b/test/eos/mocked_data/test_get_bgp_config/normal/expected_result.json
@@ -1,1 +1,97 @@
-{"IPv4-PEERS-GROUP-NAME": {"local_address": "", "description": "", "type": "", "local_as": 13335, "apply_groups": [], "multihop_ttl": 0, "remove_private_as": true, "remote_as": 0, "import_policy": "reject-all", "export_policy": "4-public-peer-anycast-out", "neighbors": {"172.17.17.1": {"local_address": "", "authentication_key": "", "description": "", "nhs": false, "local_as": 13335, "route_reflector_client": false, "remote_as": 13414, "import_policy": "", "export_policy": "", "prefix_limit": {}}, "192.168.0.1": {"local_address": "", "authentication_key": "", "description": "", "nhs": false, "local_as": 13335, "route_reflector_client": false, "remote_as": 32934, "import_policy": "", "export_policy": "", "prefix_limit": {}}}, "prefix_limit": {}, "multipath": false}, "IPv6-PEERS-GROUP-NAME": {"local_address": "", "description": "", "type": "", "local_as": 13335, "apply_groups": [], "multihop_ttl": 0, "remove_private_as": true, "remote_as": 0, "import_policy": "reject-all", "export_policy": "reject-all", "neighbors": {"2001:db8::0:2": {"local_address": "", "authentication_key": "", "description": "", "nhs": false, "local_as": 13335, "route_reflector_client": false, "remote_as": 54113, "import_policy": "", "export_policy": "", "prefix_limit": {}}, "2001:db8::0:1": {"local_address": "", "authentication_key": "", "description": "", "nhs": false, "local_as": 13335, "route_reflector_client": false, "remote_as": 8403, "import_policy": "", "export_policy": "", "prefix_limit": {}}}, "prefix_limit": {}, "multipath": false}}
+{
+  "_": {
+    "type": "",
+    "multipath": false,
+    "apply_groups": [],
+    "remove_private_as": false,
+    "multihop_ttl": 0,
+    "remote_as": 0,
+    "local_address": "",
+    "local_as": 13335,
+    "description": "",
+    "import_policy": "",
+    "export_policy": "",
+    "prefix_limit": {},
+    "neighbors": {}
+  },
+  "IPv4-PEERS-GROUP-NAME": {
+    "local_address": "",
+    "description": "",
+    "type": "",
+    "local_as": 13335,
+    "apply_groups": [],
+    "multihop_ttl": 0,
+    "remove_private_as": true,
+    "remote_as": 0,
+    "import_policy": "reject-all",
+    "export_policy": "4-public-peer-anycast-out",
+    "neighbors": {
+      "172.17.17.1": {
+        "local_address": "",
+        "authentication_key": "",
+        "description": "",
+        "nhs": false,
+        "local_as": 13335,
+        "route_reflector_client": false,
+        "remote_as": 13414,
+        "import_policy": "",
+        "export_policy": "",
+        "prefix_limit": {}
+      },
+      "192.168.0.1": {
+        "local_address": "",
+        "authentication_key": "",
+        "description": "",
+        "nhs": false,
+        "local_as": 13335,
+        "route_reflector_client": false,
+        "remote_as": 32934,
+        "import_policy": "",
+        "export_policy": "",
+        "prefix_limit": {}
+      }
+    },
+    "prefix_limit": {},
+    "multipath": false
+  },
+  "IPv6-PEERS-GROUP-NAME": {
+    "local_address": "",
+    "description": "",
+    "type": "",
+    "local_as": 13335,
+    "apply_groups": [],
+    "multihop_ttl": 0,
+    "remove_private_as": true,
+    "remote_as": 0,
+    "import_policy": "reject-all",
+    "export_policy": "reject-all",
+    "neighbors": {
+      "2001:db8::0:2": {
+        "local_address": "",
+        "authentication_key": "",
+        "description": "",
+        "nhs": false,
+        "local_as": 13335,
+        "route_reflector_client": false,
+        "remote_as": 54113,
+        "import_policy": "",
+        "export_policy": "",
+        "prefix_limit": {}
+      },
+      "2001:db8::0:1": {
+        "local_address": "",
+        "authentication_key": "",
+        "description": "",
+        "nhs": false,
+        "local_as": 13335,
+        "route_reflector_client": false,
+        "remote_as": 8403,
+        "import_policy": "",
+        "export_policy": "",
+        "prefix_limit": {}
+      }
+    },
+    "prefix_limit": {},
+    "multipath": false
+  }
+}

--- a/test/ios/mocked_data/test_get_bgp_config/mixed_with_without_groups/expected_result.json
+++ b/test/ios/mocked_data/test_get_bgp_config/mixed_with_without_groups/expected_result.json
@@ -75,7 +75,7 @@
     "export_policy": "",
     "import_policy": "",
     "local_address": "",
-    "local_as": 0,
+    "local_as": 65001,
     "multihop_ttl": 0,
     "multipath": false,
     "neighbors": {

--- a/test/ios/mocked_data/test_get_bgp_config/mixed_with_without_groups/expected_result.json
+++ b/test/ios/mocked_data/test_get_bgp_config/mixed_with_without_groups/expected_result.json
@@ -5,7 +5,7 @@
     "export_policy": "PASS-OUT",
     "import_policy": "PASS-IN",
     "local_address": "GigabitEthernet1",
-    "local_as": 0,
+    "local_as": 65001,
     "multihop_ttl": 0,
     "multipath": false,
     "neighbors": {
@@ -15,7 +15,7 @@
         "export_policy": "",
         "import_policy": "",
         "local_address": "",
-        "local_as": 0,
+        "local_as": 65001,
         "nhs": false,
         "prefix_limit": {
           "inet": {
@@ -37,7 +37,7 @@
         "export_policy": "",
         "import_policy": "",
         "local_address": "",
-        "local_as": 0,
+        "local_as": 65001,
         "nhs": false,
         "prefix_limit": {
           "inet": {

--- a/test/ios/mocked_data/test_get_bgp_config/no_afi/expected_result.json
+++ b/test/ios/mocked_data/test_get_bgp_config/no_afi/expected_result.json
@@ -20,7 +20,7 @@
                 "export_policy": "",
                 "import_policy": "",
                 "local_address": "",
-                "local_as": 0,
+                "local_as": 42,
                 "authentication_key": "",
                 "nhs": false,
                 "route_reflector_client": false

--- a/test/ios/mocked_data/test_get_bgp_config/no_afi/expected_result.json
+++ b/test/ios/mocked_data/test_get_bgp_config/no_afi/expected_result.json
@@ -2,7 +2,7 @@
     "_": {
         "apply_groups": [],
         "description": "",
-        "local_as": 0,
+        "local_as": 42,
         "type": "",
         "import_policy": "",
         "export_policy": "",

--- a/test/ios/mocked_data/test_get_bgp_config/normal/expected_result.json
+++ b/test/ios/mocked_data/test_get_bgp_config/normal/expected_result.json
@@ -1,4 +1,19 @@
 {
+  "_": {
+    "apply_groups": [],
+    "description": "",
+    "local_as": 65001,
+    "type": "",
+    "import_policy": "",
+    "export_policy": "",
+    "local_address": "",
+    "multipath": false,
+    "multihop_ttl": 0,
+    "remote_as": 0,
+    "remove_private_as": false,
+    "prefix_limit": {},
+    "neighbors": {}
+  },
   "RR-CLIENTS": {
     "apply_groups": [],
     "description": "[ibgp - rr clients]",

--- a/test/ios/mocked_data/test_get_bgp_config/normal/expected_result.json
+++ b/test/ios/mocked_data/test_get_bgp_config/normal/expected_result.json
@@ -20,7 +20,7 @@
     "export_policy": "PASS-OUT",
     "import_policy": "PASS-IN",
     "local_address": "GigabitEthernet1",
-    "local_as": 0,
+    "local_as": 65001,
     "multihop_ttl": 0,
     "multipath": false,
     "neighbors": {
@@ -30,7 +30,7 @@
         "export_policy": "",
         "import_policy": "",
         "local_address": "",
-        "local_as": 0,
+        "local_as": 65001,
         "nhs": false,
         "prefix_limit": {
           "inet": {
@@ -52,7 +52,7 @@
         "export_policy": "",
         "import_policy": "",
         "local_address": "",
-        "local_as": 0,
+        "local_as": 65001,
         "nhs": false,
         "prefix_limit": {
           "inet": {

--- a/test/ios/mocked_data/test_get_bgp_config/peers_without_groups/expected_result.json
+++ b/test/ios/mocked_data/test_get_bgp_config/peers_without_groups/expected_result.json
@@ -15,7 +15,7 @@
         "export_policy": "PASS-OUT",
         "import_policy": "PASS-IN",
         "local_address": "GigabitEthernet1",
-        "local_as": 0,
+        "local_as": 65001,
         "nhs": false,
         "prefix_limit": {
           "inet": {

--- a/test/ios/mocked_data/test_get_bgp_config/peers_without_groups/expected_result.json
+++ b/test/ios/mocked_data/test_get_bgp_config/peers_without_groups/expected_result.json
@@ -5,7 +5,7 @@
     "export_policy": "",
     "import_policy": "",
     "local_address": "",
-    "local_as": 0,
+    "local_as": 65001,
     "multihop_ttl": 0,
     "multipath": false,
     "neighbors": {

--- a/test/iosxr/mocked_data/test_get_bgp_config/mixed_with_without_groups/expected_result.json
+++ b/test/iosxr/mocked_data/test_get_bgp_config/mixed_with_without_groups/expected_result.json
@@ -30,7 +30,7 @@
         "description": "",
         "route_reflector_client": false,
         "nhs": false,
-        "local_as": 0,
+        "local_as": 65900,
         "import_policy": "pass-all",
         "local_address": "",
         "prefix_limit": {
@@ -54,7 +54,7 @@
     "remove_private_as": false,
     "description": "",
     "export_policy": "",
-    "local_as": 0,
+    "local_as": 65900,
     "apply_groups": [],
     "multipath": false,
     "prefix_limit": {}
@@ -68,7 +68,7 @@
         "description": "",
         "route_reflector_client": false,
         "nhs": false,
-        "local_as": 0,
+        "local_as": 65900,
         "import_policy": "RP-SPECIAL-SNOWFLAKE-IN",
         "local_address": "",
         "prefix_limit": {
@@ -90,7 +90,7 @@
         "description": "",
         "route_reflector_client": false,
         "nhs": false,
-        "local_as": 0,
+        "local_as": 65900,
         "import_policy": "",
         "local_address": "",
         "prefix_limit": {},
@@ -104,7 +104,7 @@
     "remove_private_as": true,
     "description": "",
     "export_policy": "",
-    "local_as": 0,
+    "local_as": 65900,
     "apply_groups": [],
     "multipath": false,
     "prefix_limit": {}

--- a/test/iosxr/mocked_data/test_get_bgp_config/mixed_with_without_groups/expected_result.json
+++ b/test/iosxr/mocked_data/test_get_bgp_config/mixed_with_without_groups/expected_result.json
@@ -8,7 +8,7 @@
         "description": "",
         "route_reflector_client": false,
         "nhs": false,
-        "local_as": 0,
+        "local_as": 65900,
         "import_policy": "pass-all",
         "local_address": "",
         "prefix_limit": {

--- a/test/iosxr/mocked_data/test_get_bgp_config/normal/expected_result.json
+++ b/test/iosxr/mocked_data/test_get_bgp_config/normal/expected_result.json
@@ -1,4 +1,19 @@
 {
+  "_": {
+    "local_as": 13335,
+    "remove_private_as": false,
+    "import_policy": "",
+    "multihop_ttl": 0,
+    "neighbors": {},
+    "multipath": false,
+    "export_policy": "",
+    "type": "",
+    "apply_groups": [],
+    "remote_as": 0,
+    "prefix_limit": {},
+    "description": "",
+    "local_address": ""
+  },
   "4-public-anycast-peers": {
     "local_as": 0,
     "remove_private_as": true,

--- a/test/iosxr/mocked_data/test_get_bgp_config/normal/expected_result.json
+++ b/test/iosxr/mocked_data/test_get_bgp_config/normal/expected_result.json
@@ -15,14 +15,14 @@
     "local_address": ""
   },
   "4-public-anycast-peers": {
-    "local_as": 0,
+    "local_as": 13335,
     "remove_private_as": true,
     "import_policy": "4-public-anycast-peers-in",
     "multihop_ttl": 0,
     "neighbors": {
       "192.168.20.3": {
         "export_policy": "",
-        "local_as": 0,
+        "local_as": 13335,
         "prefix_limit": {
           "inet": {
             "unicast": {
@@ -44,7 +44,7 @@
       },
       "172.17.17.50": {
         "export_policy": "",
-        "local_as": 0,
+        "local_as": 13335,
         "prefix_limit": {
           "inet": {
             "unicast": {
@@ -66,7 +66,7 @@
       },
       "192.168.50.5": {
         "export_policy": "",
-        "local_as": 0,
+        "local_as": 13335,
         "prefix_limit": {
           "inet": {
             "unicast": {

--- a/test/iosxr/mocked_data/test_get_bgp_config/peers_without_groups/expected_result.json
+++ b/test/iosxr/mocked_data/test_get_bgp_config/peers_without_groups/expected_result.json
@@ -10,7 +10,7 @@
     "remove_private_as": false,
     "remote_as": 0,
     "multihop_ttl": 0,
-    "local_as": 0,
+    "local_as": 65900,
     "apply_groups": [],
     "neighbors": {
       "10.255.255.2": {

--- a/test/iosxr/mocked_data/test_get_bgp_config/peers_without_groups/expected_result.json
+++ b/test/iosxr/mocked_data/test_get_bgp_config/peers_without_groups/expected_result.json
@@ -26,7 +26,7 @@
             }
           }
         },
-        "local_as": 0,
+        "local_as": 65900,
         "description": "",
         "local_address": "",
         "import_policy": "pass-all",
@@ -48,7 +48,7 @@
             }
           }
         },
-        "local_as": 0,
+        "local_as": 65900,
         "description": "",
         "local_address": "",
         "import_policy": "pass-all",

--- a/test/iosxr_netconf/mocked_data/test_get_bgp_config/normal/expected_result.json
+++ b/test/iosxr_netconf/mocked_data/test_get_bgp_config/normal/expected_result.json
@@ -5,7 +5,7 @@
         "export_policy": "EBGP-OUT-POLICY",
         "import_policy": "EBGP-IN-POLICY",
         "local_address": "",
-        "local_as": 0,
+        "local_as": 65172,
         "multihop_ttl": 0,
         "multipath": false,
         "neighbors": {

--- a/test/iosxr_netconf/mocked_data/test_get_bgp_config/normal/expected_result.json
+++ b/test/iosxr_netconf/mocked_data/test_get_bgp_config/normal/expected_result.json
@@ -30,7 +30,7 @@
                 "export_policy": "",
                 "import_policy": "",
                 "local_address": "",
-                "local_as": 0,
+                "local_as": 65172,
                 "nhs": false,
                 "prefix_limit": {
                     "inet": {
@@ -52,7 +52,7 @@
                 "export_policy": "",
                 "import_policy": "",
                 "local_address": "",
-                "local_as": 0,
+                "local_as": 65172,
                 "nhs": false,
                 "prefix_limit": {
                     "inet": {
@@ -80,7 +80,7 @@
         "export_policy": "EBGP-VRF-OUT-POLICY",
         "import_policy": "EBGP-VRF-IN-POLICY",
         "local_address": "",
-        "local_as": 0,
+        "local_as": 65172,
         "multihop_ttl": 0,
         "multipath": false,
         "neighbors": {},
@@ -95,7 +95,7 @@
         "export_policy": "IBGPv6-OUT-POLICY",
         "import_policy": "IBGPv6-IN-POLICY",
         "local_address": "",
-        "local_as": 0,
+        "local_as": 65172,
         "multihop_ttl": 0,
         "multipath": false,
         "neighbors": {
@@ -105,7 +105,7 @@
                 "export_policy": "",
                 "import_policy": "",
                 "local_address": "",
-                "local_as": 0,
+                "local_as": 65172,
                 "nhs": false,
                 "prefix_limit": {
                     "inet6": {
@@ -127,7 +127,7 @@
                 "export_policy": "",
                 "import_policy": "",
                 "local_address": "",
-                "local_as": 0,
+                "local_as": 65172,
                 "nhs": false,
                 "prefix_limit": {
                     "inet6": {
@@ -155,7 +155,7 @@
         "export_policy": "EBGPv6-VRF-OUT-POLICY",
         "import_policy": "EBGPv6-VRF-IN-POLICY",
         "local_address": "",
-        "local_as": 0,
+        "local_as": 65172,
         "multihop_ttl": 0,
         "multipath": false,
         "neighbors": {},
@@ -170,7 +170,7 @@
         "export_policy": "IBGP-OUT-POLICY",
         "import_policy": "",
         "local_address": "",
-        "local_as": 0,
+        "local_as": 65172,
         "multihop_ttl": 0,
         "multipath": false,
         "neighbors": {
@@ -180,7 +180,7 @@
                 "export_policy": "",
                 "import_policy": "",
                 "local_address": "",
-                "local_as": 0,
+                "local_as": 65172,
                 "nhs": false,
                 "prefix_limit": {
                     "inet": {
@@ -208,7 +208,7 @@
         "export_policy": "IBGP-OUT-POLICY",
         "import_policy": "",
         "local_address": "",
-        "local_as": 0,
+        "local_as": 65172,
         "multihop_ttl": 0,
         "multipath": false,
         "neighbors": {
@@ -218,7 +218,7 @@
                 "export_policy": "",
                 "import_policy": "",
                 "local_address": "",
-                "local_as": 0,
+                "local_as": 65172,
                 "nhs": false,
                 "prefix_limit": {
                     "inet6": {

--- a/test/iosxr_netconf/mocked_data/test_get_bgp_config/normal/expected_result.json
+++ b/test/iosxr_netconf/mocked_data/test_get_bgp_config/normal/expected_result.json
@@ -1,4 +1,19 @@
 {
+    "_": {
+        "apply_groups": [],
+        "description": "",
+        "export_policy": "",
+        "import_policy": "",
+        "local_address": "",
+        "local_as": 65172,
+        "multihop_ttl": 0,
+        "multipath": false,
+        "neighbors": {},
+        "prefix_limit": {},
+        "remote_as": 0,
+        "remove_private_as": false,
+        "type": ""
+    },
     "EBGP": {
         "apply_groups": [],
         "description": "",

--- a/test/junos/mocked_data/test_get_bgp_config/nhs/_configuration__routing_options__autonomous_system____routing_options___configuration_.xml
+++ b/test/junos/mocked_data/test_get_bgp_config/nhs/_configuration__routing_options__autonomous_system____routing_options___configuration_.xml
@@ -1,0 +1,7 @@
+<configuration>
+        <routing-options>
+            <autonomous-system>
+                <as-number>65001</as-number>
+            </autonomous-system>
+        </routing-options>
+</configuration>

--- a/test/junos/mocked_data/test_get_bgp_config/nhs/expected_result.json
+++ b/test/junos/mocked_data/test_get_bgp_config/nhs/expected_result.json
@@ -1,1 +1,73 @@
-{"internal":{"apply_groups":[],"description":"","export_policy":"","import_policy":"","local_address":"","local_as":0,"multihop_ttl":0,"multipath":false,"neighbors":{"10.10.10.1":{"authentication_key":"","description":"","export_policy":"nhs","import_policy":"","local_address":"","local_as":0,"nhs":true,"prefix_limit":{},"remote_as":0,"route_reflector_client":false}},"prefix_limit":{},"remote_as":0,"remove_private_as":false,"type":"internal"},"internal-2":{"apply_groups":[],"description":"","export_policy":"","import_policy":"","local_address":"","local_as":0,"multihop_ttl":0,"multipath":false,"neighbors":{"10.10.10.2":{"authentication_key":"","description":"","export_policy":"static","import_policy":"","local_address":"","local_as":0,"nhs":false,"prefix_limit":{},"remote_as":0,"route_reflector_client":false}},"prefix_limit":{},"remote_as":0,"remove_private_as":false,"type":"internal"}}
+{
+  "_": {
+    "export_policy": "",
+    "multipath": false,
+    "prefix_limit": {},
+    "description": "",
+    "local_as": 65001,
+    "multihop_ttl": 0,
+    "apply_groups": [],
+    "remote_as": 0,
+    "remove_private_as": false,
+    "local_address": "",
+    "type": "",
+    "import_policy": "",
+    "neighbors": {}
+  },
+  "internal": {
+    "apply_groups": [],
+    "description": "",
+    "export_policy": "",
+    "import_policy": "",
+    "local_address": "",
+    "local_as": 0,
+    "multihop_ttl": 0,
+    "multipath": false,
+    "neighbors": {
+      "10.10.10.1": {
+        "authentication_key": "",
+        "description": "",
+        "export_policy": "nhs",
+        "import_policy": "",
+        "local_address": "",
+        "local_as": 0,
+        "nhs": true,
+        "prefix_limit": {},
+        "remote_as": 0,
+        "route_reflector_client": false
+      }
+    },
+    "prefix_limit": {},
+    "remote_as": 0,
+    "remove_private_as": false,
+    "type": "internal"
+  },
+  "internal-2": {
+    "apply_groups": [],
+    "description": "",
+    "export_policy": "",
+    "import_policy": "",
+    "local_address": "",
+    "local_as": 0,
+    "multihop_ttl": 0,
+    "multipath": false,
+    "neighbors": {
+      "10.10.10.2": {
+        "authentication_key": "",
+        "description": "",
+        "export_policy": "static",
+        "import_policy": "",
+        "local_address": "",
+        "local_as": 0,
+        "nhs": false,
+        "prefix_limit": {},
+        "remote_as": 0,
+        "route_reflector_client": false
+      }
+    },
+    "prefix_limit": {},
+    "remote_as": 0,
+    "remove_private_as": false,
+    "type": "internal"
+  }
+}

--- a/test/junos/mocked_data/test_get_bgp_config/normal/_configuration__routing_options__autonomous_system____routing_options___configuration_.xml
+++ b/test/junos/mocked_data/test_get_bgp_config/normal/_configuration__routing_options__autonomous_system____routing_options___configuration_.xml
@@ -1,0 +1,7 @@
+<configuration>
+        <routing-options>
+            <autonomous-system>
+                <as-number>13335</as-number>
+            </autonomous-system>
+        </routing-options>
+</configuration>

--- a/test/junos/mocked_data/test_get_bgp_config/normal/expected_result.json
+++ b/test/junos/mocked_data/test_get_bgp_config/normal/expected_result.json
@@ -1,1 +1,86 @@
-{"PEERS-GROUP-NAME": {"neighbors": {"192.168.0.1": {"export_policy": "", "prefix_limit": {"inet": {"unicast": {"limit": 100}}}, "route_reflector_client": false, "description": "Facebook [CDN]", "local_as": 0, "nhs": false, "local_address": "", "remote_as": 32934, "authentication_key": "", "import_policy": ""}, "172.17.17.1": {"export_policy": "", "prefix_limit": {"inet": {"unicast": {"limit": 500}}}, "route_reflector_client": false, "description": "Twitter [CDN]", "local_as": 0, "nhs": false, "local_address": "", "remote_as": 13414, "authentication_key": "", "import_policy": ""}}, "export_policy": "PUBLIC-PEER-OUT", "multipath": true, "prefix_limit": {}, "description": "", "local_as": 13335, "multihop_ttl": 0, "apply_groups": ["B", "G", "P", "-", "P", "R", "E", "F", "I", "X", "-", "L", "I", "M", "I", "T"], "remote_as": 0, "remove_private_as": true, "local_address": "", "type": "external", "import_policy": "PUBLIC-PEER-IN"}}
+{
+  "_": {
+    "export_policy": "",
+    "multipath": false,
+    "prefix_limit": {},
+    "description": "",
+    "local_as": 13335,
+    "multihop_ttl": 0,
+    "apply_groups": [],
+    "remote_as": 0,
+    "remove_private_as": false,
+    "local_address": "",
+    "type": "",
+    "import_policy": "",
+    "neighbors": {}
+  },
+  "PEERS-GROUP-NAME": {
+    "neighbors": {
+      "192.168.0.1": {
+        "export_policy": "",
+        "prefix_limit": {
+          "inet": {
+            "unicast": {
+              "limit": 100
+            }
+          }
+        },
+        "route_reflector_client": false,
+        "description": "Facebook [CDN]",
+        "local_as": 0,
+        "nhs": false,
+        "local_address": "",
+        "remote_as": 32934,
+        "authentication_key": "",
+        "import_policy": ""
+      },
+      "172.17.17.1": {
+        "export_policy": "",
+        "prefix_limit": {
+          "inet": {
+            "unicast": {
+              "limit": 500
+            }
+          }
+        },
+        "route_reflector_client": false,
+        "description": "Twitter [CDN]",
+        "local_as": 0,
+        "nhs": false,
+        "local_address": "",
+        "remote_as": 13414,
+        "authentication_key": "",
+        "import_policy": ""
+      }
+    },
+    "export_policy": "PUBLIC-PEER-OUT",
+    "multipath": true,
+    "prefix_limit": {},
+    "description": "",
+    "local_as": 13335,
+    "multihop_ttl": 0,
+    "apply_groups": [
+      "B",
+      "G",
+      "P",
+      "-",
+      "P",
+      "R",
+      "E",
+      "F",
+      "I",
+      "X",
+      "-",
+      "L",
+      "I",
+      "M",
+      "I",
+      "T"
+    ],
+    "remote_as": 0,
+    "remove_private_as": true,
+    "local_address": "",
+    "type": "external",
+    "import_policy": "PUBLIC-PEER-IN"
+  }
+}


### PR DESCRIPTION
Closes #1878

This changeset also includes logic to set the `local_as` in the group and neighbor dictionaries in the return value to the actual local AS instead of using `0` as a value to indicate it was not overridden