### PR TITLE
Rename ssh_config_file to ssh_config for iosxr_netconf driver

### DIFF
--- a/napalm/iosxr_netconf/iosxr_netconf.py
+++ b/napalm/iosxr_netconf/iosxr_netconf.py
@@ -70,6 +70,8 @@ class IOSXRNETCONFDriver(NetworkDriver):
         self.lock_on_connect = self.optional_args.pop("config_lock", False)
         self.key_file = self.optional_args.pop("key_file", None)
         self.config_encoding = self.optional_args.pop("config_encoding", "cli")
+        if "ssh_config_file" in self.optional_args:
+            self.optional_args["ssh_config"] = self.optional_args.pop("ssh_config_file")
         if self.config_encoding not in C.CONFIG_ENCODINGS:
             raise ValueError(f"config encoding must be one of {C.CONFIG_ENCODINGS}")
 


### PR DESCRIPTION
ncclient does not like unknown options and napalm-nornir passes `ssh_config_file` by default. This PR renames the option to `ssh_config`. Ncclient should be happy with this option but I did not test it.
https://github.com/ncclient/ncclient/blob/5d95954ff59897475c64fe82230ac7ce3cef7f02/ncclient/transport/ssh.py#L163

This PR is related to https://github.com/nornir-automation/nornir_napalm/issues/63