### PR TITLE
Fix `Can't convert with callable None` - for junos routers

### DIFF
--- a/napalm/junos/junos.py
+++ b/napalm/junos/junos.py
@@ -1246,6 +1246,8 @@ class JunOSDriver(NetworkDriver):
         }
         _GROUP_FIELDS_DATATYPE_MAP_.update(_COMMON_FIELDS_DATATYPE_)
 
+        _UNWANTED_GROUP_FIELDS = ["multihop", "cluster"]
+
         _DATATYPE_DEFAULT_ = {str: "", int: 0, bool: False, list: []}
 
         bgp_config = {}
@@ -1302,6 +1304,8 @@ class JunOSDriver(NetworkDriver):
             is_nhs, boolean = is_nhs_list[0]
             nhs_policies[policy_name] = boolean if boolean is not None else False
 
+        unwanted_group_fields = dict()
+
         for bgp_group in bgp_items:
             bgp_group_name = bgp_group[0]
             bgp_group_details = bgp_group[1]
@@ -1314,6 +1318,9 @@ class JunOSDriver(NetworkDriver):
             # Always overwrite with the system local_as (this will either be
             # valid or will be zero i.e. the same as the default value).
             bgp_config[bgp_group_name]["local_as"] = system_bgp_asn
+            unwanted_group_fields[bgp_group_name] = dict(
+                {key: False for key in _UNWANTED_GROUP_FIELDS}
+            )
 
             for key, value in bgp_group_details:
                 if "_prefix_limit" in key or value is None:
@@ -1335,6 +1342,10 @@ class JunOSDriver(NetworkDriver):
                 if key == "neighbors":
                     bgp_group_peers = value
                     continue
+
+                if key in _UNWANTED_GROUP_FIELDS:
+                    unwanted_group_fields[bgp_group_name][key] = True
+                    continue
                 if datatype:
                     bgp_config[bgp_group_name].update(
                         {key: napalm.base.helpers.convert(datatype, value, default)}
@@ -1354,9 +1365,7 @@ class JunOSDriver(NetworkDriver):
             bgp_config[bgp_group_name]["prefix_limit"] = build_prefix_limit(
                 **prefix_limit_fields
             )
-            if "multihop" in bgp_config[bgp_group_name].keys():
-                # Delete 'multihop' key from the output
-                del bgp_config[bgp_group_name]["multihop"]
+            if unwanted_group_fields[bgp_group_name]["multihop"]:
                 if bgp_config[bgp_group_name]["multihop_ttl"] == 0:
                     # Set ttl to default value 64
                     bgp_config[bgp_group_name]["multihop_ttl"] = 64
@@ -1411,7 +1420,7 @@ class JunOSDriver(NetworkDriver):
                         # we do not want cluster in the output
                         del bgp_peer_details["cluster"]
 
-                if "cluster" in bgp_config[bgp_group_name].keys():
+                if unwanted_group_fields[bgp_group_name]["cluster"]:
                     bgp_peer_details["route_reflector_client"] = True
                 prefix_limit_fields = {}
                 for key, value in bgp_group_details:
@@ -1433,10 +1442,6 @@ class JunOSDriver(NetworkDriver):
                 ] = bgp_peer_details
                 if neighbor and bgp_peer_address == neighbor_ip:
                     break  # found the desired neighbor
-
-            if "cluster" in bgp_config[bgp_group_name].keys():
-                # we do not want cluster in the output
-                del bgp_config[bgp_group_name]["cluster"]
 
         return bgp_config
 


### PR DESCRIPTION
The code keeps breaking on this line: https://github.com/napalm-automation/napalm/blob/develop/napalm/junos/junos.py#L1339 
when there is a key that is not included in the [_GROUP_FIELDS_DATATYPE_MAP_](https://github.com/napalm-automation/napalm/blob/develop/napalm/junos/junos.py#L1247)
In particular, for the group names "multihop" and "cluster" this is a problem because it will inevitably show up in the router configs, but the datatype will always be None, which will provoke this error:
ValueError: Can't convert with callable None - no default is defined for this type.
originating from [here](https://github.com/napalm-automation/napalm/blob/develop/napalm/base/helpers.py#L471)

In previous versions, this `convert` function was not doing the type checks, so if it was just returning None. The value for this case is irrelevant because both are deleted from the config further ([here](https://github.com/napalm-automation/napalm/blob/develop/napalm/junos/junos.py#L1358) and [here](https://github.com/napalm-automation/napalm/blob/develop/napalm/junos/junos.py#L1438)), respectively. Their existence in the config is temporary and not necessary - it is only used to produce/update other values ([here](https://github.com/napalm-automation/napalm/blob/develop/napalm/junos/junos.py#L1359) and [here](https://github.com/napalm-automation/napalm/blob/develop/napalm/junos/junos.py#L1414))

Therefore, I added here a conditional clause that never adds them to the final bgp config, so there is no need to delete it further ahead. Instead, a separate object is created for validation.

Issue: https://github.com/napalm-automation/napalm/issues/1932
