### PR TITLE
Remove future requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@ setuptools>=38.4.0
 cffi>=1.11.3
 paramiko>=2.6.0
 requests>=2.7.0
-future
 textfsm
 jinja2
 netaddr


### PR DESCRIPTION
Now that we support Python >= 3.7, we can remove the requirement on the future module, which appears to be unused.