### PR TITLE
Switch to dynamic versioning

### DIFF
--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -18,6 +18,8 @@ jobs:
       uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
     - name: Install Python 3.13
       run: uv python install 3.13
+    - name: Version
+      run: uv version -- ${{ github.ref_name }}
     - name: Build
       run: uv build
     - name: Publish

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,10 @@
 [build-system]
-requires = ["hatchling"]
-build-backend = "hatchling.build"
+requires = ["uv_build >= 0.11.32, <0.12.0"]
+build-backend = "uv_build"
 
 [project]
 name = "napalm"
-version = "5.1.1"
+version = "0.0.0.dev0"
 description = "Network Automation and Programmability Abstraction Layer with Multivendor support"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -82,6 +82,10 @@ docs = [
 managed = true
 package = true
 
+[tool.uv.build-backend]
+module-name = "napalm"
+module-root = ""
+
 [tool.pytest.ini_options]
 norecursedirs = [
     ".git",
@@ -110,13 +114,13 @@ omit = [
 ]
 
 [tool.ruff]
-line-length = 100 
+line-length = 100
 
-# Specify your floor Python version (i.e. minimum version Netmiko supports) 
+# Specify your floor Python version (i.e. minimum version Netmiko supports)
 target-version = "py310"
 
 # Files or directories to exclude from linting and formatting
-exclude = [ 
+exclude = [
     ".git",
     ".venv",
     "__pycache__",
@@ -130,7 +134,7 @@ exclude = [
 # select = ["E", "F", "W", "I", "UP", "B"]
 
 # If you want to be extra strict about line length in the linter:
-# extend-select = ["E501"] 
+# extend-select = ["E501"]
 
 [tool.ruff.format]
 # Matches Black's style but honors the 100 char limit

--- a/uv.lock
+++ b/uv.lock
@@ -1012,7 +1012,7 @@ wheels = [
 
 [[package]]
 name = "napalm"
-version = "5.1.1"
+version = "0.0.0.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "jinja2" },


### PR DESCRIPTION
Have uv set the pyproject.toml to the value of github.ref_name

Since the publish workflow triggers on tag pushes, this will be set to the bare tag name, which we can pass directly to `uv version`