### PR TITLE
Fixes napalm-automation/napalm#2086 stripping whitespace

### DIFF
--- a/napalm/ios/ios.py
+++ b/napalm/ios/ios.py
@@ -3796,7 +3796,7 @@ class IOSDriver(NetworkDriver):
             output = self._send_command("show vlan id {}".format(vlan_id))
             _vlans = self._get_vlan_all_ports(output)
             if len(_vlans) == 0:
-                vlans[vlan_id] = {"name": vlan_name, "interfaces": []}
+                vlans[vlan_id] = {"name": vlan_name.strip(), "interfaces": []}
             elif len(_vlans) == 1:
                 vlans.update(_vlans)
             elif len(_vlans.keys()) > 1:


### PR DESCRIPTION
VLAN names are cleaned up if the ports are in the `self._get_vlan_all_ports(output)` function. However,  if no ports are found the whitespace remains.

The change removes the whitespace if no ports are found in `ios.py` line 3797

