### PR TITLE
fix: eos config_session not cleared if discard failed

### DIFF
--- a/docs/support/index.rst
+++ b/docs/support/index.rst
@@ -141,6 +141,7 @@ ____________________________________
 * :code:`eos_fn0039_config` (eos) - Transform old style configuration to the new style, available beginning with EOS release 4.23.0, as per FN 0039. Beware
   that enabling this option will change the configuration you're loading through NAPALM. Default: ``False`` (won't change your configuration commands).
   .. versionadded:: 3.0.1
+* :code:`force_cfg_session_invalid` (eos) - Force the config_session to be cleared in case of issues, like `discard_config` failure. (default: ``False``)
 
 The transport argument
 ______________________

--- a/napalm/eos/eos.py
+++ b/napalm/eos/eos.py
@@ -543,9 +543,10 @@ class EOSDriver(NetworkDriver):
     def discard_config(self):
         """Implementation of NAPALM method discard_config."""
         if self.config_session is not None:
-            commands = [f"configure session {self.config_session} abort"]
-            self._run_commands(commands, encoding="text")
+            config_session = self.config_session
             self.config_session = None
+            commands = [f"configure session {config_session} abort"]
+            self._run_commands(commands, encoding="text")
 
     def rollback(self):
         """Implementation of NAPALM method rollback."""

--- a/napalm/eos/eos.py
+++ b/napalm/eos/eos.py
@@ -96,6 +96,8 @@ class EOSDriver(NetworkDriver):
         Optional args:
             * lock_disable (True/False): force configuration lock to be disabled (for external lock
                 management).
+            * force_cfg_session_invalid (True/False): force invalidation of the config session
+                in case of failure.
             * enable_password (True/False): Enable password for privilege elevation
             * eos_autoComplete (True/False): Allow for shortening of cli commands
             * transport (string): transport, eos_transport is a fallback for compatibility.
@@ -134,6 +136,10 @@ class EOSDriver(NetworkDriver):
         # Define locking method
         self.lock_disable = self.optional_args.pop("lock_disable", False)
 
+        self.force_cfg_session_invalid = self.optional_args.pop(
+            "force_cfg_session_invalid", False
+        )
+
         # eos_transport is there for backwards compatibility, transport is the preferred method
         transport = self.optional_args.get(
             "transport", self.optional_args.get("eos_transport", "https")
@@ -150,7 +156,6 @@ class EOSDriver(NetworkDriver):
         self.netmiko_optional_args = netmiko_args(optional_args)
 
     def _process_optional_args_eapi(self, optional_args):
-
         # Parse pyeapi transport class
         self.transport_class = self._parse_transport(self.transport)
 
@@ -544,9 +549,13 @@ class EOSDriver(NetworkDriver):
         """Implementation of NAPALM method discard_config."""
         if self.config_session is not None:
             config_session = self.config_session
-            self.config_session = None
+
+            if self.force_cfg_session_invalid:
+                self.config_session = None
+
             commands = [f"configure session {config_session} abort"]
             self._run_commands(commands, encoding="text")
+            self.config_session = None
 
     def rollback(self):
         """Implementation of NAPALM method rollback."""


### PR DESCRIPTION
If the abort command is refused, for instance because of a TACACS issue, the config_session is never cleared because an exception is raised by self._run_commands.

This is an issue in Saltstack case:
- a pending session could contain incomplete changes
- this pending session is resumed on the next load_config call causing messed up configuration

This change ensure the config_session is always cleared.