### PR TITLE
Refactor BGP detail template for prefix statistics because RPKI validation adds another IPv4 Unicast: line

### DIFF
--- a/napalm/eos/utils/textfsm_templates/bgp_detail_multi_agent.tpl
+++ b/napalm/eos/utils/textfsm_templates/bgp_detail_multi_agent.tpl
@@ -38,8 +38,7 @@ Start
   ^\s+Last event was ${last_event}
   ^\s+Updates:\s+${output_updates}\s+${input_updates}
   ^\s+Total messages:\s+${output_messages}\s+${input_messages}
-  ^\s+IPv4 Unicast:\s+${advertised_prefix_count}\s+${received_prefix_count}
-  ^\s+IPv6 Unicast:\s+${advertised_ipv6_prefix_count}\s+${received_ipv6_prefix_count}
+  ^\s+Prefix Statistics: -> PrefixStats
   ^\s+Inbound route map is ${import_policy}
   ^\s+Outbound route map is ${export_policy}
   ^\s+Nexthop matches local IP address: ${multihop}
@@ -49,3 +48,8 @@ Start
   ^.*, remote port is ${remote_port}
   ^\s+Send-Q:\s+${messages_queued_out}/.*
   ^$$ -> Next.Record
+
+PrefixStats
+  ^\s+IPv4 Unicast:\s+${advertised_prefix_count}\s+${received_prefix_count}
+  ^\s+IPv6 Unicast:\s+${advertised_ipv6_prefix_count}\s+${received_ipv6_prefix_count}
+  ^\s+Configured maximum total number of routes.* -> Start


### PR DESCRIPTION
This PR changes the textfsm template to better handle parsing when RPKI is enabled on the router.
When RPKI is enabled, Arista adds a new block :
```
RPKI Origin Validation:
    use local ROA database
    validation wait for roa sync is disabled
                          Valid       Invalid       Unknown
    IPv4 Unicast:        617862           891        412050
    IPv6 Unicast:             0             0             0
```

This block is after the Prefix Statistics one, so it replaces the values of Sent and Received routes with the RPKI Valid and Invalid values.

---

Copilot summary :
This pull request refactors the `bgp_detail_multi_agent.tpl` TextFSM template to improve how prefix statistics are parsed. The main change is moving the parsing of IPv4 and IPv6 unicast prefix statistics into a dedicated `PrefixStats` state, making the template more modular and easier to maintain.

**Template parsing improvements:**

* Changed the parsing of IPv4 and IPv6 unicast prefix statistics from inline in the `Start` state to a new `PrefixStats` state, making the template more organized and modular. [[1]](diffhunk://#diff-1699ea9f74995e9cdc9b89deb7b81c267c90ec62f02ff5aca2c1835a5ad0bfe0L41-R41) [[2]](diffhunk://#diff-1699ea9f74995e9cdc9b89deb7b81c267c90ec62f02ff5aca2c1835a5ad0bfe0R51-R55)
* Added a transition from the `Start` state to the new `PrefixStats` state when encountering the "Prefix Statistics" line, and defined transitions back to `Start` after processing prefix statistics. [[1]](diffhunk://#diff-1699ea9f74995e9cdc9b89deb7b81c267c90ec62f02ff5aca2c1835a5ad0bfe0L41-R41) [[2]](diffhunk://#diff-1699ea9f74995e9cdc9b89deb7b81c267c90ec62f02ff5aca2c1835a5ad0bfe0R51-R55)