### PR TITLE
Bump ansible version in docs requirements

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -5,4 +5,4 @@ invoke==2.2.0
 jinja2==3.1.4
 MarkupSafe==2.1.5
 pytest==8.2.1
-ansible==9.6.0
+ansible==9.6.1


### PR DESCRIPTION
Ansible 9.6.0 was removed after a windows venv was included in the collection release.

https://forum.ansible.com/t/release-announcement-ansible-community-package-9-6-1/6206