### PR TITLE
added pyenv `.python-version` file to the gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,7 @@ docs/_static/
 .venv
 .vscode
 .devcontainer
+.python-version
 
 env
 *.swp


### PR DESCRIPTION
Hi all,
pyenv uses the `.python-version` file that contains the venv name that should be selected when a user enters a directory.
Since this is a dev-related file, I am adding this to gitignore