### PR TITLE
Fix config templates that fail to render on Python 3

### DIFF
--- a/napalm/eos/templates/delete_snmp_config.j2
+++ b/napalm/eos/templates/delete_snmp_config.j2
@@ -9,7 +9,7 @@ no snmp-server chassis-id "{{chassis_id}}"
 {% endif %}
 {% if (community is defined) and community %}
 {%- if community is mapping -%}
-{% for comm_name, comm_details in community.iteritems() %}
+{% for comm_name, comm_details in community.items() %}
 no snmp-server community {{comm_name}}
 {% endfor %}
 {%- elif community is string -%}

--- a/napalm/eos/templates/snmp_config.j2
+++ b/napalm/eos/templates/snmp_config.j2
@@ -8,7 +8,7 @@ snmp-server contact "{{contact}}"
 snmp-server chassis-id "{{chassis_id}}"
 {% endif %}
 {% if (community is defined) and community %}
-{% for comm_name, comm_details in community.iteritems() %}
+{% for comm_name, comm_details in community.items() %}
 {% if (comm_details is defined) and comm_details %}
 {% if (comm_details.get('mode') is defined) and comm_details.get('mode') == 'rw' %}
 community {{comm_name}} rw

--- a/napalm/ios/templates/delete_snmp_config.j2
+++ b/napalm/ios/templates/delete_snmp_config.j2
@@ -8,7 +8,7 @@ no snmp-server contact
 no snmp-server chassis-id
 {% endif %}
 {% if (community is defined) and community %}
-{% for comm_name, comm_details in community.iteritems() %}
+{% for comm_name, comm_details in community.items() %}
 no snmp-server community {{comm_name}}
 {% endfor %}
 {% endif %}

--- a/napalm/ios/templates/snmp_config.j2
+++ b/napalm/ios/templates/snmp_config.j2
@@ -8,7 +8,7 @@ snmp-server contact "{{contact}}"
 snmp-server chassis-id "{{chassis_id}}"
 {% endif %}
 {% if (community is defined) and community %}
-{% for comm_name, comm_details in community.iteritems() %}
+{% for comm_name, comm_details in community.items() %}
 {% if (comm_details is defined) and comm_details %}
 {% if (comm_details.get('mode') is defined) and comm_details.get('mode') == 'rw' %}
 community {{comm_name}} RW

--- a/napalm/iosxr/templates/delete_probes.j2
+++ b/napalm/iosxr/templates/delete_probes.j2
@@ -1,14 +1,14 @@
 ipsla
   {% set probe_id = 0 %}
-  {% for probe_name, probe_test in probes.iteritems() %}
-  {% for test_name, test_details in probe_test.iteritems() %}
+  {% for probe_name, probe_test in probes.items() %}
+  {% for test_name, test_details in probe_test.items() %}
   no schedule operation {{probe_id + loop.index}}
   {% endfor %}
   {% set probe_id = probe_id + probe_test.keys()|length %}
   {% endfor %}
   {% set probe_id = 0 %}
-  {% for probe_name, probe_test in probes.iteritems() %}
-  {% for test_name, test_details in probe_test.iteritems() %}
+  {% for probe_name, probe_test in probes.items() %}
+  {% for test_name, test_details in probe_test.items() %}
   no operation {{probe_id + loop.index}}
   {% endfor %}
   {% set probe_id = probe_id + probe_test.keys()|length %}

--- a/napalm/iosxr/templates/delete_snmp_config.j2
+++ b/napalm/iosxr/templates/delete_snmp_config.j2
@@ -8,7 +8,7 @@ no snmp-server contact "{{contact}}"
 no snmp-server chassis-id "{{chassis_id}}"
 {% endif %}
 {% if (community is defined) and community %}
-{% for comm_name, comm_details in community.iteritems() %}
+{% for comm_name, comm_details in community.items() %}
 no community {{comm_name}}
 {% endfor %}
 {% endif %}

--- a/napalm/iosxr/templates/delete_users.j2
+++ b/napalm/iosxr/templates/delete_users.j2
@@ -1,4 +1,4 @@
-{%- for user_name, user_details in users.iteritems() %}
+{%- for user_name, user_details in users.items() %}
 {%- if user_details %}
 username {{user_name}}
 {%- endif %}

--- a/napalm/iosxr/templates/schedule_probes.j2
+++ b/napalm/iosxr/templates/schedule_probes.j2
@@ -1,7 +1,7 @@
 ipsla
   {% set probe_id = 0 %}
-  {% for probe_name, probe_test in probes.iteritems() %}
-  {% for test_name, test_details in probe_test.iteritems() %}
+  {% for probe_name, probe_test in probes.items() %}
+  {% for test_name, test_details in probe_test.items() %}
   schedule operation {{probe_id + loop.index}}
     start-time now
     life forever

--- a/napalm/iosxr/templates/set_probes.j2
+++ b/napalm/iosxr/templates/set_probes.j2
@@ -1,14 +1,14 @@
 ipsla
   {% set probe_id = 0 %}
-  {% for probe_name, probe_test in probes.iteritems() %}
-  {% for test_name, test_details in probe_test.iteritems() %}
+  {% for probe_name, probe_test in probes.items() %}
+  {% for test_name, test_details in probe_test.items() %}
   no schedule operation {{probe_id + loop.index}}
   {% endfor %}
   {% set probe_id = probe_id + probe_test.keys()|length %}
   {% endfor %}
   {% set probe_id = 0 %}
-  {% for probe_name, probe_test in probes.iteritems() %}
-  {% for test_name, test_details in probe_test.iteritems() %}
+  {% for probe_name, probe_test in probes.items() %}
+  {% for test_name, test_details in probe_test.items() %}
   operation {{probe_id + loop.index}}
     {% if test_details.probe_type is defined %}
     type {{test_details.probe_type|replace('ping', 'echo')|replace('-', ' ')}}

--- a/napalm/iosxr/templates/snmp_config.j2
+++ b/napalm/iosxr/templates/snmp_config.j2
@@ -8,7 +8,7 @@ snmp-server contact "{{contact}}"
 snmp-server chassis-id "{{chassis_id}}"
 {% endif %}
 {% if (community is defined) and community %}
-{% for comm_name, comm_details in community.iteritems() %}
+{% for comm_name, comm_details in community.items() %}
 {% if (comm_details is defined) and comm_details %}
 {% if (comm_details.get('mode') is defined) and comm_details.get('mode') == 'rw' %}
 snmp-server community {{comm_name}} RW

--- a/napalm/junos/templates/delete_probes.j2
+++ b/napalm/junos/templates/delete_probes.j2
@@ -1,8 +1,8 @@
 services {
   rpm {
-    {% for probe_name, probe_test in probes.iteritems() %}
+    {% for probe_name, probe_test in probes.items() %}
     probe {{probe_name}} {
-      {% for test_name, test_details in probe_test.iteritems() %}
+      {% for test_name, test_details in probe_test.items() %}
         delete: test {{test_name}};
       {% endfor %}
     }

--- a/napalm/junos/templates/delete_snmp_config.j2
+++ b/napalm/junos/templates/delete_snmp_config.j2
@@ -6,7 +6,7 @@ snmp {
   delete: contact "{{contact}}";
   {% endif %}
   {% if (community is defined) and community %}
-  {% for comm_name, comm_details in community.iteritems() %}
+  {% for comm_name, comm_details in community.items() %}
   delete: community {{comm_name}} {
     {% if (comm_details is defined) and comm_details %}
     {% if (comm_details.get('mode') is defined) and comm_details.get('mode') == 'rw' %}

--- a/napalm/junos/templates/set_probes.j2
+++ b/napalm/junos/templates/set_probes.j2
@@ -1,8 +1,8 @@
 services {
   rpm {
-    {% for probe_name, probe_test in probes.iteritems() %}
+    {% for probe_name, probe_test in probes.items() %}
     probe {{probe_name}} {
-      {% for test_name, test_details in probe_test.iteritems() %}
+      {% for test_name, test_details in probe_test.items() %}
         test {{test_name}} {
           {% if test_details.probe_type is defined %}
           probe-type {{test_details.probe_type}};

--- a/napalm/junos/templates/snmp_config.j2
+++ b/napalm/junos/templates/snmp_config.j2
@@ -6,7 +6,7 @@ snmp {
   contact "{{contact}}";
   {% endif %}
   {% if (community is defined) and community %}
-  {% for comm_name, comm_details in community.iteritems() %}
+  {% for comm_name, comm_details in community.items() %}
   community {{comm_name}} {
     {% if (comm_details is defined) and comm_details %}
     {% if (comm_details.get('mode') is defined) and comm_details.get('mode') == 'rw' %}

--- a/napalm/nxos/templates/delete_snmp_config.j2
+++ b/napalm/nxos/templates/delete_snmp_config.j2
@@ -8,7 +8,7 @@ no snmp-server contact "{{contact}}"
 no snmp-server chassis-id "{{chassis_id}}"
 {% endif %}
 {% if (community is defined) and community %}
-{% for comm_name, comm_details in community.iteritems() %}
+{% for comm_name, comm_details in community.items() %}
 no community {{comm_name}}
 {% endfor %}
 {% endif %}

--- a/napalm/nxos/templates/delete_users.j2
+++ b/napalm/nxos/templates/delete_users.j2
@@ -11,6 +11,7 @@ no username {{user_name}} password
 {%- if user_details.get('level') %}
 no username {{user_name}} role priv-{{user_details.level}}
 {%- endif %}
-{%- endfor %}
 {%- else -%}
+no username {{user_name}}
 {%- endif -%}
+{%- endfor %}

--- a/napalm/nxos/templates/snmp_config.j2
+++ b/napalm/nxos/templates/snmp_config.j2
@@ -8,7 +8,7 @@ snmp-server contact "{{contact}}"
 snmp-server chassis-id "{{chassis_id}}"
 {% endif %}
 {% if (community is defined) and community %}
-{% for comm_name, comm_details in community.iteritems() %}
+{% for comm_name, comm_details in community.items() %}
 {% if (comm_details is defined) and comm_details %}
 {% if (comm_details.get('mode') is defined) and comm_details.get('mode') == 'rw' %}
 community {{comm_name}} rw

--- a/napalm/nxos_ssh/templates/delete_snmp_config.j2
+++ b/napalm/nxos_ssh/templates/delete_snmp_config.j2
@@ -8,7 +8,7 @@ no snmp-server contact "{{contact}}"
 no snmp-server chassis-id "{{chassis_id}}"
 {% endif %}
 {% if (community is defined) and community %}
-{% for comm_name, comm_details in community.iteritems() %}
+{% for comm_name, comm_details in community.items() %}
 no community {{comm_name}}
 {% endfor %}
 {% endif %}

--- a/napalm/nxos_ssh/templates/delete_users.j2
+++ b/napalm/nxos_ssh/templates/delete_users.j2
@@ -11,6 +11,7 @@ no username {{user_name}} password
 {%- if user_details.get('level') %}
 no username {{user_name}} role priv-{{user_details.level}}
 {%- endif %}
-{%- endfor %}
 {%- else -%}
+no username {{user_name}}
 {%- endif -%}
+{%- endfor %}

--- a/napalm/nxos_ssh/templates/snmp_config.j2
+++ b/napalm/nxos_ssh/templates/snmp_config.j2
@@ -8,7 +8,7 @@ snmp-server contact "{{contact}}"
 snmp-server chassis-id "{{chassis_id}}"
 {% endif %}
 {% if (community is defined) and community %}
-{% for comm_name, comm_details in community.iteritems() %}
+{% for comm_name, comm_details in community.items() %}
 {% if (comm_details is defined) and comm_details %}
 {% if (comm_details.get('mode') is defined) and comm_details.get('mode') == 'rw' %}
 community {{comm_name}} rw

--- a/test/base/test_config_templates.py
+++ b/test/base/test_config_templates.py
@@ -1,0 +1,115 @@
+"""
+Ensure the shipped per-driver configuration templates render under Python 3.
+
+These templates (snmp_config, set_probes, set_users, ...) used ``dict.iteritems``
+which does not exist on Python 3, so every one of them raised at render time.
+This test renders each shipped template the same way ``load_template`` does
+(FileSystemLoader over the driver's ``templates`` dir plus the NAPALM custom
+Jinja filters) and asserts it produces output, guarding against a regression.
+"""
+
+import os
+
+import jinja2
+import pytest
+
+import napalm
+from napalm.base.utils.jinja_filters import CustomJinjaFilters
+
+NAPALM_DIR = os.path.dirname(os.path.abspath(napalm.__file__))
+
+_NTP_PEERS = {"peers": ["192.0.2.1", "192.0.2.2"]}
+_NTP_SERVERS = {"servers": ["192.0.2.10", "192.0.2.11"]}
+_SNMP = {
+    "location": "DC1",
+    "contact": "noc",
+    "chassis_id": "ch1",
+    "community": {
+        "public": {"mode": "ro"},
+        "private": {"mode": "rw", "acl": "10"},
+    },
+}
+_PROBES = {
+    "probes": {
+        "probe1": {
+            "test1": {
+                "probe_type": "icmp-ping",
+                "target": "192.0.2.1",
+                "probe_count": 5,
+                "test_interval": 3,
+                "source": "192.0.2.2",
+            }
+        }
+    }
+}
+_USERS = {
+    "users": {
+        "admin": {
+            "level": 15,
+            "password": "$1$abc$0123456789abcdef",
+            "sshkeys": ["ssh-rsa AAAAB3Nza example@host"],
+        }
+    }
+}
+_HOSTNAME = {"hostname": "router1"}
+
+# Sample render variables keyed by template name (matches what the napalm_*
+# helper functions pass through load_template).
+VARS_BY_TEMPLATE = {
+    "snmp_config": _SNMP,
+    "delete_snmp_config": _SNMP,
+    "set_probes": _PROBES,
+    "delete_probes": _PROBES,
+    "schedule_probes": _PROBES,
+    "set_users": _USERS,
+    "delete_users": _USERS,
+    "set_ntp_peers": _NTP_PEERS,
+    "delete_ntp_peers": _NTP_PEERS,
+    "set_ntp_servers": _NTP_SERVERS,
+    "delete_ntp_servers": _NTP_SERVERS,
+    "set_hostname": _HOSTNAME,
+}
+
+
+def _discover_cases():
+    cases = []
+    for driver in sorted(os.listdir(NAPALM_DIR)):
+        templates_dir = os.path.join(NAPALM_DIR, driver, "templates")
+        if not os.path.isdir(templates_dir):
+            continue
+        for entry in sorted(os.listdir(templates_dir)):
+            if not entry.endswith(".j2"):
+                continue
+            name = entry[: -len(".j2")]
+            if name in VARS_BY_TEMPLATE:
+                cases.append((driver, name))
+    return cases
+
+
+CASES = _discover_cases()
+
+
+def _render(driver, template_name, variables):
+    search_path = [os.path.join(NAPALM_DIR, driver, "templates")]
+    environment = jinja2.Environment(
+        loader=jinja2.FileSystemLoader(search_path),
+    )
+    for filter_name, filter_function in CustomJinjaFilters.filters().items():
+        environment.filters[filter_name] = filter_function
+    template = environment.get_template(f"{template_name}.j2")
+    return template.render(**variables)
+
+
+def test_cases_discovered():
+    # Guard against the discovery silently finding nothing (e.g. a layout change).
+    assert CASES, "no shipped config templates were discovered"
+
+
+@pytest.mark.parametrize("driver, template_name", CASES)
+def test_config_template_renders(driver, template_name):
+    # The property under test is that the template renders under Python 3 at all
+    # (the bugs -- ``dict.iteritems`` and a mis-nested ``endfor`` -- raised).
+    # Some templates are intentionally empty (e.g. junos schedule_probes), so an
+    # empty result is fine; a raised exception is not.
+    rendered = _render(driver, template_name, VARS_BY_TEMPLATE[template_name])
+    assert isinstance(rendered, str)


### PR DESCRIPTION
## What

The shipped per-driver configuration templates fail to render on Python 3.

`snmp_config`, `delete_snmp_config`, `set_probes`, `delete_probes`,
`schedule_probes` and iosxr's `delete_users` use `dict.iteritems()`, which was
removed in Python 3, so they raise `jinja2.exceptions.UndefinedError` at render
time on every supported Python (3.10-3.14). This affects all six drivers that
ship them: eos, ios, iosxr, junos, nxos and nxos_ssh (27 occurrences across 18
templates). This PR replaces `.iteritems()` with `.items()`.

Separately, `nxos/templates/delete_users.j2` and
`nxos_ssh/templates/delete_users.j2` have a mis-nested `{% endfor %}` placed
before the `{% endif %}` that closes the enclosing `{% if user_details %}`,
which is a `TemplateSyntaxError` -- the template never rendered at all -- plus an
empty `else` branch. They are reordered to close the `if` before the loop and to
delete the whole user in the `else`, matching `eos/templates/delete_users.j2`.

## Why

Any consumer that renders these templates (e.g. `load_template`, or Salt's
`net.load_template` via `netusers`/`netsnmp`/`netntp`) gets a hard failure
instead of config. Users of `set_snmp_config`, the probe templates, etc. cannot
generate config on any supported Python.

## Testing

Adds `test/base/test_config_templates.py`, which renders every shipped config
template through the same Jinja setup `load_template` uses (a `FileSystemLoader`
over the driver's `templates` dir plus the NAPALM custom filters) and asserts it
renders under Python 3. It fails on `develop` (21 of 56 cases raise) and passes
with this change (all 56).

```
uv run pytest test/base/ -q
168 passed, 31 skipped
```

## Pull Request Checklist

- [x] Code passes `ruff check` and `ruff format`
- [x] Code passes `mypy` type checking
- [x] All tests pass locally with `pytest`
- [x] New functionality includes appropriate tests
- [x] Documentation is updated if necessary (n/a -- internal templates)
