### PR TITLE
Add support for enclosed arg to junos cli.

### DIFF
--- a/napalm/junos/junos.py
+++ b/napalm/junos/junos.py
@@ -1102,6 +1102,11 @@ class JunOSDriver(NetworkDriver):
                 exploded_pipe = pipe.split()
                 pipe_oper = exploded_pipe[0]  # always there
                 pipe_args = "".join(exploded_pipe[1:2])
+                enclosed_arg = re.match(r'"(.+)"', " ".join(exploded_pipe[1:]))
+                if enclosed_arg:
+                    pipe_args = enclosed_arg.group().strip('"')
+                else:
+                    pipe_args = "".join(exploded_pipe[1:2])
                 # will not throw error when there's no arg
                 pipe_oper_args[pipe_oper] = pipe_args
             for oper in _OF_MAP.keys():


### PR DESCRIPTION
 It seems junos cli() is not working property using pipes and enclosing with double quotation marks.  
e.g. `show configuration | display set | match "set version"`. 
I fixed this issue.