### PR TITLE
use plain dict in IOSDriver.get_bgp_neighbors_detail()

### DIFF
--- a/napalm/ios/ios.py
+++ b/napalm/ios/ios.py
@@ -22,7 +22,6 @@ import socket
 import telnetlib
 import tempfile
 import uuid
-from collections import defaultdict
 
 from netmiko import FileTransfer, InLineTransfer
 
@@ -2076,7 +2075,7 @@ class IOSDriver(NetworkDriver):
         return bgp_neighbor_data
 
     def get_bgp_neighbors_detail(self, neighbor_address=""):
-        bgp_detail = defaultdict(lambda: defaultdict(lambda: []))
+        bgp_detail = {}
 
         raw_bgp_sum = self._send_command("show ip bgp all sum").strip()
 
@@ -2227,6 +2226,14 @@ class IOSDriver(NetworkDriver):
                         "export_policy": bgp_neigh_afi["policy_out"],
                     }
                 )
+
+            vrf_name = details["routing_table"]
+            if vrf_name not in bgp_detail.keys():
+                bgp_detail[vrf_name] = {}
+            remote_as = details["remote_as"]
+            if remote_as not in bgp_detail[vrf_name].keys():
+                bgp_detail[vrf_name][remote_as] = []
+
             bgp_detail[details["routing_table"]][details["remote_as"]].append(details)
         return bgp_detail
 


### PR DESCRIPTION
fixes #2161 by omitting `defaultdict` and creating the missing empty dicts / lists manually, when required.