### PR TITLE
Discard unexpected NTP strings

### DIFF
--- a/napalm/eos/eos.py
+++ b/napalm/eos/eos.py
@@ -1224,6 +1224,8 @@ class EOSDriver(NetworkDriver):
                 "key_id": -1,
             }
             tokens = server.split()
+            if tokens[0] != "ntp":
+                continue
             if tokens[2] == "vrf":
                 details["network_instance"] = tokens[3]
                 server_ip = details["address"] = tokens[4]
@@ -1269,6 +1271,8 @@ class EOSDriver(NetworkDriver):
 
                 elif tokens[idx] == "prefer":
                     details["prefer"] = True
+                    idx += 1
+                else:  # Shouldn't happen
                     idx += 1
 
             result[server_ip] = details

--- a/test/eos/mocked_data/test_get_ntp_servers/extra-output/expected_result.json
+++ b/test/eos/mocked_data/test_get_ntp_servers/extra-output/expected_result.json
@@ -1,0 +1,35 @@
+{
+  "1.2.3.4": {
+    "port": 123,
+    "version": 4,
+    "association_type": "SERVER",
+    "iburst": false,
+    "prefer": false,
+    "network_instance": "default",
+    "source_address": "",
+    "key_id": -1,
+    "address": "1.2.3.4"
+  },
+  "5.6.7.8": {
+    "port": 123,
+    "version": 4,
+    "association_type": "SERVER",
+    "iburst": false,
+    "prefer": false,
+    "network_instance": "default",
+    "source_address": "",
+    "key_id": -1,
+    "address": "5.6.7.8"
+  },
+  "2001:0db8:0a0b:12f0:0000:0000:0000:0001": {
+    "port": 123,
+    "version": 4,
+    "association_type": "SERVER",
+    "iburst": false,
+    "prefer": false,
+    "network_instance": "default",
+    "source_address": "",
+    "key_id": -1,
+    "address": "2001:0db8:0a0b:12f0:0000:0000:0000:0001"
+  }
+}

--- a/test/eos/mocked_data/test_get_ntp_servers/extra-output/show_running_config___section_ntp.text
+++ b/test/eos/mocked_data/test_get_ntp_servers/extra-output/show_running_config___section_ntp.text
@@ -1,0 +1,7 @@
+ip access-list test-acl
+    10 remark ntp
+    20 permit udp any eq ntp any
+    30 permit udp any any eq ntp
+ntp server 1.2.3.4
+ntp server 5.6.7.8
+ntp server 2001:0db8:0a0b:12f0:0000:0000:0000:0001


### PR DESCRIPTION
When parsing config lines that contain the string NTP, discard lines that don't start with ntp.  Also, ensure that we increment idx EVERY token, to ensure we don't enter an infinite loop.