### PR TITLE
Clean up IOS-XR SSH sessions correctly address regressing from #2214

### DIFF
--- a/napalm/pyIOSXR/iosxr.py
+++ b/napalm/pyIOSXR/iosxr.py
@@ -510,7 +510,10 @@ class IOSXR(object):
         if self.lock_on_connect or self.locked:
             self.unlock()  # this refers to the config DB
         self._unlock_xml_agent()  # this refers to the XML agent
-        self.device.disconnect()  # close the underlying SSH session
+        # Both of the following methods are needed to cleanup the IOSXR connection successfully.
+        if hasattr(self.device, "remote_conn"):
+            self.device.remote_conn.close()  # close the underlying Paramiko/Netmiko channel.
+        self.device.disconnect()  # close the Netmiko session, inclusive of SSH cleanup if used.
 
     def lock(self):
         """


### PR DESCRIPTION
This addresses the regression introduced by https://github.com/napalm-automation/napalm/pull/2214 and solves https://github.com/napalm-automation/napalm/issues/2213

Without the two cleanup paths the Parmiko channel doesn't get closed correctly and it appears to make the processing hang. Combined
this cleans up the Paramiko channel and correctly closes and cleans up the SSH session on the IOSXR device.

Signed-off-by: Adrian Arumugam <adrian@a6m.au>
