### PR TITLE
Bump black to 24.3.0 and format files

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,4 +1,5 @@
 """conf.py."""
+
 # -*- coding: utf-8 -*-
 #
 # napalm documentation build configuration file, created by

--- a/napalm/base/helpers.py
+++ b/napalm/base/helpers.py
@@ -1,4 +1,5 @@
 """Helper functions for the NAPALM base."""
+
 import ipaddress
 import itertools
 import logging

--- a/napalm/base/test/conftest.py
+++ b/napalm/base/test/conftest.py
@@ -1,4 +1,5 @@
 """Test fixtures."""
+
 import ast
 import json
 import os

--- a/napalm/base/test/double.py
+++ b/napalm/base/test/double.py
@@ -1,4 +1,5 @@
 """Base class for Test doubles."""
+
 import json
 import re
 import os

--- a/napalm/base/test/getters.py
+++ b/napalm/base/test/getters.py
@@ -1,4 +1,5 @@
 """Testing framework."""
+
 import functools
 from itertools import zip_longest
 import inspect

--- a/napalm/base/utils/jinja_filters.py
+++ b/napalm/base/utils/jinja_filters.py
@@ -1,4 +1,5 @@
 """Some common jinja filters."""
+
 from typing import Dict, Any
 
 

--- a/napalm/base/utils/string_parsers.py
+++ b/napalm/base/utils/string_parsers.py
@@ -1,4 +1,5 @@
 """ Common methods to normalize a string """
+
 import re
 import struct
 from typing import Union, List, Iterable, Dict, Optional, Tuple

--- a/napalm/base/validate.py
+++ b/napalm/base/validate.py
@@ -3,6 +3,7 @@ Validation methods for the NAPALM base.
 
 See: https://napalm.readthedocs.io/en/latest/validate.html
 """
+
 import yaml
 import copy
 import re

--- a/napalm/eos/eos.py
+++ b/napalm/eos/eos.py
@@ -1395,7 +1395,7 @@ class EOSDriver(NetworkDriver):
                         interface_details.get("linkLocal", {})
                         .get("subnet", "::/0")
                         .split("/")[-1]
-                    )
+                    ),
                     # when no link-local set, address will be None and maslken 0
                 }
             )

--- a/napalm/eos/utils/versions.py
+++ b/napalm/eos/utils/versions.py
@@ -1,4 +1,5 @@
 """Some functions to work with EOS version numbers"""
+
 import re
 
 

--- a/napalm/ios/ios.py
+++ b/napalm/ios/ios.py
@@ -1,4 +1,5 @@
 """NAPALM Cisco IOS Handler."""
+
 # Copyright 2015 Spotify AB. All rights reserved.
 #
 # The contents of this file are licensed under the Apache License, Version 2.0
@@ -2100,46 +2101,54 @@ class IOSDriver(NetworkDriver):
                 "up": neigh["up"] != "never",
                 "local_as": napalm.base.helpers.as_number(neigh["local_as"]),
                 "remote_as": napalm.base.helpers.as_number(neigh["remote_as"]),
-                "router_id": napalm.base.helpers.ip(bgp_neigh["router_id"])
-                if bgp_neigh["router_id"]
-                else "",
-                "local_address": napalm.base.helpers.ip(bgp_neigh["local_address"])
-                if bgp_neigh["local_address"]
-                else "",
+                "router_id": (
+                    napalm.base.helpers.ip(bgp_neigh["router_id"])
+                    if bgp_neigh["router_id"]
+                    else ""
+                ),
+                "local_address": (
+                    napalm.base.helpers.ip(bgp_neigh["local_address"])
+                    if bgp_neigh["local_address"]
+                    else ""
+                ),
                 "local_address_configured": False,
-                "local_port": napalm.base.helpers.as_number(bgp_neigh["local_port"])
-                if bgp_neigh["local_port"]
-                else 0,
+                "local_port": (
+                    napalm.base.helpers.as_number(bgp_neigh["local_port"])
+                    if bgp_neigh["local_port"]
+                    else 0
+                ),
                 "routing_table": bgp_neigh["vrf"] if bgp_neigh["vrf"] else "global",
                 "remote_address": napalm.base.helpers.ip(bgp_neigh["neighbor"]),
-                "remote_port": napalm.base.helpers.as_number(bgp_neigh["remote_port"])
-                if bgp_neigh["remote_port"]
-                else 0,
+                "remote_port": (
+                    napalm.base.helpers.as_number(bgp_neigh["remote_port"])
+                    if bgp_neigh["remote_port"]
+                    else 0
+                ),
                 "multihop": False,
                 "multipath": False,
                 "remove_private_as": False,
                 "import_policy": "",
                 "export_policy": "",
-                "input_messages": napalm.base.helpers.as_number(
-                    bgp_neigh["msg_total_in"]
-                )
-                if bgp_neigh["msg_total_in"]
-                else 0,
-                "output_messages": napalm.base.helpers.as_number(
-                    bgp_neigh["msg_total_out"]
-                )
-                if bgp_neigh["msg_total_out"]
-                else 0,
-                "input_updates": napalm.base.helpers.as_number(
-                    bgp_neigh["msg_update_in"]
-                )
-                if bgp_neigh["msg_update_in"]
-                else 0,
-                "output_updates": napalm.base.helpers.as_number(
-                    bgp_neigh["msg_update_out"]
-                )
-                if bgp_neigh["msg_update_out"]
-                else 0,
+                "input_messages": (
+                    napalm.base.helpers.as_number(bgp_neigh["msg_total_in"])
+                    if bgp_neigh["msg_total_in"]
+                    else 0
+                ),
+                "output_messages": (
+                    napalm.base.helpers.as_number(bgp_neigh["msg_total_out"])
+                    if bgp_neigh["msg_total_out"]
+                    else 0
+                ),
+                "input_updates": (
+                    napalm.base.helpers.as_number(bgp_neigh["msg_update_in"])
+                    if bgp_neigh["msg_update_in"]
+                    else 0
+                ),
+                "output_updates": (
+                    napalm.base.helpers.as_number(bgp_neigh["msg_update_out"])
+                    if bgp_neigh["msg_update_out"]
+                    else 0
+                ),
                 "messages_queued_out": napalm.base.helpers.as_number(neigh["out_q"]),
                 "connection_state": bgp_neigh["bgp_state"],
                 "previous_connection_state": "",
@@ -2150,13 +2159,17 @@ class IOSDriver(NetworkDriver):
                     else False
                 ),
                 "local_as_prepend": False,
-                "holdtime": napalm.base.helpers.as_number(bgp_neigh["holdtime"])
-                if bgp_neigh["holdtime"]
-                else 0,
+                "holdtime": (
+                    napalm.base.helpers.as_number(bgp_neigh["holdtime"])
+                    if bgp_neigh["holdtime"]
+                    else 0
+                ),
                 "configured_holdtime": 0,
-                "keepalive": napalm.base.helpers.as_number(bgp_neigh["keepalive"])
-                if bgp_neigh["keepalive"]
-                else 0,
+                "keepalive": (
+                    napalm.base.helpers.as_number(bgp_neigh["keepalive"])
+                    if bgp_neigh["keepalive"]
+                    else 0
+                ),
                 "configured_keepalive": 0,
                 "active_prefix_count": 0,
                 "received_prefix_count": 0,
@@ -3209,10 +3222,10 @@ class IOSDriver(NetworkDriver):
                             # was not specified
                             if protocol == "" or protocol == route_entry["protocol"]:
                                 if route_proto == "bgp":
-                                    route_entry[
-                                        "protocol_attributes"
-                                    ] = self._get_bgp_route_attr(
-                                        destination, _vrf, nh, ip_version
+                                    route_entry["protocol_attributes"] = (
+                                        self._get_bgp_route_attr(
+                                            destination, _vrf, nh, ip_version
+                                        )
                                     )
                                 nh_line_found = (
                                     False  # for next RT entry processing ...
@@ -3305,12 +3318,16 @@ class IOSDriver(NetworkDriver):
             output = self._send_command(command)
         for match in re.finditer(username_regex, output, re.M):
             users[match.groupdict()["username"]] = {
-                "level": int(match.groupdict()["priv_level"])
-                if match.groupdict()["priv_level"]
-                else 1,
-                "password": match.groupdict()["pwd_hash"]
-                if match.groupdict()["pwd_hash"]
-                else "",
+                "level": (
+                    int(match.groupdict()["priv_level"])
+                    if match.groupdict()["priv_level"]
+                    else 1
+                ),
+                "password": (
+                    match.groupdict()["pwd_hash"]
+                    if match.groupdict()["pwd_hash"]
+                    else ""
+                ),
                 "sshkeys": [],
             }
         for match in re.finditer(pub_keychain_regex, output, re.M):

--- a/napalm/iosxr/iosxr.py
+++ b/napalm/iosxr/iosxr.py
@@ -318,9 +318,9 @@ class IOSXRDriver(NetworkDriver):
                     "is_enabled": enabled,
                     "mac_address": mac_address,
                     "description": description,
-                    "last_flapped": last_flapped / 1e9
-                    if last_flapped != -1.0
-                    else -1.0,
+                    "last_flapped": (
+                        last_flapped / 1e9 if last_flapped != -1.0 else -1.0
+                    ),
                 }
             )
 
@@ -587,23 +587,23 @@ class IOSXRDriver(NetworkDriver):
                         ),
                         0,
                     )
-                    this_neighbor["address_family"][this_afi][
-                        "accepted_prefixes"
-                    ] = napalm.base.helpers.convert(
-                        int,
-                        napalm.base.helpers.find_txt(
-                            neighbor, "AFData/Entry/PrefixesAccepted"
-                        ),
-                        0,
+                    this_neighbor["address_family"][this_afi]["accepted_prefixes"] = (
+                        napalm.base.helpers.convert(
+                            int,
+                            napalm.base.helpers.find_txt(
+                                neighbor, "AFData/Entry/PrefixesAccepted"
+                            ),
+                            0,
+                        )
                     )
-                    this_neighbor["address_family"][this_afi][
-                        "sent_prefixes"
-                    ] = napalm.base.helpers.convert(
-                        int,
-                        napalm.base.helpers.find_txt(
-                            neighbor, "AFData/Entry/PrefixesAdvertised"
-                        ),
-                        0,
+                    this_neighbor["address_family"][this_afi]["sent_prefixes"] = (
+                        napalm.base.helpers.convert(
+                            int,
+                            napalm.base.helpers.find_txt(
+                                neighbor, "AFData/Entry/PrefixesAdvertised"
+                            ),
+                            0,
+                        )
                     )
                 except AttributeError:
                     this_neighbor["address_family"][this_afi]["received_prefixes"] = -1
@@ -947,11 +947,11 @@ class IOSXRDriver(NetworkDriver):
             try:
                 cli_output[str(command)] = str(self.device._execute_show(command))
             except TimeoutError:
-                cli_output[
-                    str(command)
-                ] = 'Execution of command \
+                cli_output[str(command)] = (
+                    'Execution of command \
                     "{command}" took too long! Please adjust your params!'.format(
-                    command=command
+                        command=command
+                    )
                 )
                 logger.error(str(cli_output))
                 raise CommandTimeoutException(str(cli_output))
@@ -2288,9 +2288,9 @@ class IOSXRDriver(NetworkDriver):
                 last_probe_host_name = tag_value
                 continue
             if tag_name == "DeltaTime":
-                last_hop_dict["probes"][last_probe_index][
-                    "rtt"
-                ] = napalm.base.helpers.convert(float, tag_value, 0.0)
+                last_hop_dict["probes"][last_probe_index]["rtt"] = (
+                    napalm.base.helpers.convert(float, tag_value, 0.0)
+                )
                 continue
 
         if last_hop_index:

--- a/napalm/iosxr_netconf/iosxr_netconf.py
+++ b/napalm/iosxr_netconf/iosxr_netconf.py
@@ -801,30 +801,30 @@ class IOSXRNETCONFDriver(NetworkDriver):
                         ),
                         0,
                     )
-                    this_neighbor["address_family"][this_afi][
-                        "accepted_prefixes"
-                    ] = napalm.base.helpers.convert(
-                        int,
-                        self._find_txt(
-                            neighbor,
-                            "./bgp:af-data/bgp:prefixes-accepted",
-                            default="",
-                            namespaces=C.NS,
-                        ),
-                        0,
+                    this_neighbor["address_family"][this_afi]["accepted_prefixes"] = (
+                        napalm.base.helpers.convert(
+                            int,
+                            self._find_txt(
+                                neighbor,
+                                "./bgp:af-data/bgp:prefixes-accepted",
+                                default="",
+                                namespaces=C.NS,
+                            ),
+                            0,
+                        )
                     )
-                    this_neighbor["address_family"][this_afi][
-                        "sent_prefixes"
-                    ] = napalm.base.helpers.convert(
-                        int,
-                        self._find_txt(
-                            neighbor,
-                            "./bgp:af-data/\
+                    this_neighbor["address_family"][this_afi]["sent_prefixes"] = (
+                        napalm.base.helpers.convert(
+                            int,
+                            self._find_txt(
+                                neighbor,
+                                "./bgp:af-data/\
                             bgp:prefixes-advertised",
-                            default="",
-                            namespaces=C.NS,
-                        ),
-                        0,
+                                default="",
+                                namespaces=C.NS,
+                            ),
+                            0,
+                        )
                     )
                 except AttributeError:
                     this_neighbor["address_family"][this_afi]["received_prefixes"] = -1

--- a/napalm/junos/junos.py
+++ b/napalm/junos/junos.py
@@ -1484,7 +1484,7 @@ class JunOSDriver(NetworkDriver):
             "RemovePrivateAS": "remove_private_as",
             "Multipath": "multipath",
             "Multihop": "multihop",
-            "AddressFamily": "local_address_configured"
+            "AddressFamily": "local_address_configured",
             # 'AuthKey'        : 'authentication_key_set'
             # but other vendors do not specify if auth key is set
             # other options:
@@ -1728,7 +1728,7 @@ class JunOSDriver(NetworkDriver):
 
         _FAMILY_VMAP_ = {
             "inet": "ipv4",
-            "inet6": "ipv6"
+            "inet6": "ipv6",
             # can add more mappings
         }
         _FAMILY_MAX_PREFIXLEN = {"inet": 32, "inet6": 128}

--- a/napalm/junos/utils/junos_views.py
+++ b/napalm/junos/utils/junos_views.py
@@ -1,6 +1,7 @@
 """
 Load tables/views
 """
+
 import yaml
 import re
 from jnpr.junos.factory import FactoryLoader

--- a/napalm/nxapi_plumbing/__init__.py
+++ b/napalm/nxapi_plumbing/__init__.py
@@ -3,6 +3,7 @@ Fork of pynxos library from network to code and mzbenami
 
 Re-implemented by ktbyers to support XML-RPC in addition to JSON-RPC
 """
+
 from napalm.nxapi_plumbing.device import Device
 from napalm.nxapi_plumbing.api_client import RPCClient, XMLClient
 from napalm.nxapi_plumbing.errors import (

--- a/napalm/nxapi_plumbing/api_client.py
+++ b/napalm/nxapi_plumbing/api_client.py
@@ -3,6 +3,7 @@ Fork of pynxos library from network to code and mzbenami
 
 Reimplemented by ktbyers to support XML-RPC in addition to JSON-RPC
 """
+
 from __future__ import print_function, unicode_literals
 
 from builtins import super

--- a/napalm/nxos/nxos.py
+++ b/napalm/nxos/nxos.py
@@ -669,15 +669,15 @@ class NXOSDriverBase(NetworkDriver):
             # Add field missing on IOS
             lldp_entry["parent_interface"] = ""
             # Translate the capability fields
-            lldp_entry[
-                "remote_system_capab"
-            ] = napalm.base.helpers.transform_lldp_capab(
-                lldp_entry["remote_system_capab"]
+            lldp_entry["remote_system_capab"] = (
+                napalm.base.helpers.transform_lldp_capab(
+                    lldp_entry["remote_system_capab"]
+                )
             )
-            lldp_entry[
-                "remote_system_enable_capab"
-            ] = napalm.base.helpers.transform_lldp_capab(
-                lldp_entry["remote_system_enable_capab"]
+            lldp_entry["remote_system_enable_capab"] = (
+                napalm.base.helpers.transform_lldp_capab(
+                    lldp_entry["remote_system_enable_capab"]
+                )
             )
             # Turn the interfaces into their long version
             local_intf = canonical_interface_name(local_intf)

--- a/napalm/nxos_ssh/nxos_ssh.py
+++ b/napalm/nxos_ssh/nxos_ssh.py
@@ -1485,9 +1485,9 @@ class NXOSSSHDriver(NXOSDriverBase):
                                 "preference": int(nh_metric),
                             }
                             if nh_source == "bgp":
-                                route_entry[
-                                    "protocol_attributes"
-                                ] = self._get_bgp_route_attr(cur_prefix, curvrf, nh_ip)
+                                route_entry["protocol_attributes"] = (
+                                    self._get_bgp_route_attr(cur_prefix, curvrf, nh_ip)
+                                )
                             else:
                                 route_entry["protocol_attributes"] = {}
                             nh_list.append(route_entry)

--- a/napalm/pyIOSXR/exceptions.py
+++ b/napalm/pyIOSXR/exceptions.py
@@ -43,7 +43,6 @@ class ConnectError(IOSXRException):
 
 
 class CommitError(IOSXRException):
-
     """Raised when unable to commit. Mostly due to ERROR 0x41866c00"""
 
     pass

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-black==23.3.0
+black==24.3.0
 coveralls==3.3.1
 ddt==1.6.0
 flake8-import-order==0.18.2

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 """setup.py file."""
+
 from setuptools import setup, find_packages
 
 with open("requirements.txt", "r") as fs:

--- a/test/base/test_get_network_driver.py
+++ b/test/base/test_get_network_driver.py
@@ -1,4 +1,5 @@
 """Test the method get_network_driver."""
+
 import unittest
 from ddt import ddt, data
 

--- a/test/base/validate/test_unit.py
+++ b/test/base/validate/test_unit.py
@@ -1,4 +1,5 @@
 """Tests for the validate methods."""
+
 import pytest
 import copy
 

--- a/test/base/validate/test_validate.py
+++ b/test/base/validate/test_validate.py
@@ -1,4 +1,5 @@
 """Tests for the validate operation."""
+
 import json
 import os
 import yaml

--- a/test/eos/conftest.py
+++ b/test/eos/conftest.py
@@ -1,4 +1,5 @@
 """Test fixtures."""
+
 from builtins import super
 
 import pytest

--- a/test/eos/test_versions.py
+++ b/test/eos/test_versions.py
@@ -1,4 +1,5 @@
 """Tests for versions utils"""
+
 from napalm.eos.utils.versions import EOSVersion
 
 

--- a/test/ios/conftest.py
+++ b/test/ios/conftest.py
@@ -1,4 +1,5 @@
 """Test fixtures."""
+
 from builtins import super
 
 import pytest

--- a/test/ios/test_getters.py
+++ b/test/ios/test_getters.py
@@ -1,4 +1,5 @@
 """Tests for getters."""
+
 from napalm.base.test.getters import BaseTestGetters
 import pytest
 

--- a/test/iosxr/conftest.py
+++ b/test/iosxr/conftest.py
@@ -1,4 +1,5 @@
 """Test fixtures."""
+
 from builtins import super
 
 import pytest

--- a/test/iosxr/test_getters.py
+++ b/test/iosxr/test_getters.py
@@ -1,4 +1,5 @@
 """Tests for getters."""
+
 from napalm.base.test.getters import BaseTestGetters
 import pytest
 

--- a/test/iosxr_netconf/conftest.py
+++ b/test/iosxr_netconf/conftest.py
@@ -1,4 +1,5 @@
 """Test fixtures."""
+
 import pytest
 from lxml import etree
 from napalm.base.test import conftest as parent_conftest

--- a/test/iosxr_netconf/test_getters.py
+++ b/test/iosxr_netconf/test_getters.py
@@ -1,4 +1,5 @@
 """Tests for getters."""
+
 from napalm.base.test.getters import BaseTestGetters
 import pytest
 

--- a/test/junos/TestJunOSDriver.py
+++ b/test/junos/TestJunOSDriver.py
@@ -95,7 +95,6 @@ class FakeJunOSDevice:
 
 
 class FakeRPCObject:
-
     """
     Fake RPC caller.
     """
@@ -144,7 +143,6 @@ class FakeRPCObject:
 
 
 class FakeConnectionRPCObject:
-
     """
     Will make fake RPC requests that usually are directly made via netconf.
     """

--- a/test/junos/conftest.py
+++ b/test/junos/conftest.py
@@ -1,4 +1,5 @@
 """Test fixtures."""
+
 import copy
 
 import lxml
@@ -126,7 +127,6 @@ class FakeJunOSDevice(BaseTestDouble):
 
 
 class FakeRPCObject:
-
     """
     Fake RPC caller.
     """
@@ -170,7 +170,6 @@ class FakeRPCObject:
 
 
 class FakeConnectionRPCObject:
-
     """
     Will make fake RPC requests that usually are directly made via netconf.
     """

--- a/test/nxos/conftest.py
+++ b/test/nxos/conftest.py
@@ -1,4 +1,5 @@
 """Test fixtures."""
+
 from builtins import super
 
 import pytest

--- a/test/nxos_ssh/conftest.py
+++ b/test/nxos_ssh/conftest.py
@@ -1,4 +1,5 @@
 """Test fixtures."""
+
 from builtins import super
 
 import pytest

--- a/test/pyiosxr/test_iosxr.py
+++ b/test/pyiosxr/test_iosxr.py
@@ -24,7 +24,6 @@ from napalm.pyIOSXR.exceptions import InvalidXMLResponse
 
 
 class _MockedNetMikoDevice(object):
-
     """
     Defines the minimum attributes necessary to mock a SSH connection using netmiko.
     """
@@ -97,7 +96,6 @@ class _MockedNetMikoDevice(object):
 
 
 class _MockedIOSXRDevice(IOSXR):
-
     """
     Overrides only the very basic methods from the main device driver, that cannot be mocked.
     """
@@ -112,7 +110,6 @@ class _MockedIOSXRDevice(IOSXR):
 
 
 class TestIOSXRDevice(unittest.TestCase):
-
     """
     Tests IOS-XR basic functions.
     """


### PR DESCRIPTION
Updating black due to [CVE-2024-21503](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-21503), which also brings some small formatting changes.