### PR TITLE
Fixing parsing error when there is no BGP configured on Junos

### DIFF
--- a/napalm/junos/junos.py
+++ b/napalm/junos/junos.py
@@ -1256,7 +1256,7 @@ class JunOSDriver(NetworkDriver):
         bgp_asn_obj = routing_options.xml.find(
             "./routing-options/autonomous-system/as-number"
         )
-        bgp_asn = int(bgp_asn_obj.text) if bgp_asn_obj else 0
+        bgp_asn = int(bgp_asn_obj.text) if bgp_asn_obj is not None else 0
 
         bgp_config["_"] = {
             "apply_groups": [],

--- a/napalm/junos/junos.py
+++ b/napalm/junos/junos.py
@@ -1253,11 +1253,10 @@ class JunOSDriver(NetworkDriver):
         routing_options = junos_views.junos_routing_config_table(self.device)
         routing_options.get(options=self.junos_config_options)
 
-        bgp_asn = int(
-            routing_options.xml.find(
-                "./routing-options/autonomous-system/as-number"
-            ).text
+        bgp_asn_obj = routing_options.xml.find(
+            "./routing-options/autonomous-system/as-number"
         )
+        bgp_asn = int(bgp_asn_obj.text) if bgp_asn_obj else 0
 
         bgp_config["_"] = {
             "apply_groups": [],


### PR DESCRIPTION
Currently if there is no BGP configuration on a Junos device you will get an exception when calling `get_bgp_config`