### PR TITLE
Use isinstance(list) instead of types comparison in napalm/base/validate.py#L165

### DIFF
--- a/napalm/base/validate.py
+++ b/napalm/base/validate.py
@@ -162,7 +162,7 @@ def compare(
             else:
                 return src == dst
 
-    elif type(src) == type(dst) == list:
+    elif isinstance(src, list) and isinstance(dst, list):
         pairs = zip(src, dst)
         diff_lists = [
             [(k, x[k], y[k]) for k in x if not re.search(x[k], y[k])]


### PR DESCRIPTION
Fixes #1984 

Use isinstance(list) instead of types comparison in [napalm/base/validate.py#L165](https://github.com/napalm-automation/napalm/blob/develop/napalm/base/validate.py#L165)