### PR TITLE
nxos: implement uptime for get_bgp_neighbors

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -13,5 +13,6 @@ types-PyYAML==6.0.12.20240311
 types-requests==2.32.0.20240521
 types-six==1.16.21.20240513
 types-setuptools==69.5.0.20240522
+types-python-dateutil
 ttp==0.9.5
 ttp_templates==0.3.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ ttp
 ttp_templates
 netutils>=1.0.0
 typing-extensions>=4.3.0
+python-dateutil

--- a/test/nxos/mocked_data/test_get_bgp_neighbors/issue_870/expected_result.json
+++ b/test/nxos/mocked_data/test_get_bgp_neighbors/issue_870/expected_result.json
@@ -159,7 +159,7 @@
             "received_prefixes": 13
           }
         }, 
-        "uptime": -1, 
+        "uptime": 4088562,
         "remote_as": 64862, 
         "description": "", 
         "remote_id": "10.1.1.179", 
@@ -175,7 +175,7 @@
             "received_prefixes": 0 
           }
         }, 
-        "uptime": -1, 
+        "uptime": 1496562,
         "remote_as": 64862, 
         "description": "", 
         "remote_id": "10.1.1.177", 

--- a/test/nxos/mocked_data/test_get_bgp_neighbors/issue_870/show_bgp_all_summary_vrf_all.json
+++ b/test/nxos/mocked_data/test_get_bgp_neighbors/issue_870/show_bgp_all_summary_vrf_all.json
@@ -57,7 +57,7 @@
                             "inq": "0",
                             "outq": "0",
                             "neighboras": "64862",
-                            "time": "6w3d",
+                            "time": "P1M17DT7H42M42S",
                             "state": "Established",
                             "prefixreceived": "13"
                           }

--- a/test/nxos/test_getters.py
+++ b/test/nxos/test_getters.py
@@ -27,3 +27,7 @@ class TestGetter(BaseTestGetters):
             assert helpers.test_model(models.InterfaceDict, interface_data)
 
         return get_interfaces
+
+    test_get_bgp_neighbors = patch("time.time", mock_time)(
+        BaseTestGetters.test_get_bgp_neighbors
+    )


### PR DESCRIPTION
This adds a dependency on python-dateutil to calculate years and months lengths, depending on the current date. Alternatively we can just go for a fixed arbitrary time length for years and months.