### PR TITLE
eos: Save running-config for rollback instead of startup-config (fixes issue #1952).

### DIFF
--- a/napalm/eos/eos.py
+++ b/napalm/eos/eos.py
@@ -508,7 +508,7 @@ class EOSDriver(NetworkDriver):
                 raise CommitError("Pending commit confirm already in process!")
 
             commands = [
-                "copy startup-config flash:rollback-0",
+                "copy running-config flash:rollback-0",
                 "configure session {} commit timer {}".format(
                     self.config_session,
                     time.strftime("%H:%M:%S", time.gmtime(revert_in)),
@@ -517,7 +517,7 @@ class EOSDriver(NetworkDriver):
             self._run_commands(commands, encoding="text")
         else:
             commands = [
-                "copy startup-config flash:rollback-0",
+                "copy running-config flash:rollback-0",
                 "configure session {} commit".format(self.config_session),
                 "write memory",
             ]


### PR DESCRIPTION
As per [issue](https://github.com/napalm-automation/napalm/issues/1952), I believe it should save the running config for rollback, not the startup config, which could be different to the running config if changes have been made since the last `write memory`.
