### PR TITLE
Update nxos.py to expose file transfer errors

### DIFF
--- a/napalm/nxos/nxos.py
+++ b/napalm/nxos/nxos.py
@@ -157,11 +157,11 @@ class NXOSDriverBase(NetworkDriver):
             )
             if not transfer_result["file_exists"]:
                 raise ValueError()
-        except Exception:
+        except Exception as e:
             msg = (
                 "Could not transfer file. There was an error "
                 "during transfer. Please make sure remote "
-                "permissions are set."
+                f"permissions are set. Caught Error:\n{repr(str(e))}"
             )
             raise ReplaceConfigException(msg)
 


### PR DESCRIPTION
Napalm was catching file transfer errors for NXOS without providing adequate details to debug. This change will expose the caught error 