### PR TITLE
Fix as_number() crash on BGP origin code suffix

### DIFF
--- a/napalm/base/helpers.py
+++ b/napalm/base/helpers.py
@@ -548,7 +548,7 @@ def ip(addr: str, version: Optional[int] = None) -> str:
 
 def as_number(as_number_val: str) -> int:
     """Convert AS Number to standardized asplain notation as an integer."""
-    as_number_str = str(as_number_val)
+    as_number_str = str(as_number_val).rstrip("ei?")
     if "." in as_number_str:
         big, little = as_number_str.split(".")
         return (int(big) << 16) + int(little)

--- a/test/base/test_helpers.py
+++ b/test/base/test_helpers.py
@@ -385,6 +385,9 @@ class TestBaseHelpers(unittest.TestCase):
         self.assertEqual(napalm.base.helpers.as_number("1.65535"), 131071)
         self.assertEqual(napalm.base.helpers.as_number("65535.65535"), 4294967295)
         self.assertEqual(napalm.base.helpers.as_number(64001), 64001)
+        self.assertEqual(napalm.base.helpers.as_number("64001e"), 64001)
+        self.assertEqual(napalm.base.helpers.as_number("64001i"), 64001)
+        self.assertEqual(napalm.base.helpers.as_number("64001?"), 64001)
 
     def test_convert_uptime_string_seconds(self):
         """


### PR DESCRIPTION
EOS eAPI appends the BGP origin attribute as the final token of `asPathEntry.asPath`. `get_route_to` passes `as_path.strip("()").split()[-1]` directly to `as_number()` helper, which calls `int()` on it and crashes.

The existing `asPathType in ["Internal", "Local"]` guard does not help: it describes how the route was received (iBGP/eBGP), not the route's origin attribute. An eBGP route with origin IGP has `asPathType = "External"` and `asPath = "65001 i"`.
