### PR TITLE
Remove transitive dependency scp from requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,6 @@ pyeapi>=1.0.2
 netmiko>=4.4.0
 # Temp fix until PyEZ 2.7.4 is released (PY3.13 support)
 git+https://github.com/Juniper/py-junos-eznc.git@39bd1cfb007b6adea654baeaf78a26d1ad35f385
-scp
 lxml>=4.3.0
 ncclient
 ttp


### PR DESCRIPTION
As part of our ongoing research on Python dependency management we noticed a potential improvement in your project’s dependency management.

Specifically, the transitive dependency `scp` from `junos-eznc` is specified as a requirement in the requirements.txt file, when in reality it is not needed.

This PR removes it from requirements.txt to let pip manage it automatically, which helps keeping the dependency list clean.

Hope this is helpful!

Best regards