### PR TITLE
Fix LLDP neighbors detail retrieval on ASR9K devices

### DIFF
--- a/napalm/iosxr/iosxr.py
+++ b/napalm/iosxr/iosxr.py
@@ -798,7 +798,20 @@ class IOSXRDriver(NetworkDriver):
 
         rpc_command = "<Get><Operational><LLDP><NodeTable></NodeTable></LLDP></Operational></Get>"
 
-        result_tree = ETREE.fromstring(self.device.make_rpc_call(rpc_command))
+        try:
+            result_tree = ETREE.fromstring(self.device.make_rpc_call(rpc_command))
+        except napalm.pyIOSXR.exceptions.XMLCLIError:
+            logger.info(
+                "Attempting more specific ASR9K rpc call for LLDP neighbors query"
+            )
+            rpc_command = (
+                "<Get><Operational>"
+                "<LLDP><NodeTable><Node><Naming><NodeName>"
+                "<Rack>0</Rack><Slot>0</Slot><Instance>CPU0</Instance>"
+                "</NodeName></Naming></Node></NodeTable></LLDP>"
+                "</Operational></Get>"
+            )
+            result_tree = ETREE.fromstring(self.device.make_rpc_call(rpc_command))
 
         for neighbor in result_tree.xpath(".//Neighbors/DetailTable/Detail/Entry"):
             interface_name = napalm.base.helpers.convert(


### PR DESCRIPTION
The original implementation of the get_lldp_neighbors_detail method fails with an XMLCLIError exception when used on Cisco ASR9K devices. This is due to the ASR9K requiring a more specific XML path in the RPC call.

Added a try/except block that:
1. First attempts the generic LLDP query
2. If that fails with XMLCLIError, tries a more specific query that includes the exact node path (Rack 0, Slot 0, Instance CPU0)
3. Also added an informative log message to indicate when fallback occurs

This change maintains backward compatibility with standard IOS-XR devices while adding support for ASR9K devices.

Closes #2207 