### PR TITLE
[eos] fix banner when transport is ssh

### DIFF
--- a/napalm/eos/eos.py
+++ b/napalm/eos/eos.py
@@ -427,10 +427,11 @@ class EOSDriver(NetworkDriver):
                 continue
             commands.append(line)
 
-        for start, depth in [
-            (s, d) for (s, d) in self.HEREDOC_COMMANDS if s in commands
-        ]:
-            commands = self._multiline_convert(commands, start=start, depth=depth)
+        if self.transport != "ssh":
+            for start, depth in [
+                (s, d) for (s, d) in self.HEREDOC_COMMANDS if s in commands
+            ]:
+                commands = self._multiline_convert(commands, start=start, depth=depth)
 
         commands = self._mode_comment_convert(commands)
 

--- a/napalm/eos/eos.py
+++ b/napalm/eos/eos.py
@@ -421,8 +421,6 @@ class EOSDriver(NetworkDriver):
 
         for line in lines:
             line = line.strip()
-            if line == "":
-                continue
             if line.startswith("!") and not line.startswith("!!"):
                 continue
             commands.append(line)
@@ -433,7 +431,7 @@ class EOSDriver(NetworkDriver):
             ]:
                 commands = self._multiline_convert(commands, start=start, depth=depth)
 
-        commands = self._mode_comment_convert(commands)
+            commands = self._mode_comment_convert(commands)
 
         if self.transport == "ssh":
             try:

--- a/test/eos/test_heredoc.py
+++ b/test/eos/test_heredoc.py
@@ -190,12 +190,12 @@ class TestConfigMangling(object):
             "ip name-server 192.0.2.1",
             {
                 "cmd": "banner login",
-                "input": "\nThis is a banner that spans\nmultiple lines in order to test\nHEREDOC conversion\n",
+                "input": "\nThis is a banner that spans\nmultiple lines in order to test\nHEREDOC conversion\n", #noqa
             },
             "management api http-commands",
             {
                 "cmd": "protocol https certificate",
-                "input": "---BEGIN CERTIFICATE---\nFAKE-CERTIFICATE-DATA\n---END CERTIFICATE---\nEOF\n---BEGIN PRIVATE KEY---\nFAKE-KEY-DATA\n---END PRIVATE KEY---",
+                "input": "---BEGIN CERTIFICATE---\nFAKE-CERTIFICATE-DATA\n---END CERTIFICATE---\nEOF\n---BEGIN PRIVATE KEY---\nFAKE-KEY-DATA\n---END PRIVATE KEY---", #noqa
             },
             "management ssh",
             "idle-timeout 15",

--- a/test/eos/test_heredoc.py
+++ b/test/eos/test_heredoc.py
@@ -190,12 +190,12 @@ class TestConfigMangling(object):
             "ip name-server 192.0.2.1",
             {
                 "cmd": "banner login",
-                "input": "\nThis is a banner that spans\nmultiple lines in order to test\nHEREDOC conversion\n",  #  noqa
+                "input": "\nThis is a banner that spans\nmultiple lines in order to test\nHEREDOC conversion\n",
             },
             "management api http-commands",
             {
                 "cmd": "protocol https certificate",
-                "input": "---BEGIN CERTIFICATE---\nFAKE-CERTIFICATE-DATA\n---END CERTIFICATE---\nEOF\n---BEGIN PRIVATE KEY---\nFAKE-KEY-DATA\n---END PRIVATE KEY---",  # noqa
+                "input": "---BEGIN CERTIFICATE---\nFAKE-CERTIFICATE-DATA\n---END CERTIFICATE---\nEOF\n---BEGIN PRIVATE KEY---\nFAKE-KEY-DATA\n---END PRIVATE KEY---",
             },
             "management ssh",
             "idle-timeout 15",

--- a/test/eos/test_heredoc.py
+++ b/test/eos/test_heredoc.py
@@ -190,12 +190,12 @@ class TestConfigMangling(object):
             "ip name-server 192.0.2.1",
             {
                 "cmd": "banner login",
-                "input": "\nThis is a banner that spans\nmultiple lines in order to test\nHEREDOC conversion\n", #noqa
+                "input": "\nThis is a banner that spans\nmultiple lines in order to test\nHEREDOC conversion\n",  # noqa
             },
             "management api http-commands",
             {
                 "cmd": "protocol https certificate",
-                "input": "---BEGIN CERTIFICATE---\nFAKE-CERTIFICATE-DATA\n---END CERTIFICATE---\nEOF\n---BEGIN PRIVATE KEY---\nFAKE-KEY-DATA\n---END PRIVATE KEY---", #noqa
+                "input": "---BEGIN CERTIFICATE---\nFAKE-CERTIFICATE-DATA\n---END CERTIFICATE---\nEOF\n---BEGIN PRIVATE KEY---\nFAKE-KEY-DATA\n---END PRIVATE KEY---",  # noqa
             },
             "management ssh",
             "idle-timeout 15",

--- a/test/eos/test_heredoc.py
+++ b/test/eos/test_heredoc.py
@@ -147,7 +147,7 @@ class TestConfigMangling(object):
         ]
 
         self.device.device.run_commands.assert_called_with(expected_result)
-    
+
     def test_heredoc_with_blank_lines(self):
         raw_config = dedent(
             """\

--- a/test/eos_ssh/conftest.py
+++ b/test/eos_ssh/conftest.py
@@ -68,4 +68,3 @@ class FakeEOSDevice(BaseTestDouble):
 
     def send_config_set(self, commands, **kwargs):
         return self.run_commands(commands)
-    

--- a/test/eos_ssh/conftest.py
+++ b/test/eos_ssh/conftest.py
@@ -38,11 +38,11 @@ class PatchedEOSDriver(eos.EOSDriver):
 
     def __init__(self, hostname, username, password, timeout=60, optional_args=None):
 
-        optional_args = {
-            "transport": "ssh"
-        }
+        optional_args = {"transport": "ssh"}
 
-        super().__init__(hostname, username, password, timeout, optional_args=optional_args)
+        super().__init__(
+            hostname, username, password, timeout, optional_args=optional_args
+        )
 
         self.patched_attrs = ["device"]
         self.device = FakeEOSDevice()
@@ -56,13 +56,14 @@ class PatchedEOSDriver(eos.EOSDriver):
     def open(self):
         pass
 
+
 class FakeEOSDevice(BaseTestDouble):
     """EOS device test double."""
 
     def __init__(self):
         super(FakeEOSDevice, self).__init__()
         self.connection = object()
-    
+
     def send_command_expect(self, command, **kwargs):
         return self.send_config_set([command])
 

--- a/test/eos_ssh/conftest.py
+++ b/test/eos_ssh/conftest.py
@@ -3,8 +3,6 @@
 from builtins import super
 
 import pytest
-import re
-from datetime import datetime
 
 from napalm.base.test import conftest as parent_conftest
 

--- a/test/eos_ssh/conftest.py
+++ b/test/eos_ssh/conftest.py
@@ -1,0 +1,71 @@
+"""Test fixtures."""
+
+from builtins import super
+
+import pytest
+import re
+from datetime import datetime
+
+from napalm.base.test import conftest as parent_conftest
+
+from napalm.base.test.double import BaseTestDouble
+
+from napalm.eos import eos
+
+
+@pytest.fixture(scope="class")
+def set_device_parameters(request):
+    """Set up the class."""
+
+    def fin():
+        request.cls.device.close()
+
+    request.addfinalizer(fin)
+
+    request.cls.driver = eos.EOSDriver
+    request.cls.patched_driver = PatchedEOSDriver
+    request.cls.vendor = "eos"
+    parent_conftest.set_device_parameters(request)
+
+
+def pytest_generate_tests(metafunc):
+    """Generate test cases dynamically."""
+    parent_conftest.pytest_generate_tests(metafunc, __file__)
+
+
+class PatchedEOSDriver(eos.EOSDriver):
+    """Patched EOS Driver."""
+
+    def __init__(self, hostname, username, password, timeout=60, optional_args=None):
+
+        optional_args = {
+            "transport": "ssh"
+        }
+
+        super().__init__(hostname, username, password, timeout, optional_args=optional_args)
+
+        self.patched_attrs = ["device"]
+        self.device = FakeEOSDevice()
+
+    def _obtain_lock(self, wait_time=None):
+        pass
+
+    def close(self):
+        pass
+
+    def open(self):
+        pass
+
+class FakeEOSDevice(BaseTestDouble):
+    """EOS device test double."""
+
+    def __init__(self):
+        super(FakeEOSDevice, self).__init__()
+        self.connection = object()
+    
+    def send_command_expect(self, command, **kwargs):
+        return self.send_config_set([command])
+
+    def send_config_set(self, commands, **kwargs):
+        return self.run_commands(commands)
+    

--- a/test/eos_ssh/test_heredoc.py
+++ b/test/eos_ssh/test_heredoc.py
@@ -38,11 +38,10 @@ class TestConfigMangling(object):
             "HEREDOC conversion",
             "EOF",
             "management ssh",
-            "idle-timeout 15"
+            "idle-timeout 15",
         ]
 
         self.device.device.run_commands.assert_called_with(expected_result)
-
 
     def test_mode_comment(self):
         raw_config = dedent(
@@ -86,7 +85,7 @@ class TestConfigMangling(object):
             "This is a multi-line HEREDOC",
             "comment for standard ACL test3",
             "EOF",
-            "permit host 192.0.2.3"
+            "permit host 192.0.2.3",
         ]
 
         self.device.device.run_commands.assert_called_with(expected_result)
@@ -122,7 +121,7 @@ class TestConfigMangling(object):
             "!!!bangs!",
             "EOF",
             "management ssh",
-            "idle-timeout 15"
+            "idle-timeout 15",
         ]
 
         self.device.device.run_commands.assert_called_with(expected_result)
@@ -185,8 +184,7 @@ class TestConfigMangling(object):
             "---END PRIVATE KEY---",
             "EOF",
             "management ssh",
-            "idle-timeout 15"
+            "idle-timeout 15",
         ]
 
         self.device.device.run_commands.assert_called_with(expected_result)
-

--- a/test/eos_ssh/test_heredoc.py
+++ b/test/eos_ssh/test_heredoc.py
@@ -1,4 +1,4 @@
-from unittest import mock
+import mock
 import pytest
 from textwrap import dedent
 
@@ -17,17 +17,6 @@ class TestConfigMangling(object):
         HEREDOC conversion
         EOF
         !
-        management api http-commands
-          protocol https certificate
-          ---BEGIN CERTIFICATE---
-          FAKE-CERTIFICATE-DATA
-          ---END CERTIFICATE---
-          EOF
-          ---BEGIN PRIVATE KEY---
-          FAKE-KEY-DATA
-          ---END PRIVATE KEY---
-          EOF
-        !
         management ssh
           idle-timeout 15
         !
@@ -43,21 +32,17 @@ class TestConfigMangling(object):
             "rollback clean-config",
             "hostname vEOS",
             "ip name-server 192.0.2.1",
-            {
-                "cmd": "banner login",
-                "input": "This is a banner that spans\nmultiple lines in order to test\nHEREDOC conversion",  #  noqa
-            },
-            "management api http-commands",
-            {
-                "cmd": "protocol https certificate",
-                "input": "---BEGIN CERTIFICATE---\nFAKE-CERTIFICATE-DATA\n---END CERTIFICATE---\nEOF\n---BEGIN PRIVATE KEY---\nFAKE-KEY-DATA\n---END PRIVATE KEY---",  # noqa
-            },
+            "banner login",
+            "This is a banner that spans",
+            "multiple lines in order to test",
+            "HEREDOC conversion",
+            "EOF",
             "management ssh",
-            "idle-timeout 15",
-            "end",
+            "idle-timeout 15"
         ]
 
         self.device.device.run_commands.assert_called_with(expected_result)
+
 
     def test_mode_comment(self):
         raw_config = dedent(
@@ -89,24 +74,19 @@ class TestConfigMangling(object):
         expected_result = [
             "configure session {}".format(self.device.config_session),
             "ip access-list standard test1",
-            {
-                "cmd": "comment",
-                "input": "This is a\nmultiline mode comment\nfor standard ACL test1",
-            },
+            "!! This is a",
+            "!! multiline mode comment",
+            "!! for standard ACL test1",
             "permit host 192.0.2.1",
             "ip access-list standard test2",
-            {
-                "cmd": "comment",
-                "input": "This is a single-line mode comment for standard ACL test2",
-            },
+            "!! This is a single-line mode comment for standard ACL test2",
             "permit host 192.0.2.2",
             "ip access-list standard test3",
-            {
-                "cmd": "comment",
-                "input": "This is a multi-line HEREDOC\ncomment for standard ACL test3",
-            },
-            "permit host 192.0.2.3",
-            "end",
+            "comment",
+            "This is a multi-line HEREDOC",
+            "comment for standard ACL test3",
+            "EOF",
+            "permit host 192.0.2.3"
         ]
 
         self.device.device.run_commands.assert_called_with(expected_result)
@@ -137,17 +117,16 @@ class TestConfigMangling(object):
             "rollback clean-config",
             "hostname vEOS",
             "ip name-server 192.0.2.1",
-            {
-                "cmd": "banner login",
-                "input": "!! This is a banner that contains\n!!!bangs!",  #  noqa
-            },
+            "banner login",
+            "!! This is a banner that contains",
+            "!!!bangs!",
+            "EOF",
             "management ssh",
-            "idle-timeout 15",
-            "end",
+            "idle-timeout 15"
         ]
 
         self.device.device.run_commands.assert_called_with(expected_result)
-    
+
     def test_heredoc_with_blank_lines(self):
         raw_config = dedent(
             """\
@@ -188,18 +167,26 @@ class TestConfigMangling(object):
             "rollback clean-config",
             "hostname vEOS",
             "ip name-server 192.0.2.1",
-            {
-                "cmd": "banner login",
-                "input": "\nThis is a banner that spans\nmultiple lines in order to test\nHEREDOC conversion\n",  #  noqa
-            },
+            "banner login",
+            "",
+            "This is a banner that spans",
+            "multiple lines in order to test",
+            "HEREDOC conversion",
+            "",
+            "EOF",
             "management api http-commands",
-            {
-                "cmd": "protocol https certificate",
-                "input": "---BEGIN CERTIFICATE---\nFAKE-CERTIFICATE-DATA\n---END CERTIFICATE---\nEOF\n---BEGIN PRIVATE KEY---\nFAKE-KEY-DATA\n---END PRIVATE KEY---",  # noqa
-            },
+            "protocol https certificate",
+            "---BEGIN CERTIFICATE---",
+            "FAKE-CERTIFICATE-DATA",
+            "---END CERTIFICATE---",
+            "EOF",
+            "---BEGIN PRIVATE KEY---",
+            "FAKE-KEY-DATA",
+            "---END PRIVATE KEY---",
+            "EOF",
             "management ssh",
-            "idle-timeout 15",
-            "end",
+            "idle-timeout 15"
         ]
 
         self.device.device.run_commands.assert_called_with(expected_result)
+

--- a/test/eos_ssh/test_heredoc.py
+++ b/test/eos_ssh/test_heredoc.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 import pytest
 from textwrap import dedent
 


### PR DESCRIPTION
When setting transport="ssh" the heredoc commands cause an issue because they are not a string.
This allows for heredoc commands to not be converted when using "ssh" transport  