### PR TITLE
Explicitly close IOSXR connection

### DIFF
--- a/napalm/pyIOSXR/iosxr.py
+++ b/napalm/pyIOSXR/iosxr.py
@@ -510,7 +510,7 @@ class IOSXR(object):
         if self.lock_on_connect or self.locked:
             self.unlock()  # this refers to the config DB
         self._unlock_xml_agent()  # this refers to the XML agent
-        self.device.disconnect()  # close the underlying SSH session        
+        self.device.disconnect()  # close the underlying SSH session
 
     def lock(self):
         """

--- a/napalm/pyIOSXR/iosxr.py
+++ b/napalm/pyIOSXR/iosxr.py
@@ -510,10 +510,7 @@ class IOSXR(object):
         if self.lock_on_connect or self.locked:
             self.unlock()  # this refers to the config DB
         self._unlock_xml_agent()  # this refers to the XML agent
-        if hasattr(self.device, "remote_conn"):
-            self.device.remote_conn.close()  # close the underlying SSH session
-        # run netmiko cleanup for session before __exit__
-        self.device.disconnect()
+        self.device.disconnect()  # close the underlying SSH session        
 
     def lock(self):
         """

--- a/napalm/pyIOSXR/iosxr.py
+++ b/napalm/pyIOSXR/iosxr.py
@@ -512,6 +512,8 @@ class IOSXR(object):
         self._unlock_xml_agent()  # this refers to the XML agent
         if hasattr(self.device, "remote_conn"):
             self.device.remote_conn.close()  # close the underlying SSH session
+        # run netmiko cleanup for session before __exit__
+        self.device.disconnect()
 
     def lock(self):
         """

--- a/test/pyiosxr/test_iosxr.py
+++ b/test/pyiosxr/test_iosxr.py
@@ -35,6 +35,9 @@ class _MockedNetMikoDevice(object):
 
         self.remote_conn = _MockedParamikoTransport()
 
+    def disconnect(self):
+        self.remote_conn.close()
+
     @staticmethod
     def get_mock_file(command, format="xml"):
         filename = (


### PR DESCRIPTION
Explicitly disconnect napalm.pyIOSXR.iosxr class IOSXR before __exit__
This is for issue #2213 