### PR TITLE
fix: handle Not Supported temperature sensors in get_environment()

### DIFF
--- a/napalm/ios/ios.py
+++ b/napalm/ios/ios.py
@@ -2340,7 +2340,10 @@ class IOSDriver(NetworkDriver):
                 m = re_temp_value.match(line)
                 if m is not None:
                     temp_name = m.group(1).lower()
-                    temp_value = float(line.split(":")[1].split()[0])
+                    try:
+                        temp_value = float(line.split(":")[1].split()[0])
+                    except (ValueError, IndexError):
+                        continue
                     env_value = {
                         "is_alert": False,
                         "is_critical": False,


### PR DESCRIPTION
## Fix for Issue #1000: get_environment fails on Cisco 2960

**Problem:** When `get_environment()` is called on Cisco Catalyst 2960 switches, the code crashes with `ValueError: could not convert string to float: Not` because some devices output mixed data where some sensors are supported and some report `Not Supported`.

**Root cause:** The top-level check `if "Not Supported" not in output` passes when there is at least one valid temperature, but individual lines like `Inlet Temperature Value: Not Supported` then crash the float conversion.

**Fix:** Wrap the temperature value float conversion in a try/except block. Lines that fail conversion (ValueError or IndexError) are silently skipped, allowing valid sensors to still be parsed.

**Changes:**
- `napalm/ios/ios.py`: Added try/except around `temp_value = float(...)` in the temperature parsing loop, with `continue` on failure

**Testing:** Syntax validated with py_compile. The fix handles both "Not Supported" and "Not" value cases gracefully.