### PR TITLE
fix(nxos): correct is_up/is_enabled field mapping in get_interfaces

### DIFF
--- a/napalm/nxos/nxos.py
+++ b/napalm/nxos/nxos.py
@@ -976,11 +976,11 @@ class NXOSDriver(NXOSDriverBase):
             interface_speed = float(float(interface_speed) / 1000.0)
 
             if "admin_state" in interface_details:
-                is_up = interface_details.get("admin_state", "") == "up"
+                is_enabled = interface_details.get("admin_state", "") == "up"
             elif "svi_admin_state" in interface_details:
-                is_up = interface_details.get("svi_admin_state", "") == "up"
+                is_enabled = interface_details.get("svi_admin_state", "") == "up"
             else:
-                is_up = interface_details.get("state", "") == "up"
+                is_enabled = interface_details.get("state", "") == "up"
             if interface_details.get("eth_hw_addr"):
                 mac_address = interface_details["eth_hw_addr"]
             elif interface_details.get("svi_mac"):
@@ -994,11 +994,11 @@ class NXOSDriver(NXOSDriverBase):
             assert isinstance(desc, str)
             desc = desc.strip('"')
             interfaces[interface_name] = {
-                "is_up": is_up,
-                "is_enabled": (
+                "is_up": (
                     interface_details.get("state") == "up"
                     or interface_details.get("svi_admin_state") == "up"
                 ),
+                "is_enabled": is_enabled,
                 "description": desc,
                 "last_flapped": self._compute_timestamp(
                     interface_details.get("eth_link_flapped", "")

--- a/test/nxos/mocked_data/test_get_interfaces/admin_up_oper_down/expected_result.json
+++ b/test/nxos/mocked_data/test_get_interfaces/admin_up_oper_down/expected_result.json
@@ -1,0 +1,20 @@
+{
+    "Ethernet1/1": {
+        "is_enabled": true,
+        "description": "",
+        "last_flapped": -1.0,
+        "is_up": false,
+        "mac_address": "2C:C2:60:4F:FE:B2",
+        "mtu": 1500,
+        "speed": 1000.0
+    },
+    "Ethernet1/2": {
+        "is_enabled": false,
+        "description": "",
+        "last_flapped": -1.0,
+        "is_up": false,
+        "mac_address": "2C:C2:60:4F:FE:B3",
+        "mtu": 1500,
+        "speed": 1000.0
+    }
+}

--- a/test/nxos/mocked_data/test_get_interfaces/admin_up_oper_down/show_interface.json
+++ b/test/nxos/mocked_data/test_get_interfaces/admin_up_oper_down/show_interface.json
@@ -1,0 +1,42 @@
+{
+  "TABLE_interface": {
+    "ROW_interface": [
+      {
+        "interface": "Ethernet1/1",
+        "state": "down",
+        "admin_state": "up",
+        "share_state": "Dedicated",
+        "eth_hw_desc": "Ethernet",
+        "eth_hw_addr": "2cc2.604f.feb2",
+        "eth_bia_addr": "2cc2.604f.feb2",
+        "eth_mtu": "1500",
+        "eth_bw": 1000000,
+        "eth_dly": 10,
+        "medium": "broadcast",
+        "eth_mode": "routed",
+        "eth_duplex": "auto",
+        "eth_speed": "auto-speed",
+        "eth_autoneg": "on",
+        "eth_link_flapped": "never"
+      },
+      {
+        "interface": "Ethernet1/2",
+        "state": "down",
+        "admin_state": "down",
+        "share_state": "Dedicated",
+        "eth_hw_desc": "Ethernet",
+        "eth_hw_addr": "2cc2.604f.feb3",
+        "eth_bia_addr": "2cc2.604f.feb3",
+        "eth_mtu": "1500",
+        "eth_bw": 1000000,
+        "eth_dly": 10,
+        "medium": "broadcast",
+        "eth_mode": "routed",
+        "eth_duplex": "auto",
+        "eth_speed": "auto-speed",
+        "eth_autoneg": "on",
+        "eth_link_flapped": "never"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Fixes #1544.

The NX-API `nxos` driver's `get_interfaces()` populated `is_up` from
`admin_state` and `is_enabled` from `state` — the inverse of every other
NAPALM driver and the spec. A port that is admin-up but operationally
down (no link) was returned as `is_up=True, is_enabled=False` — the
opposite of reality.

## Fix

Swap the variable name and dict-key assignments in `napalm/nxos/nxos.py`
so each output key reads its correct source field:

- `is_enabled` ← `admin_state` / `svi_admin_state` (else `state`)
- `is_up`       ← `state` (or `svi_admin_state` for SVIs)

No logic change — only the field-to-output-key mapping.

## Test plan

The existing fixtures (`normal/`, `vlan_interface/`) do not exercise the
bug because every interface in them has `admin_state == state`. Added a
new mocked-data scenario `admin_up_oper_down/` with two interfaces:

- `Ethernet1/1` — `admin_state=up`, `state=down` → expects
  `is_enabled=true, is_up=false`
- `Ethernet1/2` — both down → expects `is_enabled=false, is_up=false`

All 532 existing tests still pass; the new fixture is the regression test.

Verified against a real Nexus 9000v running NX-OS via NAPALM 5.1.0
(NX-API transport).
- Before fix: `{'is_up': true, 'is_enabled': false}` for an admin-up,
  link-down port.
- After fix:  `{'is_up': false, 'is_enabled': true}`.
- `mgmt0` (admin-up, oper-up) was unaffected.