### PR TITLE
fix: documentation build

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -12,9 +12,12 @@ sphinx:
 # Optionally build your docs in additional formats such as PDF and ePub
 formats: all
 
-# Optionally set the version of Python and requirements required to build your docs
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+
 python:
-  version: 3.8
   install:
     - method: pip
       path: .


### PR DESCRIPTION
Fix: #2065

I've upgraded python version to 3.11 as the github CI for the doc use 3.11