### PR TITLE
Expose pyEAPI `send_enable` via optional_args

### DIFF
--- a/napalm/eos/eos.py
+++ b/napalm/eos/eos.py
@@ -127,6 +127,8 @@ class EOSDriver(NetworkDriver):
         self.optional_args = optional_args or {}
 
         self.enablepwd = self.optional_args.pop("enable_password", "")
+        force_no_enable = self.optional_args.pop("force_no_enable", False)
+        self.send_enable = not force_no_enable
         self.eos_autoComplete = self.optional_args.pop("eos_autoComplete", None)
 
         # Define locking method
@@ -267,6 +269,7 @@ class EOSDriver(NetworkDriver):
                 ret.append(cmd_json)
             return ret
         else:
+            kwargs.setdefault("send_enable", self.send_enable)
             return self.device.run_commands(commands, **kwargs)
 
     def _obtain_lock(self, wait_time=None):

--- a/test/eos/conftest.py
+++ b/test/eos/conftest.py
@@ -47,7 +47,7 @@ class FakeEOSDevice(BaseTestDouble):
         super(FakeEOSDevice, self).__init__()
         self.connection = object()
 
-    def run_commands(self, command_list, encoding="json"):
+    def run_commands(self, command_list, encoding="json", send_enable=True):
         """Fake run_commands."""
         result = list()
 

--- a/test/eos/test_heredoc.py
+++ b/test/eos/test_heredoc.py
@@ -57,7 +57,7 @@ class TestConfigMangling(object):
             "end",
         ]
 
-        self.device.device.run_commands.assert_called_with(expected_result)
+        self.device.device.run_commands.assert_called_with(expected_result, send_enable=True)
 
     def test_mode_comment(self):
         raw_config = dedent(
@@ -109,7 +109,7 @@ class TestConfigMangling(object):
             "end",
         ]
 
-        self.device.device.run_commands.assert_called_with(expected_result)
+        self.device.device.run_commands.assert_called_with(expected_result, send_enable=True)
 
     def test_heredoc_with_bangs(self):
         raw_config = dedent(
@@ -146,7 +146,7 @@ class TestConfigMangling(object):
             "end",
         ]
 
-        self.device.device.run_commands.assert_called_with(expected_result)
+        self.device.device.run_commands.assert_called_with(expected_result, send_enable=True)
 
     def test_heredoc_with_blank_lines(self):
         raw_config = dedent(
@@ -202,4 +202,4 @@ class TestConfigMangling(object):
             "end",
         ]
 
-        self.device.device.run_commands.assert_called_with(expected_result)
+        self.device.device.run_commands.assert_called_with(expected_result, send_enable=True)


### PR DESCRIPTION
If using NAPALM with a non-privileged user with a custom role, allow the end-user to skip sending "enable", as it would return an error. 

This allows a locally configured read-only user with an extremely limited command set to be defined that bypasses any existing TACACS authorization and accounting, speeding up execution