### PR TITLE
Improvements to network driver import behavior

### DIFF
--- a/napalm/base/__init__.py
+++ b/napalm/base/__init__.py
@@ -85,18 +85,20 @@ def get_network_driver(name: str, prepend: bool = True) -> Type[NetworkDriver]:
     The *name* argument must be one of three forms (case-insensitive; hyphens are ignored):
 
     1. **Plain driver name** — a simple identifier with no dots, e.g. ``"eos"``, ``"junos"``,
-       ``"iosxr"``.  The function will search for the driver in the following order:
+       ``"IOS-XR"``.  The function will search for the driver in the following order:
        ``custom_napalm.<name>`` (site-local), ``napalm.<name>`` (core), ``napalm_<name>``
        (community).
     2. **Explicit core/custom path** — a single-dot name beginning with ``napalm.`` or
        ``custom_napalm.``, e.g. ``"napalm.eos"`` or ``"custom_napalm.mydriver"``.  Only that
-       exact module is loaded.
+       exact module is tried; no additional candidates are constructed.  Requires
+       ``prepend=True`` (the default).
     3. **Already-qualified name** — any name that already contains ``"napalm"`` (e.g.
-       ``"napalm_eos"``), passed with ``prepend=False``.
+       ``"napalm_eos"``), passed with ``prepend=False`` to suppress the automatic
+       ``napalm.`` prefix.  The name must still satisfy rule 1 or 2 above.
 
     Names with more than one dot, dots outside the ``napalm.`` / ``custom_napalm.``
-    prefixes, or names not starting with "napalm" and passed with ``prepend=False`` are
-    rejected with ``ModuleImportError``.
+    prefixes, or bare names passed with ``prepend=False`` are rejected with
+    ``ModuleImportError``.
 
     :param name:         the driver name in one of the three forms described above.
     :param prepend:      when ``True`` (default) the ``napalm.`` prefix is added automatically
@@ -112,7 +114,7 @@ def get_network_driver(name: str, prepend: bool = True) -> Type[NetworkDriver]:
 
         >>> get_network_driver('junos')
         <class 'napalm.junos.junos.JunOSDriver'>
-        >>> get_network_driver('iosxr')
+        >>> get_network_driver('IOS-XR')
         <class 'napalm.iosxr.iosxr.IOSXRDriver'>
         >>> get_network_driver('napalm.eos')
         <class 'napalm.eos.eos.EOSDriver'>
@@ -130,11 +132,8 @@ def get_network_driver(name: str, prepend: bool = True) -> Type[NetworkDriver]:
     name = name.lower()
     # Try to not raise error when users requests IOS-XR for e.g.
     module_install_name = name.replace("-", "")
-
-    # Basical validation of name including allowed package namespaces
     _validate_driver_name(module_install_name, name)
 
-    # prepend = False -> the name must start with "napalm"
     if not prepend and "napalm" not in module_install_name:
         raise ModuleImportError(
             f'Invalid driver name "{name}": when prepend=False the name must '

--- a/napalm/base/__init__.py
+++ b/napalm/base/__init__.py
@@ -31,6 +31,45 @@ __all__ = [
 ]
 
 
+def _validate_driver_name(module_install_name: str, original_name: str) -> None:
+    """
+    Validate that *module_install_name* (the normalised form of the caller-supplied
+    driver name, after lower-casing and hyphen removal) does not contain unsafe
+    path components that could reach unintended modules via
+    ``importlib.import_module``.
+
+    Rules
+    -----
+    * A dot is only permitted when the name begins with exactly ``napalm.`` or
+      ``custom_napalm.`` — the two documented namespaces for explicit driver
+      references.
+    * The portion *after* the allowed prefix must itself be dot-free, preventing
+      traversal into arbitrary sub-packages (e.g. ``napalm.eos.eos`` is rejected).
+    * All other names with dots are rejected unconditionally.
+
+    :param module_install_name: normalised driver name (lowercase, hyphens removed).
+    :param original_name:       the raw value supplied by the caller, used in the
+                                error message.
+    :raise ModuleImportError:   when the name violates the rules above.
+    """
+    if "." not in module_install_name:
+        return  # simple identifier — nothing more to check
+
+    for prefix in ("napalm.", "custom_napalm."):
+        if module_install_name.startswith(prefix):
+            suffix = module_install_name[len(prefix) :]
+            if "." not in suffix:
+                # exactly one dot, in an allowed namespace
+                return
+            # starts with a known prefix but has extra dots — fall through to error
+            break
+
+    raise ModuleImportError(
+        f'Invalid driver name "{original_name}": dots are only permitted in the '
+        '"napalm.<driver>" or "custom_napalm.<driver>" forms.'
+    )
+
+
 def get_network_driver(name: str, prepend: bool = True) -> Type[NetworkDriver]:
     """
     Searches for a class derived form the base NAPALM class NetworkDriver in a specific library.
@@ -73,17 +112,26 @@ def get_network_driver(name: str, prepend: bool = True) -> Type[NetworkDriver]:
     name = name.lower()
     # Try to not raise error when users requests IOS-XR for e.g.
     module_install_name = name.replace("-", "")
-    community_install_name = "napalm_{name}".format(name=module_install_name)
-    custom_install_name = "custom_napalm.{name}".format(name=module_install_name)
-    # Can also request using napalm_[SOMETHING]
-    if "napalm" not in module_install_name and prepend is True:
-        module_install_name = "napalm.{name}".format(name=module_install_name)
-    # Order is custom_napalm_os (local only) ->  napalm.os (core) ->  napalm_os (community)
-    for module_name in [
-        custom_install_name,
-        module_install_name,
-        community_install_name,
-    ]:
+    _validate_driver_name(module_install_name, name)
+
+    if "." in module_install_name:
+        # Caller supplied an explicit dotted module path (e.g. "napalm.eos" or
+        # "custom_napalm.mydriver").
+        candidates = [module_install_name]
+    else:
+        community_install_name = f"napalm_{module_install_name}"
+        custom_install_name = f"custom_napalm.{module_install_name}"
+        # Can also request using napalm_[SOMETHING]
+        if "napalm" not in module_install_name and prepend is True:
+            module_install_name = f"napalm.{module_install_name}"
+        # Order is custom_napalm_os (local only) ->  napalm.os (core) ->  napalm_os (community)
+        candidates = [
+            custom_install_name,
+            module_install_name,
+            community_install_name,
+        ]
+
+    for module_name in candidates:
         try:
             module = importlib.import_module(module_name)
             break
@@ -96,9 +144,7 @@ def get_network_driver(name: str, prepend: bool = True) -> Type[NetworkDriver]:
                     continue
             raise e
     else:
-        raise ModuleImportError(
-            'Cannot import "{install_name}". Is the library installed?'.format(install_name=name)
-        )
+        raise ModuleImportError(f'Cannot import "{name}". Is the library installed?')
 
     for name, obj in inspect.getmembers(module):
         if inspect.isclass(obj) and issubclass(obj, NetworkDriver):
@@ -106,7 +152,5 @@ def get_network_driver(name: str, prepend: bool = True) -> Type[NetworkDriver]:
 
     # looks like you don't have any Driver class in your module...
     raise ModuleImportError(
-        'No class inheriting "napalm.base.base.NetworkDriver" found in "{install_name}".'.format(
-            install_name=module_install_name
-        )
+        f'No class inheriting "napalm.base.base.NetworkDriver" found in "{module_install_name}".'
     )

--- a/napalm/base/__init__.py
+++ b/napalm/base/__init__.py
@@ -72,8 +72,7 @@ def _validate_driver_name(module_install_name: str, original_name: str) -> None:
 
 def get_network_driver(name: str, prepend: bool = True) -> Type[NetworkDriver]:
     """
-    Searches for a class derived form the base NAPALM class NetworkDriver in a specific library.
-    The library name must repect the following pattern: napalm_[DEVICE_OS].
+    Searches for a class derived from the base NAPALM class NetworkDriver in a specific library.
     NAPALM community supports a list of devices and provides the corresponding libraries; for
     full reference please refer to the `Supported Network Operation Systems`_ paragraph on
     `Read the Docs`_.
@@ -83,10 +82,31 @@ def get_network_driver(name: str, prepend: bool = True) -> Type[NetworkDriver]:
     .. _`Read the Docs`: \
     http://napalm.readthedocs.io/
 
-    :param name:         the name of the device operating system or the name of the library.
-    :return:                    the first class derived from NetworkDriver, found in the library.
-    :raise ModuleImportError:   when the library is not installed or a derived class from \
-    NetworkDriver was not found.
+    The *name* argument must be one of three forms (case-insensitive; hyphens are ignored):
+
+    1. **Plain driver name** — a simple identifier with no dots, e.g. ``"eos"``, ``"junos"``,
+       ``"IOS-XR"``.  The function will search for the driver in the following order:
+       ``custom_napalm.<name>`` (site-local), ``napalm.<name>`` (core), ``napalm_<name>``
+       (community).
+    2. **Explicit core/custom path** — a single-dot name beginning with ``napalm.`` or
+       ``custom_napalm.``, e.g. ``"napalm.eos"`` or ``"custom_napalm.mydriver"``.  Only that
+       exact module is tried; no additional candidates are constructed.  Requires
+       ``prepend=True`` (the default).
+    3. **Already-qualified name** — any name that already contains ``"napalm"`` (e.g.
+       ``"napalm_eos"``), passed with ``prepend=False`` to suppress the automatic
+       ``napalm.`` prefix.  The name must still satisfy rule 1 or 2 above.
+
+    Names with more than one dot, dots outside the ``napalm.`` / ``custom_napalm.``
+    prefixes, or bare names passed with ``prepend=False`` are rejected with
+    ``ModuleImportError``.
+
+    :param name:         the driver name in one of the three forms described above.
+    :param prepend:      when ``True`` (default) the ``napalm.`` prefix is added automatically
+                         for plain names.  Set to ``False`` only when *name* already contains
+                         ``"napalm"``.
+    :return:             the first class derived from NetworkDriver found in the resolved module.
+    :raise ModuleImportError:   when the name is invalid, the library is not installed, or no
+                                class derived from NetworkDriver was found.
 
     Example::
 

--- a/napalm/base/__init__.py
+++ b/napalm/base/__init__.py
@@ -114,6 +114,12 @@ def get_network_driver(name: str, prepend: bool = True) -> Type[NetworkDriver]:
     module_install_name = name.replace("-", "")
     _validate_driver_name(module_install_name, name)
 
+    if not prepend and "napalm" not in module_install_name:
+        raise ModuleImportError(
+            f'Invalid driver name "{name}": when prepend=False the name must '
+            'already contain "napalm" (e.g. "napalm.eos" or "napalm_eos").'
+        )
+
     if "." in module_install_name:
         # Caller supplied an explicit dotted module path (e.g. "napalm.eos" or
         # "custom_napalm.mydriver").
@@ -122,7 +128,7 @@ def get_network_driver(name: str, prepend: bool = True) -> Type[NetworkDriver]:
         community_install_name = f"napalm_{module_install_name}"
         custom_install_name = f"custom_napalm.{module_install_name}"
         # Can also request using napalm_[SOMETHING]
-        if "napalm" not in module_install_name and prepend is True:
+        if "napalm" not in module_install_name:
             module_install_name = f"napalm.{module_install_name}"
         # Order is custom_napalm_os (local only) ->  napalm.os (core) ->  napalm_os (community)
         candidates = [

--- a/napalm/base/__init__.py
+++ b/napalm/base/__init__.py
@@ -85,20 +85,18 @@ def get_network_driver(name: str, prepend: bool = True) -> Type[NetworkDriver]:
     The *name* argument must be one of three forms (case-insensitive; hyphens are ignored):
 
     1. **Plain driver name** — a simple identifier with no dots, e.g. ``"eos"``, ``"junos"``,
-       ``"IOS-XR"``.  The function will search for the driver in the following order:
+       ``"iosxr"``.  The function will search for the driver in the following order:
        ``custom_napalm.<name>`` (site-local), ``napalm.<name>`` (core), ``napalm_<name>``
        (community).
     2. **Explicit core/custom path** — a single-dot name beginning with ``napalm.`` or
        ``custom_napalm.``, e.g. ``"napalm.eos"`` or ``"custom_napalm.mydriver"``.  Only that
-       exact module is tried; no additional candidates are constructed.  Requires
-       ``prepend=True`` (the default).
+       exact module is loaded.
     3. **Already-qualified name** — any name that already contains ``"napalm"`` (e.g.
-       ``"napalm_eos"``), passed with ``prepend=False`` to suppress the automatic
-       ``napalm.`` prefix.  The name must still satisfy rule 1 or 2 above.
+       ``"napalm_eos"``), passed with ``prepend=False``.
 
     Names with more than one dot, dots outside the ``napalm.`` / ``custom_napalm.``
-    prefixes, or bare names passed with ``prepend=False`` are rejected with
-    ``ModuleImportError``.
+    prefixes, or names not starting with "napalm" and passed with ``prepend=False`` are
+    rejected with ``ModuleImportError``.
 
     :param name:         the driver name in one of the three forms described above.
     :param prepend:      when ``True`` (default) the ``napalm.`` prefix is added automatically
@@ -114,7 +112,7 @@ def get_network_driver(name: str, prepend: bool = True) -> Type[NetworkDriver]:
 
         >>> get_network_driver('junos')
         <class 'napalm.junos.junos.JunOSDriver'>
-        >>> get_network_driver('IOS-XR')
+        >>> get_network_driver('iosxr')
         <class 'napalm.iosxr.iosxr.IOSXRDriver'>
         >>> get_network_driver('napalm.eos')
         <class 'napalm.eos.eos.EOSDriver'>
@@ -132,8 +130,11 @@ def get_network_driver(name: str, prepend: bool = True) -> Type[NetworkDriver]:
     name = name.lower()
     # Try to not raise error when users requests IOS-XR for e.g.
     module_install_name = name.replace("-", "")
+
+    # Basical validation of name including allowed package namespaces
     _validate_driver_name(module_install_name, name)
 
+    # prepend = False -> the name must start with "napalm"
     if not prepend and "napalm" not in module_install_name:
         raise ModuleImportError(
             f'Invalid driver name "{name}": when prepend=False the name must '

--- a/test/base/test_get_network_driver.py
+++ b/test/base/test_get_network_driver.py
@@ -26,6 +26,11 @@ _FAKE_MODULE = types.ModuleType("fake_driver_module")
 _FAKE_MODULE.FakeDriver = _FakeDriver
 
 
+def _fail_import(mod_name: str) -> None:
+    """side_effect helper: always raises ImportError for the given module name."""
+    raise ImportError(f"No module named {mod_name}")
+
+
 # ---------------------------------------------------------------------------
 # Integration tests — require all driver packages to be installed
 # ---------------------------------------------------------------------------
@@ -66,12 +71,7 @@ class TestGetNetworkDriverUnit(unittest.TestCase):
     @data("fake00001", "network00001", "driver00001")
     def test_get_wrong_network_driver(self, driver):
         """get_network_driver raises ModuleImportError when all candidate imports fail."""
-        with patch(
-            "napalm.base.importlib.import_module",
-            side_effect=lambda mod_name: (_ for _ in ()).throw(
-                ImportError(f"No module named {mod_name}")
-            ),
-        ):
+        with patch("napalm.base.importlib.import_module", side_effect=_fail_import):
             self.assertRaises(ModuleImportError, get_network_driver, driver, prepend=False)
 
     # --- prepend=False behaviour ---

--- a/test/base/test_get_network_driver.py
+++ b/test/base/test_get_network_driver.py
@@ -1,6 +1,8 @@
 """Test the method get_network_driver."""
 
+import types
 import unittest
+from unittest.mock import patch
 from ddt import ddt, data
 
 import napalm
@@ -11,19 +13,66 @@ from napalm.base.exceptions import ModuleImportError
 from napalm.base import _validate_driver_name
 
 
+# ---------------------------------------------------------------------------
+# Shared mock helpers
+# ---------------------------------------------------------------------------
+
+
+class _FakeDriver(NetworkDriver):
+    """Minimal NetworkDriver subclass used as a stand-in by unit tests."""
+
+
+_FAKE_MODULE = types.ModuleType("fake_driver_module")
+_FAKE_MODULE.FakeDriver = _FakeDriver
+
+
+# ---------------------------------------------------------------------------
+# Integration tests — require all driver packages to be installed
+# ---------------------------------------------------------------------------
+
+
 @ddt
-class TestGetNetworkDriver(unittest.TestCase):
-    """Test the method get_network_driver."""
+class TestGetNetworkDriverIntegration(unittest.TestCase):
+    """Integration tests for get_network_driver: exercises real driver imports."""
 
     @data(*napalm.SUPPORTED_DRIVERS)
     def test_get_network_driver(self, driver):
-        """Check that we can get the desired driver and is instance of NetworkDriver."""
+        """Check that we can get the desired driver and it is a subclass of NetworkDriver."""
         self.assertTrue(issubclass(get_network_driver(driver), NetworkDriver))
 
-    @data("fake", "network", "driver", "sys", 1)
+    @data("fake00001", "network00001", "driver00001")
     def test_get_wrong_network_driver(self, driver):
-        """Check that inexisting driver throws ModuleImportError."""
+        """Check that a non-existent driver raises ModuleImportError."""
         self.assertRaises(ModuleImportError, get_network_driver, driver, prepend=False)
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — mock importlib.import_module; no driver installs required
+# ---------------------------------------------------------------------------
+
+
+@ddt
+class TestGetNetworkDriverUnit(unittest.TestCase):
+    """Unit tests for get_network_driver logic, independent of driver installation."""
+
+    @data(*napalm.SUPPORTED_DRIVERS)
+    def test_get_network_driver(self, driver):
+        """get_network_driver returns a NetworkDriver subclass and calls import_module."""
+        with patch("napalm.base.importlib.import_module", return_value=_FAKE_MODULE) as mock_import:
+            result = get_network_driver(driver)
+        self.assertTrue(issubclass(result, NetworkDriver))
+        mock_import.assert_called()
+
+    @data("fake00001", "network00001", "driver00001")
+    def test_get_wrong_network_driver(self, driver):
+        """get_network_driver raises ModuleImportError when all candidate imports fail."""
+        with patch(
+            "napalm.base.importlib.import_module",
+            side_effect=lambda mod_name: (_ for _ in ()).throw(
+                ImportError(f"No module named {mod_name}")
+            ),
+        ):
+            self.assertRaises(ModuleImportError, get_network_driver, driver, prepend=False)
 
 
 @ddt

--- a/test/base/test_get_network_driver.py
+++ b/test/base/test_get_network_driver.py
@@ -8,6 +8,7 @@ import napalm
 from napalm.base import get_network_driver
 from napalm.base.base import NetworkDriver
 from napalm.base.exceptions import ModuleImportError
+from napalm.base import _validate_driver_name
 
 
 @ddt
@@ -23,3 +24,53 @@ class TestGetNetworkDriver(unittest.TestCase):
     def test_get_wrong_network_driver(self, driver):
         """Check that inexisting driver throws ModuleImportError."""
         self.assertRaises(ModuleImportError, get_network_driver, driver, prepend=False)
+
+
+@ddt
+class TestValidateDriverName(unittest.TestCase):
+    """Unit tests for _validate_driver_name."""
+
+    # --- cases that must pass without raising ---
+
+    @data(
+        # plain identifiers — no dots at all
+        "eos",
+        "ios",
+        "iosxr",
+        "nxos",
+        "nxosssh",
+        "junos",
+        "iosxr_netconf",
+        # explicit napalm.<driver> form (documented in the docstring)
+        "napalm.eos",
+        "napalm.junos",
+        "napalm.iosxr_netconf",
+        # explicit custom_napalm.<driver> form
+        "custom_napalm.mydriver",
+        "custom_napalm.acme_os",
+    )
+    def test_valid_names(self, name):
+        """_validate_driver_name must not raise for legitimate driver names."""
+        # Should complete without raising
+        _validate_driver_name(name, name)
+
+    # --- cases that must raise ModuleImportError ---
+
+    @data(
+        # arbitrary dot — not under an allowed prefix
+        "eos.eos",
+        "some.module",
+        # deep traversal under the napalm. prefix
+        "napalm.eos.eos",
+        "napalm.a.b.c",
+        # deep traversal under the custom_napalm. prefix
+        "custom_napalm.mydriver.sub",
+        # leading dot
+        ".eos",
+        # arbitrary top-level package with dot
+        "os.path",
+        "subprocess.something",
+    )
+    def test_invalid_names(self, name):
+        """_validate_driver_name must raise ModuleImportError for unsafe names."""
+        self.assertRaises(ModuleImportError, _validate_driver_name, name, name)

--- a/test/base/test_get_network_driver.py
+++ b/test/base/test_get_network_driver.py
@@ -74,6 +74,21 @@ class TestGetNetworkDriverUnit(unittest.TestCase):
         ):
             self.assertRaises(ModuleImportError, get_network_driver, driver, prepend=False)
 
+    # --- prepend=False behaviour ---
+
+    @data("eos", "ios", "junos", "fake00001")
+    def test_prepend_false_without_napalm_raises(self, driver):
+        """prepend=False with a bare name (no 'napalm' in it) must raise immediately."""
+        self.assertRaises(ModuleImportError, get_network_driver, driver, prepend=False)
+
+    @data("napalm.eos", "napalm_eos", "napalm.junos", "napalm_junos")
+    def test_prepend_false_with_napalm_name_accepted(self, driver):
+        """prepend=False with a name that already contains 'napalm' is accepted."""
+        with patch("napalm.base.importlib.import_module", return_value=_FAKE_MODULE) as mock_import:
+            result = get_network_driver(driver, prepend=False)
+        self.assertTrue(issubclass(result, NetworkDriver))
+        mock_import.assert_called()
+
 
 @ddt
 class TestValidateDriverName(unittest.TestCase):


### PR DESCRIPTION
Improve get_network_driver() behavior with respect to unsafe module loading.

### Issue:                                                                                                              
get_network_driver() in napalm/base/__init__.py passes a caller-supplied string directly to importlib.import_module().

                                                                                                              
This PR adds (some) input validation to this process.
                                                                     
### Changes:                                                                                                                
                                                                                                                         
 - Add _validate_driver_name() which enforces that dotted names are restricted to the two documented namespaces          
   (napalm.<driver> and custom_napalm.<driver>) with no deeper namespace traversal allowed.
 - Add a guard that rejects not namespaced names when prepend=False, since that flag implies the caller has already supplied a fully-qualified name containing "napalm".        
 - When a dotted name is supplied, restrict the candidate list to that single module.                                     
 - Improve the tests related to this.