### PR TITLE
Support NTP server details in base, EOS

### DIFF
--- a/napalm/base/base.py
+++ b/napalm/base/base.py
@@ -921,12 +921,23 @@ class NetworkDriver(object):
         """
         Returns the NTP servers configuration as dictionary.
         The keys of the dictionary represent the IP Addresses of the servers.
-        Inner dictionaries do not have yet any available keys.
+        Inner dictionaries MAY contain information regarding per-server configuration.
 
         Example::
 
             {
-                '192.168.0.1': {},
+                '192.168.0.1':
+                {
+                    'address': '192.168.0.1',
+                    'port': 123,
+                    'version': 4,
+                    'association_type': 'SERVER',
+                    'iburst': False,
+                    'prefer': False,
+                    'network_instance': 'default',
+                    'source_address': '192.0.2.1',
+                    'key_id': -1,
+                },
                 '17.72.148.53': {},
                 '37.187.56.220': {},
                 '162.158.20.18': {}

--- a/napalm/base/models.py
+++ b/napalm/base/models.py
@@ -223,17 +223,7 @@ IPV6NeighborDict = TypedDict(
 
 NTPPeerDict = TypedDict(
     "NTPPeerDict",
-    {
-        "address": str,
-        "port": int,
-        "version": int,
-        "association_type": str,
-        "iburst": bool,
-        "prefer": bool,
-        "network_instance": str,
-        "source_address": str,
-        "key_id": int,
-    },
+    {},
     total=False,
 )
 

--- a/napalm/base/models.py
+++ b/napalm/base/models.py
@@ -224,7 +224,15 @@ IPV6NeighborDict = TypedDict(
 NTPPeerDict = TypedDict(
     "NTPPeerDict",
     {
-        # will populate it in the future wit potential keys
+        "address": str,
+        "port": int,
+        "version": int,
+        "association_type": str,
+        "iburst": bool,
+        "prefer": bool,
+        "network_instance": str,
+        "source_address": str,
+        "key_id": int,
     },
     total=False,
 )
@@ -232,7 +240,15 @@ NTPPeerDict = TypedDict(
 NTPServerDict = TypedDict(
     "NTPServerDict",
     {
-        # will populate it in the future wit potential keys
+        "address": str,
+        "port": int,
+        "version": int,
+        "association_type": str,
+        "iburst": bool,
+        "prefer": bool,
+        "network_instance": str,
+        "source_address": str,
+        "key_id": int,
     },
     total=False,
 )

--- a/napalm/base/test/getters.py
+++ b/napalm/base/test/getters.py
@@ -311,7 +311,9 @@ class BaseTestGetters(object):
 
         for peer, peer_details in get_ntp_peers.items():
             assert isinstance(peer, str)
-            assert helpers.test_model(models.NTPPeerDict, peer_details)
+            assert helpers.test_model(
+                models.NTPPeerDict, peer_details, allow_subset=True
+            )
 
         return get_ntp_peers
 
@@ -323,7 +325,9 @@ class BaseTestGetters(object):
 
         for server, server_details in get_ntp_servers.items():
             assert isinstance(server, str)
-            assert helpers.test_model(models.NTPServerDict, server_details)
+            assert helpers.test_model(
+                models.NTPServerDict, server_details, allow_subset=True
+            )
 
         return get_ntp_servers
 

--- a/napalm/base/test/helpers.py
+++ b/napalm/base/test/helpers.py
@@ -1,14 +1,16 @@
 """Several methods to help with the tests."""
 
 
-def test_model(model, data):
+def test_model(model, data, allow_subset=False):
     """Return if the dictionary `data` complies with the `model`."""
     # Access the underlying schema for a TypedDict directly
     annotations = model.__annotations__
-    if model.__total__:
-        same_keys = set(annotations.keys()) == set(data.keys())
-    else:
+    if allow_subset:
         same_keys = set(data.keys()) <= set(annotations.keys())
+        source = data
+    else:
+        same_keys = set(annotations.keys()) == set(data.keys())
+        source = annotations
 
     if not same_keys:
         print(
@@ -18,7 +20,7 @@ def test_model(model, data):
         )
 
     correct_class = True
-    for key in data.keys():
+    for key in source.keys():
         correct_class = isinstance(data[key], annotations[key]) and correct_class
         if not correct_class:
             print(

--- a/napalm/base/test/helpers.py
+++ b/napalm/base/test/helpers.py
@@ -4,23 +4,26 @@
 def test_model(model, data):
     """Return if the dictionary `data` complies with the `model`."""
     # Access the underlying schema for a TypedDict directly
-    model = model.__annotations__
-    same_keys = set(model.keys()) == set(data.keys())
+    annotations = model.__annotations__
+    if model.__total__:
+        same_keys = set(annotations.keys()) == set(data.keys())
+    else:
+        same_keys = set(data.keys()) <= set(annotations.keys())
 
     if not same_keys:
         print(
             "model_keys: {}\ndata_keys: {}".format(
-                sorted(model.keys()), sorted(data.keys())
+                sorted(annotations.keys()), sorted(data.keys())
             )
         )
 
     correct_class = True
-    for key, instance_class in model.items():
-        correct_class = isinstance(data[key], instance_class) and correct_class
+    for key in data.keys():
+        correct_class = isinstance(data[key], annotations[key]) and correct_class
         if not correct_class:
             print(
                 "key: {}\nmodel_class: {}\ndata_class: {}".format(
-                    key, instance_class, data[key].__class__
+                    key, annotations[key], data[key].__class__
                 )
             )
 

--- a/napalm/eos/utils/textfsm_templates/ntp_peers.tpl
+++ b/napalm/eos/utils/textfsm_templates/ntp_peers.tpl
@@ -1,6 +1,0 @@
-Value NTPPeer (\w+.*)
-
-Start
-  ^ntp\s+server\s+${NTPPeer} -> Record
-
-EOF

--- a/test/eos/mocked_data/test_get_ntp_servers/details/expected_result.json
+++ b/test/eos/mocked_data/test_get_ntp_servers/details/expected_result.json
@@ -1,0 +1,24 @@
+{
+  "1.2.3.4": {
+    "port": 123,
+    "version": 4,
+    "association_type": "SERVER",
+    "iburst": true,
+    "prefer": true,
+    "network_instance": "FOO",
+    "source_address": "",
+    "key_id": -1,
+    "address": "1.2.3.4"
+  },
+  "4.3.2.1": {
+    "port": 123,
+    "version": 4,
+    "association_type": "SERVER",
+    "iburst": false,
+    "prefer": false,
+    "network_instance": "FOO",
+    "source_address": "172.20.20.2",
+    "key_id": -1,
+    "address": "4.3.2.1"
+  }
+}

--- a/test/eos/mocked_data/test_get_ntp_servers/details/show_ip_interface.json
+++ b/test/eos/mocked_data/test_get_ntp_servers/details/show_ip_interface.json
@@ -1,0 +1,48 @@
+{
+  "interfaces": {
+      "Management0": {
+          "name": "Management0",
+          "lineProtocolStatus": "up",
+          "interfaceStatus": "connected",
+          "mtu": 1500,
+          "interfaceAddressBrief": {
+              "ipAddr": {
+                  "address": "172.20.20.2",
+                  "maskLen": 24
+              }
+          },
+          "ipv4Routable240": false,
+          "ipv4Routable0": false,
+          "enabled": true,
+          "description": "",
+          "interfaceAddress": {
+              "primaryIp": {
+                  "address": "172.20.20.2",
+                  "maskLen": 24
+              },
+              "secondaryIps": {},
+              "secondaryIpsOrderedList": [],
+              "virtualIp": {
+                  "address": "0.0.0.0",
+                  "maskLen": 0
+              },
+              "virtualSecondaryIps": {},
+              "virtualSecondaryIpsOrderedList": [],
+              "broadcastAddress": "255.255.255.255",
+              "dhcp": false
+          },
+          "proxyArp": false,
+          "proxyArpAllowDefault": false,
+          "localProxyArp": false,
+          "gratuitousArp": false,
+          "routedAddr": "00:1c:73:7b:8c:1d",
+          "isVrrpBackup": false,
+          "vrf": "default",
+          "urpf": "disable",
+          "addresslessForwarding": "isInvalid",
+          "directedBroadcastEnabled": false,
+          "maxMssIngress": 0,
+          "maxMssEgress": 0
+      }
+  }
+}

--- a/test/eos/mocked_data/test_get_ntp_servers/details/show_ipv6_interface.json
+++ b/test/eos/mocked_data/test_get_ntp_servers/details/show_ipv6_interface.json
@@ -1,0 +1,46 @@
+{
+  "interfaces": {
+      "Management0": {
+          "name": "Management0",
+          "lineProtocolStatus": "up",
+          "interfaceStatus": "connected",
+          "mtu": 1500,
+          "linkLocal": {
+              "address": "fe80::21c:73ff:fe7b:8c1d",
+              "subnet": "fe80::/64",
+              "active": true,
+              "leastpref": false,
+              "dadfailed": false
+          },
+          "state": "enabled",
+          "addresses": [
+              {
+                  "address": "2001:172:20:20::2",
+                  "subnet": "2001:172:20:20::/64",
+                  "active": true,
+                  "leastpref": false,
+                  "dadfailed": false
+              }
+          ],
+          "globalAddressesAreVirtual": false,
+          "multicastGroupAddresses": [
+              "ff02::1",
+              "ff02::1:ff00:2",
+              "ff02::1:ff7b:8c1d"
+          ],
+          "dadStatus": "unavailable",
+          "dadAttempts": -1,
+          "ndReachableTime": 30000,
+          "ndRetransmitInterval": 1000,
+          "enhancedDad": false,
+          "autoConfigStatus": "stateless",
+          "urpf": "disable",
+          "urpfV4V6Mismatch": false,
+          "vrf": "default",
+          "addrSource": "manual",
+          "maxMssIngress": 0,
+          "maxMssEgress": 0,
+          "acceptUnsolicitedNa": false
+      }
+  }
+}

--- a/test/eos/mocked_data/test_get_ntp_servers/details/show_running_config___section_ntp.text
+++ b/test/eos/mocked_data/test_get_ntp_servers/details/show_running_config___section_ntp.text
@@ -1,0 +1,2 @@
+ntp server vrf FOO 1.2.3.4 prefer iburst
+ntp server vrf FOO 4.3.2.1 local-interface Management0

--- a/test/eos/mocked_data/test_get_ntp_servers/normal/expected_result.json
+++ b/test/eos/mocked_data/test_get_ntp_servers/normal/expected_result.json
@@ -1,1 +1,35 @@
-{"1.2.3.4": {}, "2001:0db8:0a0b:12f0:0000:0000:0000:0001": {}, "5.6.7.8": {}}
+{
+  "1.2.3.4": {
+    "port": 123,
+    "version": 4,
+    "association_type": "SERVER",
+    "iburst": false,
+    "prefer": false,
+    "network_instance": "default",
+    "source_address": "",
+    "key_id": -1,
+    "address": "1.2.3.4"
+  },
+  "5.6.7.8": {
+    "port": 123,
+    "version": 4,
+    "association_type": "SERVER",
+    "iburst": false,
+    "prefer": false,
+    "network_instance": "default",
+    "source_address": "",
+    "key_id": -1,
+    "address": "5.6.7.8"
+  },
+  "2001:0db8:0a0b:12f0:0000:0000:0000:0001": {
+    "port": 123,
+    "version": 4,
+    "association_type": "SERVER",
+    "iburst": false,
+    "prefer": false,
+    "network_instance": "default",
+    "source_address": "",
+    "key_id": -1,
+    "address": "2001:0db8:0a0b:12f0:0000:0000:0000:0001"
+  }
+}


### PR DESCRIPTION
Based on models from openconfig-system, return optional additional data regarding NTP servers for the first supported driver (EOS).