### PR TITLE
Add format optional parameter to core drivers to support JUNOS get_config

### DIFF
--- a/napalm/eos/eos.py
+++ b/napalm/eos/eos.py
@@ -2063,7 +2063,7 @@ class EOSDriver(NetworkDriver):
 
         return optics_detail
 
-    def get_config(self, retrieve="all", full=False, sanitized=False):
+    def get_config(self, retrieve="all", full=False, sanitized=False, format="text"):
         """get_config implementation for EOS."""
         get_startup = retrieve == "all" or retrieve == "startup"
         get_running = retrieve == "all" or retrieve == "running"

--- a/napalm/ios/ios.py
+++ b/napalm/ios/ios.py
@@ -3613,7 +3613,7 @@ class IOSDriver(NetworkDriver):
         except AttributeError:
             raise ValueError("The vrf %s does not exist" % name)
 
-    def get_config(self, retrieve="all", full=False, sanitized=False):
+    def get_config(self, retrieve="all", full=False, sanitized=False, format="text"):
         """Implementation of get_config for IOS.
 
         Returns the startup or/and running configuration as dictionary.

--- a/napalm/iosxr/iosxr.py
+++ b/napalm/iosxr/iosxr.py
@@ -2318,7 +2318,7 @@ class IOSXRDriver(NetworkDriver):
 
         return users
 
-    def get_config(self, retrieve="all", full=False, sanitized=False):
+    def get_config(self, retrieve="all", full=False, sanitized=False, format="text"):
         config = {"startup": "", "running": "", "candidate": ""}  # default values
 
         # IOS-XR only supports "all" on "show run"

--- a/napalm/iosxr_netconf/iosxr_netconf.py
+++ b/napalm/iosxr_netconf/iosxr_netconf.py
@@ -3111,7 +3111,7 @@ class IOSXRNETCONFDriver(NetworkDriver):
 
         return users
 
-    def get_config(self, retrieve="all", full=False, sanitized=False):
+    def get_config(self, retrieve="all", full=False, sanitized=False, format="text"):
         """Return device configuration."""
 
         encoding = self.config_encoding

--- a/napalm/junos/junos.py
+++ b/napalm/junos/junos.py
@@ -2435,10 +2435,11 @@ class JunOSDriver(NetworkDriver):
 
         return optics_detail
 
-    def get_config(self, retrieve="all", full=False, sanitized=False):
+    def get_config(self, retrieve="all", full=False, sanitized=False, format="text"):
         rv = {"startup": "", "running": "", "candidate": ""}
 
-        options = {"format": "text", "database": "candidate"}
+        self.format = format
+        options = {"format": self.format, "database": "candidate"}
         sanitize_strings = {
             r"^(\s+community\s+)\w+(;.*|\s+{.*)$": r"\1<removed>\2",
             r'^(.*)"\$\d\$\S+"(;.*)$': r"\1<removed>\2",

--- a/napalm/nxos/nxos.py
+++ b/napalm/nxos/nxos.py
@@ -583,7 +583,7 @@ class NXOSDriverBase(NetworkDriver):
         self._send_command_list(["terminal dont-ask"])
 
     def get_config(
-        self, retrieve: str = "all", full: bool = False, sanitized: bool = False
+        self, retrieve: str = "all", full: bool = False, sanitized: bool = False, format: str = "text"
     ) -> models.ConfigDict:
         # NX-OS adds some extra, unneeded lines that should be filtered.
         filter_strings = [


### PR DESCRIPTION
Add format optional parameter to core drivers to support JUNOS get_config text option.

Related to problem #1105