### PR TITLE
nxos: Remove duplicate code for test_get_interfaces

### DIFF
--- a/test/nxos/test_getters.py
+++ b/test/nxos/test_getters.py
@@ -1,8 +1,6 @@
 """Tests for getters."""
 
-from napalm.base.test.getters import BaseTestGetters, wrap_test_cases
-from napalm.base.test import helpers
-from napalm.base import models
+from napalm.base.test.getters import BaseTestGetters
 
 import pytest
 from mock import patch
@@ -16,14 +14,6 @@ def mock_time():
 class TestGetter(BaseTestGetters):
     """Test get_* methods."""
 
-    @patch("time.time", mock_time)
-    @wrap_test_cases
-    def test_get_interfaces(self, test_case):
-        """Test get_interfaces."""
-        get_interfaces = self.device.get_interfaces()
-        assert len(get_interfaces) > 0
-
-        for interface, interface_data in get_interfaces.items():
-            assert helpers.test_model(models.InterfaceDict, interface_data)
-
-        return get_interfaces
+    test_get_interfaces = patch("time.time", mock_time)(
+        BaseTestGetters.test_get_interfaces
+    )


### PR DESCRIPTION
test_get_interfaces contains duplicate code from the superclass. Simplify it by just adding the local mock wrapper but without copying the code.