### PR TITLE
Fix get_route_to() crash on BGP origin code suffix

### DIFF
--- a/napalm/eos/eos.py
+++ b/napalm/eos/eos.py
@@ -1486,7 +1486,7 @@ class EOSDriver(NetworkDriver):
                             remote_as = local_as
                         else:
                             remote_as = napalm.base.helpers.as_number(
-                                as_path.strip("()").split()[-1]
+                                as_path.strip("()").rstrip("ie?").split()[-1]
                             )
                         try:
                             remote_address = napalm.base.helpers.ip(

--- a/test/eos/mocked_data/test_get_route_to_longer/bgp_confederation_origin_suffix/expected_result.json
+++ b/test/eos/mocked_data/test_get_route_to_longer/bgp_confederation_origin_suffix/expected_result.json
@@ -1,0 +1,26 @@
+{
+    "1.0.4.0/25": [
+        {
+            "current_active": true,
+            "last_active": true,
+            "age": 0,
+            "next_hop": "10.253.18.200",
+            "protocol": "eBGP",
+            "outgoing_interface": "Ethernet49/1",
+            "preference": 200,
+            "inactive_reason": "",
+            "routing_table": "default",
+            "selected_next_hop": true,
+            "protocol_attributes": {
+                "metric": 197,
+                "as_path": "65001 65239 e",
+                "local_preference": 100,
+                "local_as": 202751,
+                "remote_as": 65239,
+                "remote_address": "10.253.18.200",
+                "preference2": 0,
+                "communities": []
+            }
+        }
+    ]
+}

--- a/test/eos/mocked_data/test_get_route_to_longer/bgp_confederation_origin_suffix/show_ip_bgp_1_0_4_0_24_longer_prefixes_vrf_default.json
+++ b/test/eos/mocked_data/test_get_route_to_longer/bgp_confederation_origin_suffix/show_ip_bgp_1_0_4_0_24_longer_prefixes_vrf_default.json
@@ -1,0 +1,53 @@
+{
+    "vrfs": {
+        "default": {
+            "routerId": "10.0.0.1",
+            "vrf": "default",
+            "bgpRouteEntries": {
+                "1.0.4.0/25": {
+                    "totalPaths": 1,
+                    "bgpAdvertisedPeerGroups": {},
+                    "totalAdvertisedPeers": 0,
+                    "maskLength": 25,
+                    "bgpRoutePaths": [
+                        {
+                            "asPathEntry": {
+                                "asPathType": "External",
+                                "asPath": "65001 65239 e"
+                            },
+                            "med": 197,
+                            "localPreference": 100,
+                            "weight": 0,
+                            "nextHop": "10.253.18.200",
+                            "reasonNotBestpath": "",
+                            "routeType": {
+                                "active": true,
+                                "valid": true,
+                                "ecmp": false,
+                                "ecmpHead": false,
+                                "ecmpContributor": false,
+                                "backup": false,
+                                "suppressed": false,
+                                "queued": false,
+                                "stale": false,
+                                "atomicAggregator": false
+                            },
+                            "routeDetail": {
+                                "origin": "Egp",
+                                "peerEntry": {
+                                    "peerRouterId": "10.253.18.200",
+                                    "peerAddr": "10.253.18.200"
+                                },
+                                "extCommunityList": [],
+                                "communityList": [],
+                                "recvdFromRRClient": false
+                            }
+                        }
+                    ],
+                    "address": "1.0.4.0"
+                }
+            },
+            "asn": "202751"
+        }
+    }
+}

--- a/test/eos/mocked_data/test_get_route_to_longer/bgp_confederation_origin_suffix/show_ip_route_vrf_default_1_0_4_0_24_longer_prefixes_bgp_detail.json
+++ b/test/eos/mocked_data/test_get_route_to_longer/bgp_confederation_origin_suffix/show_ip_route_vrf_default_1_0_4_0_24_longer_prefixes_bgp_detail.json
@@ -1,0 +1,28 @@
+{
+    "vrfs": {
+        "default": {
+            "routes": {
+                "1.0.4.0/25": {
+                    "kernelProgrammed": true,
+                    "directlyConnected": false,
+                    "routeAction": "forward",
+                    "routeLeaked": false,
+                    "vias": [
+                        {
+                            "interface": "Ethernet49/1",
+                            "nexthopAddr": "10.253.18.200"
+                        }
+                    ],
+                    "metric": 197,
+                    "hardwareProgrammed": true,
+                    "routeType": "eBGP",
+                    "preference": 200
+                }
+            },
+            "allRoutesProgrammedKernel": true,
+            "routingDisabled": false,
+            "allRoutesProgrammedHardware": true,
+            "defaultRouteState": "reachable"
+        }
+    }
+}

--- a/test/eos/mocked_data/test_get_route_to_longer/bgp_confederation_origin_suffix/show_vrf.json
+++ b/test/eos/mocked_data/test_get_route_to_longer/bgp_confederation_origin_suffix/show_vrf.json
@@ -1,0 +1,21 @@
+{
+  "vrfs": {
+    "default": {
+      "routeDistinguisher": "",
+      "protocols": {
+        "ipv4": {
+          "supported": true,
+          "protocolState": "up",
+          "routingState": "up"
+        },
+        "ipv6": {
+          "supported": true,
+          "protocolState": "up",
+          "routingState": "down"
+        }
+      },
+      "vrfState": "up",
+      "interfaces": ["Ethernet49/1", "Ethernet50/1", "Loopback0"]
+    }
+  }
+}


### PR DESCRIPTION
`get_route_to` with `longer=True` issues a follow-up `show ip bgp <dest> longer-prefixes` for every BGP route it finds in the routing table, to retrieve BGP-specific attributes (AS path, communities, peer info). On EOS with BGP confederations, the asPath field in that response ends in an origin code (e/i/?) rather than a number. Taking split()[-1] and passing it to int() crashes with `ValueError: invalid literal for int() with base 10: 'e'`

Fix: Strip origin code characters from the AS path string before splitting.