### PR TITLE
EOS bugfix - newer EOS reports RPKI validation info

### DIFF
--- a/napalm/eos/eos.py
+++ b/napalm/eos/eos.py
@@ -764,6 +764,18 @@ class EOSDriver(NetworkDriver):
             lines.pop(0)
             v4_stats = re.match(self._RE_BGP_PREFIX, lines.pop(0))
             v6_stats = re.match(self._RE_BGP_PREFIX, lines.pop(0))
+
+            # If RPKI validation is enabled, some versions of EOS report
+            # these values seperately, and they match RE_BGP_PREFIX and
+            # the NEIGHBOR_FILTER.
+            # However, changing those filters/regexes doesn't make sense
+            # because that would break backwards compatibility (EOS
+            # varies the number of fields in the lines that match
+            # RE_BGP_PREFIX nromally).  So we'll just strip out the RPKI
+            # lines.
+            while re.match(self._RE_BGP_PREFIX, lines[0]):
+                lines.pop(0)
+
             local_as = re.match(self._RE_BGP_LOCAL, lines.pop(0))
             data = {
                 "remote_as": napalm.base.helpers.as_number(neighbor_info.group("as")),

--- a/test/eos/mocked_data/test_get_bgp_neighbors/normal/show_ip_bgp_neighbors_vrf_all___include_IPv_46___Unicast_6PE_____0_9_____grep__v___IPv_46__Unicast_______remote_AS___Local_AS_Desc_BGP_state__remote_r.text
+++ b/test/eos/mocked_data/test_get_bgp_neighbors/normal/show_ip_bgp_neighbors_vrf_all___include_IPv_46___Unicast_6PE_____0_9_____grep__v___IPv_46__Unicast_______remote_AS___Local_AS_Desc_BGP_state__remote_r.text
@@ -9,4 +9,6 @@ BGP neighbor is 192.168.56.4, remote AS 65001, external link
   BGP state is Established, up for   32d16h
     IPv4 Unicast:           0         0
     IPv6 Unicast:           0         0
+    IPv4 Unicast:        200000             1        200000
+    IPv6 Unicast:             0             0             0
 Local AS is 65002, local router ID 192.168.56.2


### PR DESCRIPTION
In newer versions of EOS, when `show ip bgp neighbor` (and similar IPv6 command) additional information is reported for RPKI.

For instance:
```
BGP neighbor is 192.0.2.1, remote AS 65001, external link
 Description: An Upstream
  BGP version 4, remote router ID 192.0.2.1, VRF default
  Inherits configuration from and member of peer-group FOO
  Last read 00:00:02, last write 00:00:14
  Hold time is 90, keepalive interval is 30 seconds
  Configured hold time is 180, keepalive interval is 60 seconds
  Effective minimum hold time is 3 seconds
  Send failure hold time is 0 seconds
  Hold timer is active, time left: 00:01:28
  Keepalive timer is active, time left: 00:00:09
  Connect timer is inactive
  Configured idle-restart time is 300 seconds
  Idle-restart timer is inactive
  BGP state is Established, up for 48d12h
  Number of transitions to established: 1
  Last state was OpenConfirm
  Last event was ReapplyInboundPolicy
  Last sent notification:Cease/connection collision resolution, Last time 48d12h
  Types of communities advertised: standard extended large
  Neighbor Capabilities:
    Multiprotocol IPv4 Unicast: advertised and received and negotiated
    Four Octet ASN: advertised and received and negotiated
    Route Refresh: advertised and received and negotiated
    Enhanced route refresh: advertised
    Send End-of-RIB messages: advertised and received and negotiated
    Additional-paths recv capability:
      IPv4 Unicast: advertised
    Additional-paths send capability:
  Restart timer is inactive
  End of rib timer is inactive
    IPv4 Unicast End-of-RIB received: Yes
      Received 48d12h
      Number of stale paths removed after graceful restart: 0
      Number of paths received before End-of-RIB: 363
  AIGP attribute send and receive for IPv4 Unicast are disabled
  AIGP attribute send and receive for IPv4 with MPLS Labels are disabled
  AIGP attribute send and receive for IPv6 Unicast are disabled
  AIGP attribute send and receive for IPv6 with MPLS Labels are disabled
  BGP session driven failover for IPv6 Unicast is disabled
  BGP session driven failover for IPv4 Unicast is disabled
  Message Statistics:
                         Sent      Rcvd
    Opens:                  1         2
    Notifications:          1         0
    Updates:               30   8489393
    Keepalives:        164001    139688
    Route Refresh:          0         0
    Total messages:    164033   8629083
  Prefix Statistics:
                                   Sent      Rcvd     Best Paths     Best ECMP Paths
    IPv4 Unicast:                    15    123456          12345                   1
    IPv6 Unicast:                     0         0              0                   0
  Configured maximum total number of routes is 1000000, warning limit is 800000
  AFI/SAFI import missing policy actions: 
  AFI/SAFI                Import Action    Import Status
  --------------------    -------------    ------------------------------
  IPv4 Unicast            permit           OK
  AFI/SAFI export missing policy actions: 
  AFI/SAFI                Export Action    Export Status
  --------------------    -------------    ------------------------------
  IPv4 Unicast            permit           OK
  Inbound updates dropped by reason:
    AS path loop detection: 1
    Cluster ID loop detection: 0
    Enforced First AS: 0
    Malformed MPBGP routes: 0
    Originator ID matches local router ID: 0
    Nexthop matches local IP address: 0
    Unexpected IPv6 nexthop for IPv4 routes: 0
  Inbound updates with attribute errors:
    Resulting in removal of all paths in update (treat as withdraw): 0
    Resulting in AFI/SAFI disable: 0
    Resulting in attribute ignore: 0
    Disabled AFI/SAFIs: None
  Inbound paths dropped by reason:
    IPv4 unicast NLRIs dropped due to martian prefix: 0
    IPv4 unicast NLRIs dropped due to maximum route limit violation: 0
    IPv6 unicast NLRIs dropped due to martian prefix: 0
    IPv4 labeled-unicast NLRIs dropped due to excessive labels: 0
    IPv4 labeled-unicast NLRIs dropped due to martian prefix: 0
    IPv6 labeled-unicast NLRIs dropped due to excessive labels: 0
    IPv6 labeled-unicast NLRIs dropped due to martian prefix: 0
    VPN-IPv4 NLRIs dropped due to route import match failure: 0
    VPN-IPv6 NLRIs dropped due to route import match failure: 0
    L2VPN EVPN NLRIs dropped due to route import match failure: 0
    L2VPN EVPN NLRIs dropped due to unsupported route type: 0
    Link-state NLRIs dropped because reception is unsupported: 0
    RT Membership NLRIs dropped due to local origin ASN received from external peer: 0
  Outbound paths dropped by reason:
    IPv4 local address not available: 0
    IPv6 local address not available: 0
  Inbound route map is POLICY-FOO-IN
  Outbound route map is FOO-OUT
  RPKI Origin Validation:
    use local ROA database
                          Valid       Invalid       Unknown
    IPv4 Unicast:        123456            15        123456
    IPv6 Unicast:             0             0             0
Local AS is 65002, local router ID 192.0.2.2
```

As a result, the `IPv4 Unicast:` lines appear twice after the NEIGHBOR_FILTER is applied in the EOS Napalm code, which causes a runtime error because the EOS Napalm code is expecting this to be the line that starts with `Local AS`.

The fix is to trim the extra RPKI-related `IPv[46] Unicast:` lines.