### PR TITLE
Remove calls to deprecated `pkg_resources`

### DIFF
--- a/napalm/__init__.py
+++ b/napalm/__init__.py
@@ -1,4 +1,4 @@
-import pkg_resources
+from importlib.metadata import version, PackageNotFoundError
 import sys
 import logging
 
@@ -23,8 +23,8 @@ except AttributeError:
     raise RuntimeError("NAPALM requires Python 3.7 or greater")
 
 try:
-    __version__ = pkg_resources.get_distribution("napalm").version
-except pkg_resources.DistributionNotFound:
+    __version__ = version("napalm")
+except PackageNotFoundError:
     __version__ = "Not installed"
 
 __all__ = ("get_network_driver", "SUPPORTED_DRIVERS")

--- a/napalm/base/clitools/cl_napalm.py
+++ b/napalm/base/clitools/cl_napalm.py
@@ -7,7 +7,8 @@ import json
 import logging
 import argparse
 import getpass
-import pkg_resources
+import pkgutil
+from importlib.metadata import version
 from functools import wraps
 
 
@@ -156,9 +157,9 @@ def check_installed_packages():
     logger.debug("Gathering napalm packages")
     napalm_packages = sorted(
         [
-            "{}=={}".format(i.key, i.version)
-            for i in pkg_resources.working_set
-            if i.key.startswith("napalm")
+            "{}=={}".format(i.name, version(i.name))
+            for i in list(pkgutil.iter_modules())
+            if i.name.startswith("napalm")
         ]
     )
     for n in napalm_packages:

--- a/napalm/iosxr/__init__.py
+++ b/napalm/iosxr/__init__.py
@@ -15,15 +15,7 @@
 
 """napalm.iosxr package."""
 
-# Import stdlib
-import pkg_resources
-
 # Import local modules
 from napalm.iosxr.iosxr import IOSXRDriver  # noqa
 
 __all__ = ("IOSXRDriver",)
-
-try:
-    __version__ = pkg_resources.get_distribution("napalm-iosxr").version
-except pkg_resources.DistributionNotFound:
-    __version__ = "Not installed"

--- a/napalm/iosxr_netconf/__init__.py
+++ b/napalm/iosxr_netconf/__init__.py
@@ -15,15 +15,7 @@
 
 """napalm.iosxr_netconf package."""
 
-# Import stdlib
-import pkg_resources
-
 # Import local modules
 from napalm.iosxr_netconf.iosxr_netconf import IOSXRNETCONFDriver  # noqa
 
 __all__ = ("IOSXRNETCONFDriver",)
-
-try:
-    __version__ = pkg_resources.get_distribution("napalm-iosxr-netconf").version
-except pkg_resources.DistributionNotFound:
-    __version__ = "Not installed"

--- a/napalm/nxos/__init__.py
+++ b/napalm/nxos/__init__.py
@@ -15,16 +15,8 @@
 
 """napalm.nxos package."""
 
-# Import stdlib
-import pkg_resources
-
 # Import local modules
 from napalm.nxos.nxos import NXOSDriver
 from napalm.nxos.nxos import NXOSDriverBase
-
-try:
-    __version__ = pkg_resources.get_distribution("napalm-nxos").version
-except pkg_resources.DistributionNotFound:
-    __version__ = "Not installed"
 
 __all__ = ("NXOSDriver", "NXOSDriverBase")

--- a/napalm/nxos_ssh/__init__.py
+++ b/napalm/nxos_ssh/__init__.py
@@ -15,16 +15,7 @@
 
 """napalm.nxos package."""
 
-# Import stdlib
-import pkg_resources
-
 # Import local modules
 from napalm.nxos_ssh.nxos_ssh import NXOSSSHDriver
-
-
-try:
-    __version__ = pkg_resources.get_distribution("napalm-nxos-ssh").version
-except pkg_resources.DistributionNotFound:
-    __version__ = "Not installed"
 
 __all__ = ("NXOSSSHDriver",)


### PR DESCRIPTION
Update codebase to remove/refactor calls to pkg_resources when determining versioning and installed modules.

Closes #2240 