### PR TITLE
pytest wrapper should return None, not result

### DIFF
--- a/napalm/base/test/getters.py
+++ b/napalm/base/test/getters.py
@@ -90,7 +90,7 @@ def wrap_test_cases(func):
             attr.current_test = ""  # Empty them to avoid side effects
             attr.current_test_case = ""  # Empty them to avoid side effects
 
-        return result
+        return None
 
     @functools.wraps(func)
     def real_wrapper(cls, test_case):

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,8 +27,6 @@ python_files =
     test_*.py
     *_test.py
     tests.py
-json_report = report.json
-jsonapi = true
 
 [coverage:run]
 include =


### PR DESCRIPTION
While the wrapper does need the output of the wrapped function for processing, pytest complains for any test function that returns data.

Updates the wrapper function that processes mocked data to not return the wrapped function result.

Closes #2118