### PR TITLE
Commit confirm support for iosxr_netconf driver

### DIFF
--- a/docs/support/index.rst
+++ b/docs/support/index.rst
@@ -38,7 +38,7 @@ _                       EOS         Junos   IOS-XR (NETCONF)  IOS-XR (XML-Agent)
 =====================   ==========  =====   ================  ==================  ==============  ==============
 **Config. replace**     Yes         Yes     Yes               Yes                 Yes             Yes
 **Config. merge**       Yes         Yes     Yes               Yes                 Yes             Yes
-**Commit Confirm**      Yes         Yes     No                No                  No              Yes
+**Commit Confirm**      Yes         Yes     Yes               No                  No              Yes
 **Compare config**      Yes         Yes     Yes               Yes [#c1]_          Yes [#c4]_      Yes
 **Atomic Changes**      Yes         Yes     Yes               Yes                 Yes/No [#c5]_   Yes/No [#c5]_
 **Rollback**            Yes [#c2]_  Yes     Yes               Yes                 Yes/No [#c5]_   Yes

--- a/napalm/iosxr_netconf/iosxr_netconf.py
+++ b/napalm/iosxr_netconf/iosxr_netconf.py
@@ -38,9 +38,12 @@ from napalm.iosxr_netconf import constants as C
 from napalm.iosxr.utilities import strip_config_header
 from napalm.base.base import NetworkDriver
 import napalm.base.helpers
-from napalm.base.exceptions import ConnectionException
-from napalm.base.exceptions import MergeConfigException
-from napalm.base.exceptions import ReplaceConfigException
+from napalm.base.exceptions import (
+    ConnectionException,
+    MergeConfigException,
+    ReplaceConfigException,
+    CommitConfirmException,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -273,10 +276,27 @@ class IOSXRNETCONFDriver(NetworkDriver):
 
     def commit_config(self, message="", revert_in=None):
         """Commit configuration."""
-        if revert_in is not None:
-            raise NotImplementedError("Commit confirm has not been implemented on this platform.")
+        commit_args = {}
+
         if message:
             raise NotImplementedError("Commit message not implemented for this platform")
+
+        if revert_in:
+            revert_time_seconds = int(revert_in)
+            if revert_time_seconds < 30 or revert_time_seconds > 65535:
+                raise CommitConfirmException(
+                    "For Cisco IOS XR devices revert_in must be between 30 and 65535 seconds."
+                )
+            else:
+                commit_args["confirmed"] = True
+                commit_args["timeout"] = str(revert_time_seconds)
+
+        self.device.commit(**commit_args)
+        self.pending_changes = False
+        self._unlock()
+
+    def confirm_commit(self):
+        """Send final commit to confirm an in-proces commit that requires confirmation."""
         self.device.commit()
         self.pending_changes = False
         self._unlock()


### PR DESCRIPTION
Adds support for commit confirm in the iosxr_netconf driver.

The `revert_in` parameter is supported on the commit_config method. When this parameter is specified, the ncclient `Config` class attributes `confirmed` and `timeout` are specified as kwargs in `self.device.commit` method.

A new method, `confirm_commit`, is defined which will issue a final commit in a similar fashion to the drivers for EOS and Junos.

IOS XR does not expose what it calls commit trial periods (that is commit confirmed instances) via the CLI or NETCONF so the `_get_pending_commits` and `has_pending_commit` methods cannot be supported for the iosxr_netconf driver.

All checks have passed as specified in the pull request checklist.