### PR TITLE
fix(nxapi): bracket literal IPv6 hosts when building the NX-API URL

### DIFF
--- a/napalm/nxapi_plumbing/api_client.py
+++ b/napalm/nxapi_plumbing/api_client.py
@@ -5,6 +5,7 @@ Reimplemented by ktbyers to support XML-RPC in addition to JSON-RPC
 """
 
 from builtins import super
+from ipaddress import ip_address
 from typing import Optional, List, Dict, Any
 
 import requests
@@ -48,7 +49,7 @@ class RPCBase(object):
             elif transport == "https":
                 port = 443
 
-        self.url = "{}://{}:{}/ins".format(transport, host, port)
+        self.url = "{}://{}:{}/ins".format(transport, self._format_host(host), port)
         self.username = username
         self.password = password
         self.timeout = timeout
@@ -57,6 +58,17 @@ class RPCBase(object):
         self.cmd_method_conf: str
         self.cmd_method_raw: str
         self.headers: Dict
+
+    @staticmethod
+    def _format_host(host: str) -> str:
+        """Wrap literal IPv6 addresses in brackets as required by RFC 3986 section 3.2.2."""
+        if host.startswith("["):
+            return host
+        try:
+            is_ipv6 = ip_address(host).version == 6
+        except ValueError:
+            return host
+        return "[{}]".format(host) if is_ipv6 else host
 
     def _process_api_response(
         self, response: Response, commands: List[str], raw_text: bool = False

--- a/test/nxapi_plumbing/test_api_url.py
+++ b/test/nxapi_plumbing/test_api_url.py
@@ -1,0 +1,25 @@
+from urllib.parse import urlsplit
+
+import pytest
+
+from napalm.nxapi_plumbing import RPCClient, XMLClient
+
+
+@pytest.mark.parametrize("client_class", [RPCClient, XMLClient])
+@pytest.mark.parametrize(
+    "host,expected_url",
+    [
+        ("nxos1.fake.com", "https://nxos1.fake.com:8443/ins"),
+        ("10.0.0.1", "https://10.0.0.1:8443/ins"),
+        ("2001:db8::1", "https://[2001:db8::1]:8443/ins"),
+        ("[2001:db8::1]", "https://[2001:db8::1]:8443/ins"),
+    ],
+)
+def test_api_url(client_class, host, expected_url):
+    """Literal IPv6 hosts must be bracketed per RFC 3986 (see issue #2311)."""
+    client = client_class(host, "admin", "foo", port=8443)
+    assert client.url == expected_url
+
+    parsed = urlsplit(client.url)
+    assert parsed.hostname == host.strip("[]")
+    assert parsed.port == 8443


### PR DESCRIPTION
The NX-API URL was built by concatenating host and port, so an IPv6 literal `hostname` produced `https://2001:db8::1:8443/ins` — which parses with host `2001` and an uncastable port. RFC 3986 section 3.2.2 requires literal IPv6 addresses to be bracketed, so `RPCBase` now brackets a host only when it parses as an IPv6 address and is not already bracketed; FQDNs, IPv4 addresses and pre-bracketed hosts are unchanged.

Added `test/nxapi_plumbing/test_api_url.py` covering FQDN / IPv4 / bare IPv6 / pre-bracketed IPv6 for both `RPCClient` and `XMLClient`; the two IPv6 cases fail without the fix and pass with it, and the full `test/nxapi_plumbing` suite is green (32 passed).

Closes #2311

This change was prepared with AI assistance; the regression test was run locally and fails without the fix.
