### PR TITLE
Wrap EOSDriver.open()'s first command in ConnectionException

### DIFF
--- a/napalm/eos/eos.py
+++ b/napalm/eos/eos.py
@@ -33,7 +33,7 @@ from collections import defaultdict
 # third party libs
 import pyeapi
 from pyeapi.eapilib import ConnectionError, EapiConnection
-from netmiko import ConfigInvalidException
+from netmiko import ConfigInvalidException, NetMikoTimeoutException
 from typing import Dict
 
 # NAPALM base
@@ -217,7 +217,13 @@ class EOSDriver(NetworkDriver):
 
         # endif self.transport
 
-        sh_ver = self._run_commands(["show version"])
+        try:
+            sh_ver = self._run_commands(["show version"])
+        except (ConnectionError, NetMikoTimeoutException) as ce:
+            # The connection above may succeed without raising an error (e.g. the TCP
+            # handshake completes) while the device is actually unreachable or too slow
+            # to respond; that only surfaces once we send the first real command.
+            raise ConnectionException(str(ce))
         self._eos_version = EOSVersion(sh_ver[0]["version"])
         if self._eos_version < EOSVersion("4.23.0"):
             raise UnsupportedVersion(self._eos_version)

--- a/test/eos/test_open.py
+++ b/test/eos/test_open.py
@@ -1,0 +1,61 @@
+# Copyright 2026 NAPALM. All rights reserved.
+#
+# The contents of this file are licensed under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with the
+# License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+
+"""Regression tests for EOSDriver.open() error handling (napalm-automation/napalm#2318)."""
+
+from unittest import mock
+
+import pytest
+from netmiko import NetMikoTimeoutException
+from pyeapi.eapilib import ConnectionError as PyeapiConnectionError
+
+from napalm.base.exceptions import ConnectionException
+from napalm.eos.eos import EOSDriver
+
+
+def _make_driver(transport):
+    return EOSDriver(
+        hostname="127.0.0.1",
+        username="admin",
+        password="admin",
+        optional_args={"transport": transport},
+    )
+
+
+@pytest.mark.parametrize(
+    "transport, raised",
+    [
+        ("https", PyeapiConnectionError("device", "timed out")),
+        ("ssh", NetMikoTimeoutException("timed out")),
+    ],
+)
+def test_open_wraps_first_command_error_in_connection_exception(transport, raised):
+    """
+    A device that accepts the underlying connection but fails on the first real
+    command (the "show version" call used to detect the EOS version) must still
+    raise napalm's ConnectionException rather than leaking the raw pyeapi/netmiko
+    exception.
+    """
+    driver = _make_driver(transport)
+
+    if transport == "ssh":
+        driver._netmiko_open = mock.MagicMock(return_value=mock.MagicMock())
+    else:
+        driver.transport_class = mock.MagicMock()
+
+    with (
+        mock.patch.object(EOSDriver, "_run_commands", side_effect=raised),
+        pytest.raises(ConnectionException),
+    ):
+        driver.open()


### PR DESCRIPTION
Fixes #2318

## Problem
`EOSDriver.open()` establishes the underlying transport (eAPI `Node`/`EapiConnection`, or a netmiko SSH session) inside a try/except that correctly converts connection errors to napalm's `ConnectionException`. But the following line, which sends the first real command (`show version`, used to detect the EOS version), sits **outside** that try/except:

```python
sh_ver = self._run_commands(["show version"])
```

For eAPI transport, `pyeapi.client.Node()` doesn't raise on construction even if the device is unreachable — the error only surfaces once a command is actually sent (as noted by the existing comment `# does not raise an Exception if unusable`). For SSH transport, the initial `ConnectHandler()` call can succeed while the device is too slow/unresponsive for the first command. In both cases, `open()` leaked the raw `pyeapi.eapilib.ConnectionError` or `netmiko.exceptions.NetMikoTimeoutException` instead of `napalm.base.exceptions.ConnectionException`, breaking callers that only expect napalm's own exception types.

As flagged in the issue discussion, this was introduced when the version-detection call moved outside the connection try/except in `392e5e8`.

## Fix
Wrap the `show version` call in its own try/except that catches both `ConnectionError` (eAPI) and `NetMikoTimeoutException` (SSH), re-raising as `ConnectionException` — mirroring the handling already used for the transport-construction step just above it.

## Testing
Ran locally (napalm has no hardware dependency for this path):
- Added `test/eos/test_open.py` with a parametrized regression test covering both transports (`https` / eAPI and `ssh` / netmiko). Verified each test **fails** against the pre-fix code (raises the raw `NetMikoTimeoutException`/`ConnectionError`) and **passes** with the fix (`git stash` sanity check).
- Full non-integration `test/eos/` suite: 71 passed, 5 skipped (pre-existing, unrelated), 0 failed.
- `ruff check` / `ruff format --check` on changed files: clean (confirmed the pre-existing 84 ruff findings elsewhere in `eos.py` are unchanged by this diff, i.e. no new lint issues introduced).
- `mypy -p napalm.eos --config-file mypy.ini`: no issues.