### PR TITLE
Junos get_config patch

### DIFF
--- a/napalm/junos/junos.py
+++ b/napalm/junos/junos.py
@@ -2459,12 +2459,17 @@ class JunOSDriver(NetworkDriver):
         }
         if retrieve in ("candidate", "all"):
             config = self.device.rpc.get_config(filter_xml=None, options=options)
-            rv["candidate"] = str(config.text)
+            if options["format"] == "text":
+                rv["candidate"] = str(config.text)
+            else:
+                return str(config["configuration"])
         if retrieve in ("running", "all"):
             options["database"] = "committed"
             config = self.device.rpc.get_config(filter_xml=None, options=options)
-            rv["running"] = str(config.text)
-
+            if options["format"] == "text":
+                rv["candidate"] = str(config.text)
+            else:
+                return str(config["configuration"])
         if sanitized:
             return napalm.base.helpers.sanitize_configs(rv, sanitize_strings)
 

--- a/napalm/junos/junos.py
+++ b/napalm/junos/junos.py
@@ -2462,14 +2462,14 @@ class JunOSDriver(NetworkDriver):
             if options["format"] == "text":
                 rv["candidate"] = str(config.text)
             else:
-                return str(config["configuration"])
+                rv["candidate"] = str(config["configuration"])
         if retrieve in ("running", "all"):
             options["database"] = "committed"
             config = self.device.rpc.get_config(filter_xml=None, options=options)
             if options["format"] == "text":
                 rv["candidate"] = str(config.text)
             else:
-                return str(config["configuration"])
+                 rv["candidate"] = str(config["configuration"])
         if sanitized:
             return napalm.base.helpers.sanitize_configs(rv, sanitize_strings)
 


### PR DESCRIPTION
If no format attribute is specified get_config returns config as a plain text, but in json is specified, it returns a dict. 
Probably it still needs further polishing. e.g I cast it to a str, but maybe i could stay as dict.  It's my first pull request ever, Sorry if I messed something up.